### PR TITLE
feat: add std::constant_wrapper support for conformance.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Output the report
       - name: Save the benchmark result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-reports
           path: |

--- a/README.md
+++ b/README.md
@@ -244,11 +244,12 @@ module;
 export module ebd.function;
 
 export namespace ebd {
+  using ::ebd::basic_fn;
   using ::ebd::fn;
   using ::ebd::unique_fn;
   using ::ebd::safe_fn;
   using ::ebd::fn_ref;
-  using ::ebd::make_fn; // NOLINT(misc-unused-using-decls)
+  using ::ebd::make_fn;
 }
 ```
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2418,7 +2418,7 @@ namespace crtp_mixins {
     /// @note Used for function reference only. (NOT function wrapper)
     template <typename Func, 
       EMBED_DETAIL_REQUIRES(std::is_function<Func>::value),
-      EMBED_DETAIL_REQUIRES(is_invocable_using_functor<Signature, Func>::value),
+      EMBED_DETAIL_REQUIRES(is_invocable_using_t<Signature, Func>::value),
       EMBED_DETAIL_REQUIRES(always_false<Func>::value || Config::isView)
     > function(Func* function_ptr) noexcept {
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1448,15 +1448,6 @@ inline namespace fn_traits {
   using is_invocable_using_t = 
     typename is_invocable_using_impl<Signature, std::tuple<T...>>::type;
 
-  // Constraints for F&& constructor.
-  template <typename Signature, typename Functor>
-  using is_invocable_using_functor = is_invocable_using_t<
-    Signature, 
-    typename unwrap_signature<Signature>::template add_cv_like<
-      remove_reference_t<Functor>
-    >&
-  >;
-
 } // end namespace fn_traits
 
 // In the namespace "erasure_type", we define a series of 
@@ -2448,9 +2439,11 @@ namespace crtp_mixins {
     /// and returns a value convertible to `Ret`. (The Signature is `Ret(Args...)`)
     /// @note Used for function reference only. (NOT function wrapper)
     template <typename Functor, 
+      typename Tp = remove_reference_t<Functor>,
+      typename Tp_cv = typename unwrap_signature<Signature>::template add_cv_like<Tp>,
       EMBED_DETAIL_REQUIRES(!is_self<Functor, function>::value),
-      EMBED_DETAIL_REQUIRES(is_invocable_using_functor<Signature, Functor>::value),
-      EMBED_DETAIL_REQUIRES(!std::is_member_pointer<remove_reference_t<Functor>>::value),
+      EMBED_DETAIL_REQUIRES(is_invocable_using_t<Signature, Tp_cv>::value),
+      EMBED_DETAIL_REQUIRES(!std::is_member_pointer<Tp>::value),
       EMBED_DETAIL_REQUIRES(!fn_can_convert<function, Functor>::value),
       EMBED_DETAIL_REQUIRES(always_false<Functor>::value || Config::isView)
     >

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1525,6 +1525,25 @@ namespace erasure_type {
 // types for objects that implement the behaviour of invocation.
 namespace invocation {
 
+// Implement invocation for constant_wrapper.
+#if __cpp_lib_constant_wrapper >= 202603L
+# define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                            \
+  struct view_cw {                                                                    \
+    template <typename Cw>                                                            \
+    static Ret invoke(erasure_base_t*, smart_forward_t<Args>... args) NOEXCEPT {      \
+      return invoke_r<Ret>(Cw::value, std::forward<Args>(args)...);                   \
+    }                                                                                 \
+    template <typename Cw, typename Obj>                                              \
+    static Ret invoke(erasure_base_t* base, smart_forward_t<Args>... args) NOEXCEPT { \
+      auto* erased = static_cast<erasure_t*>(base);                                   \
+      C V auto& obj = *erased->template access<Obj*>();                               \
+      return invoke_r<Ret>(Cw::value, obj, std::forward<Args>(args)...);              \
+    }                                                                                 \
+  }; /* end view_cw */
+#else
+# define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)
+#endif
+
   template <std::size_t Size, typename Config, typename Signature>
   struct InvokerImpl;
 
@@ -1584,11 +1603,13 @@ namespace invocation {
       }                                                                           \
     };                                                                            \
                                                                                   \
+    EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                             \
   };
 
   EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_INVOKER_IMPL_DEFINE)
 
 #undef EMBED_DETAIL_INVOKER_IMPL_DEFINE
+#undef EMBED_DETAIL_CW_INVOKER_IMPL
 
 } // end namespace invocation
 
@@ -1886,6 +1907,35 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
       manager_impl_t::template ref_create<>(target, std::addressof(obj));
     }
+
+#if __cpp_lib_constant_wrapper >= 202603L
+
+    /// @brief Initialize the m_invoker from given std::constant_wrapper.
+
+    template <typename Cw>
+    constexpr void cw_init() noexcept {
+      m_invoker = &invoker_impl_t::view_cw::template invoke<Cw>;
+
+      // Mandates are as follows.
+      if constexpr (sizeof...(Args) > 0 && (requires {
+          typename std::constant_wrapper<remove_cvref_t<Args>::value>; } && ...)) {
+        static_assert(!requires { typename std::constant_wrapper<
+              std::invoke(Cw::value, remove_cvref_t<Args>::value...)>;
+          }, "The argument types of fn_ref are all constexpr-param, and the"
+          " INVOKE result can be wrapped into std::constant_wrapper. This"
+          " means that you can simply use std::invoke(f, args...) instead"
+          " of fn_ref to avoid indirect INVOKE."
+        );
+      }
+    }
+
+    template <typename Cw, typename Obj>
+    constexpr void cw_init(erasure_base_t* target, Obj* obj_ptr) noexcept {
+      m_invoker = &invoker_impl_t::view_cw::template invoke<Cw, Obj>;
+      manager_impl_t::template ref_create<>(target, obj_ptr);
+    }
+
+#endif
   };
 
 } // end namespace command
@@ -2504,6 +2554,63 @@ namespace crtp_mixins {
         "Internal error: asserts_for_function<...>::value should be always true.");
 
       m_command.template emplace_init<Fn>(&m_erasure, il, std::forward<CArgs>(args)...);
+    }
+
+#endif
+
+#if __cpp_lib_constant_wrapper >= 202603L
+
+    /// @todo experimental @bug Clang 20 has a bug here.
+    /// In Clang 20, when a user creates two static free functions that have the
+    /// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+    /// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+    /// `std::cw<&free_fn>` is called.
+
+    // Create function reference with given `std::constant_wrapper` param.
+    template <auto CwVal, typename Fn>
+      requires is_invocable_using_t<Signature, const Fn&>::value
+        && Config::isView
+    constexpr function(std::constant_wrapper<CwVal, Fn>) noexcept {
+      using Cw = std::constant_wrapper<CwVal, Fn>;
+      m_command.template cw_init<Cw>();
+
+      // Mandates are as follows.
+      if constexpr (std::is_pointer_v<Fn> || std::is_member_pointer_v<Fn>) {
+        static_assert(Cw::value != nullptr, "Cannot create fn_ref from null constant_wrapper");
+      }
+    }
+
+    // Create function reference with given `std::constant_wrapper` and object params.
+    template <auto CwVal, typename Fn, typename Up, typename Tp = remove_reference_t<Up>>
+      requires std::is_rvalue_reference_v<Up&&>
+        && is_invocable_using_t<Signature, const Fn&, 
+          typename unwrap_signature<Signature>::template add_cv_like<Tp>&>::value
+        && Config::isView
+    constexpr function(std::constant_wrapper<CwVal, Fn>, Up&& obj) noexcept {
+      using Cw = std::constant_wrapper<CwVal, Fn>;
+      m_command.template cw_init<Cw>(&m_erasure, std::addressof(obj));
+
+      // Mandates are as follows.
+      if constexpr (std::is_pointer_v<Fn> || std::is_member_pointer_v<Fn>) {
+        static_assert(Cw::value != nullptr, "Cannot create fn_ref from null constant_wrapper");
+      }
+    }
+
+    // Create function reference with given `std::constant_wrapper` and pointer params.
+    template <auto CwVal, typename Fn, typename Tp,
+      typename Tp_cv = typename unwrap_signature<Signature>::template add_cv_like<Tp>
+    >
+      requires std::is_convertible_v<Tp*, Tp_cv*>
+        && is_invocable_using_t<Signature, const Fn&, Tp_cv*>::value
+        && Config::isView
+    constexpr function(std::constant_wrapper<CwVal, Fn>, Tp* obj) noexcept {
+      using Cw = std::constant_wrapper<CwVal, Fn>;
+      m_command.template cw_init<Cw>(&m_erasure, obj);
+
+      // Mandates are as follows.
+      if constexpr (std::is_pointer_v<Fn> || std::is_member_pointer_v<Fn>) {
+        static_assert(Cw::value != nullptr, "Cannot create fn_ref from null constant_wrapper");
+      }
     }
 
 #endif

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2349,10 +2349,18 @@ namespace crtp_mixins {
     using CoreComponents::operator=;
 
     // Create an empty function wrapper.
-    function() noexcept : CoreComponents(nullptr) {}
+    function() noexcept
+#if __cpp_concepts >= 202002L
+      requires requires { CoreComponents(nullptr); }
+#endif
+    : CoreComponents(nullptr) {}
 
     // Create an empty function wrapper.
-    function(std::nullptr_t) noexcept : CoreComponents(nullptr) {}
+    function(std::nullptr_t) noexcept
+#if __cpp_concepts >= 202002L
+      requires requires { CoreComponents(nullptr); }
+#endif
+    : CoreComponents(nullptr) {}
 
     // Use `placement new` to create new functor during construction. (Copy)
     // From `function<Buffer_small, ...>` to `function<Buffer_big, ...>`.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1448,6 +1448,14 @@ inline namespace fn_traits {
   using is_invocable_using_t = 
     typename is_invocable_using_impl<Signature, std::tuple<T...>>::type;
 
+  template <typename T>
+  struct is_constant_wrapper : std::false_type {};
+
+#if __cpp_lib_constant_wrapper >= 202603L
+  template <auto Cw, typename T>
+  struct is_constant_wrapper<std::constant_wrapper<Cw, T>> : std::true_type {};
+#endif
+
 } // end namespace fn_traits
 
 // In the namespace "erasure_type", we define a series of 
@@ -2177,7 +2185,8 @@ namespace crtp_mixins {
     core_components_impl& operator=(std::nullptr_t)   = delete;
     template <class T, 
       EMBED_DETAIL_REQUIRES(!fn_can_convert<Self, T>::value),
-      EMBED_DETAIL_REQUIRES(!std::is_pointer<T>::value)
+      EMBED_DETAIL_REQUIRES(!std::is_pointer<T>::value),
+      EMBED_DETAIL_REQUIRES(!is_constant_wrapper<T>::value)
     >
     core_components_impl& operator=(T)                = delete;
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1432,19 +1432,21 @@ inline namespace fn_traits {
 #endif
 
   // https://eel.is/c++draft/func.wrap#ref.ctor .
-  template <typename Sig, typename Func, typename PureSig = typename unwrap_signature<Sig>::pure_sig>
+  template <typename Sig, typename Tuple, 
+    typename PureSig = typename unwrap_signature<Sig>::pure_sig>
   struct is_invocable_using_impl;
-  template <typename Sig, typename Func, typename Ret, typename... Args>
-  struct is_invocable_using_impl<Sig, Func, Ret(Args...)> {
+  template <typename Sig, typename... TArgs, typename Ret, typename... Args>
+  struct is_invocable_using_impl<Sig, std::tuple<TArgs...>, Ret(Args...)> {
     using type = conditional_t<
       unwrap_signature<Sig>::isNoexcept,
-      is_nothrow_invocable_r<Ret, Func, Args...>,
-      is_invocable_r<Ret, Func, Args...>
+      is_nothrow_invocable_r<Ret, TArgs..., Args...>,
+      is_invocable_r<Ret, TArgs..., Args...>
     >;
   };
 
-  template <typename Signature, typename Func>
-  using is_invocable_using_t = typename is_invocable_using_impl<Signature, Func>::type;
+  template <typename Signature, typename... T>
+  using is_invocable_using_t = 
+    typename is_invocable_using_impl<Signature, std::tuple<T...>>::type;
 
   // Constraints for F&& constructor.
   template <typename Signature, typename Functor>

--- a/test/HOW-TO-TEST.md
+++ b/test/HOW-TO-TEST.md
@@ -19,5 +19,5 @@ cd ./test # Go to test directory: <repo_root>/test
 
 cmake -B build -S . -DCMAKE_CXX_STANDARD=11 # Generate build files
 
-cmake --build build --config Release --target test # Build and run tests. Add '-j 100' if slow.
+cmake --build build --config Debug --target test # Build and run tests. Add '-j 100' if slow.
 ```

--- a/test/conformance/fn_ref/__constant_wrapper.hpp
+++ b/test/conformance/fn_ref/__constant_wrapper.hpp
@@ -1,0 +1,335 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Additional modifications:
+// Copyright (c) 2026 Kim-J-Smith
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEMP_LIBCPP___UTILITY_CONSTANT_WRAPPER_H
+#define TEMP_LIBCPP___UTILITY_CONSTANT_WRAPPER_H
+
+#include <utility>
+#include <functional>
+
+#if __cplusplus >= 202302L && !defined(__cpp_lib_constant_wrapper)
+
+#define __cpp_lib_constant_wrapper 202603L
+
+namespace std {
+
+template <class _Tp>
+struct __cw_fixed_value {
+  using __type  = _Tp;
+   constexpr __cw_fixed_value(__type __v) noexcept : __data(__v) {}
+  _Tp __data;
+};
+
+template <class _Tp, size_t _Extent>
+struct __cw_fixed_value<_Tp[_Extent]> {
+  using __type  = _Tp[_Extent];
+  _Tp __data[_Extent];
+
+   constexpr __cw_fixed_value(_Tp (&__arr)[_Extent]) noexcept
+      : __cw_fixed_value(__arr, make_index_sequence<_Extent>{}) {}
+
+private:
+  template <size_t... _Idxs>
+   constexpr __cw_fixed_value(_Tp (&__arr)[_Extent], index_sequence<_Idxs...>) noexcept
+      : __data{__arr[_Idxs]...} {}
+};
+
+template <class _Tp, size_t _Extent>
+__cw_fixed_value(_Tp (&)[_Extent]) -> __cw_fixed_value<_Tp[_Extent]>;
+
+template <__cw_fixed_value _Xp,
+#  ifdef __GNUC__
+          // gcc bug:  https://gcc.gnu.org/PR117392
+          class = typename decltype(__cw_fixed_value(_Xp))::__type
+#  else
+          class = typename decltype(_Xp)::__type
+#  endif
+          >
+struct constant_wrapper;
+
+template <class _Tp>
+concept __constexpr_param = requires { typename constant_wrapper<_Tp::value>; };
+
+template <__cw_fixed_value _Xp>
+constexpr auto cw = constant_wrapper<_Xp>{};
+
+struct __cw_operators {
+  // unary operators
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  friend constexpr auto operator+(_Tp) noexcept -> constant_wrapper<(+_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  friend constexpr auto operator-(_Tp) noexcept -> constant_wrapper<(-_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  friend constexpr auto operator~(_Tp) noexcept -> constant_wrapper<(~_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  friend constexpr auto operator!(_Tp) noexcept -> constant_wrapper<(!_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  friend constexpr auto operator&(_Tp) noexcept -> constant_wrapper<(&_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  friend constexpr auto operator*(_Tp) noexcept -> constant_wrapper<(*_Tp::value)> {
+    return {};
+  }
+
+  // binary operators
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator+(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value + _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator-(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value - _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator*(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value * _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator/(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value / _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator%(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value % _Rp::value)> {
+    return {};
+  }
+
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator<<(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value << _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator>>(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value >> _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator&(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value & _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator|(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value | _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator^(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value ^ _Rp::value)> {
+    return {};
+  }
+
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+    requires(!is_constructible_v<bool, decltype(_Lp::value)> || !is_constructible_v<bool, decltype(_Rp::value)>)
+  [[nodiscard]]  friend constexpr auto operator&&(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value && _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+    requires(!is_constructible_v<bool, decltype(_Lp::value)> || !is_constructible_v<bool, decltype(_Rp::value)>)
+  [[nodiscard]]  friend constexpr auto operator||(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value || _Rp::value)> {
+    return {};
+  }
+
+  // comparisons
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator<=>(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value <=> _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator<(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value < _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator<=(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value <= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator==(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value == _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator!=(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value != _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator>(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value > _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+   friend constexpr auto operator>=(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value >= _Rp::value)> {
+    return {};
+  }
+
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  friend auto operator,(_Lp, _Rp) = delete;
+
+  template <__constexpr_param _Lp, __constexpr_param _Rp>
+  [[nodiscard]]  friend constexpr auto operator->*(_Lp, _Rp) noexcept
+      -> constant_wrapper<(_Lp::value->*_Rp::value)> {
+    return {};
+  }
+
+  // pseudo-mutators
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  constexpr auto operator++(this _Tp) noexcept -> constant_wrapper<(++_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  constexpr auto operator++(this _Tp, int) noexcept
+      -> constant_wrapper<(_Tp::value++)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  constexpr auto operator--(this _Tp) noexcept -> constant_wrapper<(--_Tp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp>
+  [[nodiscard]]  constexpr auto operator--(this _Tp, int) noexcept
+      -> constant_wrapper<(_Tp::value--)> {
+    return {};
+  }
+
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator+=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value += _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator-=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value -= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator*=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value *= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator/=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value /= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator%=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value %= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator&=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value &= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator|=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value |= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator^=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value ^= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator<<=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value <<= _Rp::value)> {
+    return {};
+  }
+  template <__constexpr_param _Tp, __constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator>>=(this _Tp, _Rp) noexcept
+      -> constant_wrapper<(_Tp::value >>= _Rp::value)> {
+    return {};
+  }
+};
+
+template <const auto& _Callable, class... _Args>
+concept __constexpr_callable = (__constexpr_param<remove_cvref_t<_Args>> && ...) && requires {
+  typename constant_wrapper<std::invoke(_Callable, remove_cvref_t<_Args>::value...)>;
+};
+
+template <const auto& _Obj, class... _Args>
+concept __constexpr_indexable = (__constexpr_param<remove_cvref_t<_Args>> && ...) && requires {
+  typename constant_wrapper<_Obj[remove_cvref_t<_Args>::value...]>;
+};
+
+template <__cw_fixed_value _Xp, class>
+struct constant_wrapper : __cw_operators {
+  static constexpr const auto& value = _Xp.__data;
+  using type                         = constant_wrapper;
+  using value_type                   = decltype(_Xp)::__type;
+
+  template <__constexpr_param _Rp>
+  [[nodiscard]]  constexpr auto operator=(_Rp) const noexcept
+      -> constant_wrapper<(value = _Rp::value)> {
+    return {};
+  }
+
+   constexpr operator decltype(value)() const noexcept { return value; }
+
+  template <class... _Args>
+    requires __constexpr_callable<value, _Args...>
+  [[nodiscard]]
+   static constexpr constant_wrapper<std::invoke(value, remove_cvref_t<_Args>::value...)>
+  operator()(_Args&&...) noexcept {
+    return {};
+  }
+
+  template <class... _Args>
+    requires(!__constexpr_callable<value, _Args...> && is_invocable_v<const value_type&, _Args && ...>)
+   static constexpr decltype(auto)
+  operator()(_Args&&... __args) noexcept(noexcept(std::invoke(value, std::forward<_Args>(__args)...))) {
+    return std::invoke(value, std::forward<_Args>(__args)...);
+  }
+
+  template <class... _Args>
+    requires __constexpr_indexable<value, _Args...>
+  [[nodiscard]]
+   static constexpr constant_wrapper<value[remove_cvref_t<_Args>::value...]>
+  operator[](_Args&&...) noexcept {
+    return {};
+  }
+
+  template <class... _Args>
+    requires(!__constexpr_indexable<value, _Args...> && requires { value[std::declval<_Args>()...]; })
+   static constexpr decltype(auto)
+  operator[](_Args&&... __args) noexcept(noexcept(value[std::forward<_Args>(__args)...])) {
+    return value[std::forward<_Args>(__args)...];
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 202400L
+
+#endif // TEMP_LIBCPP___UTILITY_CONSTANT_WRAPPER_H

--- a/test/conformance/fn_ref/__constant_wrapper.hpp
+++ b/test/conformance/fn_ref/__constant_wrapper.hpp
@@ -16,7 +16,14 @@
 #include <utility>
 #include <functional>
 
-#if __cplusplus >= 202302L && !defined(__cpp_lib_constant_wrapper)
+#if defined(_MSC_VER)
+// C++23 is not full supported if _MSC_VER < 1950.
+# define MSVC_IS_OK (_MSC_VER >= 1950)
+#else
+# define MSVC_IS_OK 1
+#endif
+
+#if __cplusplus >= 202302L && !defined(__cpp_lib_constant_wrapper) && MSVC_IS_OK
 
 #define __cpp_lib_constant_wrapper 202603L
 

--- a/test/conformance/fn_ref/assign.delete.pass.cpp
+++ b/test/conformance/fn_ref/assign.delete.pass.cpp
@@ -21,6 +21,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -40,8 +42,12 @@ STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void()>, ebd::fn_ref<void() const>
 STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void()>, void (*)()>::value);
 STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void()>, void (*)(int)>::value);
 
-// STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void()>, std::constant_wrapper<[] {}>>::value);
-// STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void()>, std::constant_wrapper<[](int) {}>>::value);
+#if __cpp_lib_constant_wrapper >= 202603L
+  STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void()>, std::constant_wrapper<+[] {}>>);
+  STATIC_ASSERT_(std::is_constructible_v<ebd::fn_ref<void()>, std::constant_wrapper<[] {}>>);
+  STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void()>, std::constant_wrapper<[] {}>>);
+  STATIC_ASSERT_(!std::is_assignable_v<ebd::fn_ref<void()>, std::constant_wrapper<[](int) {}>>);
+#endif
 
 // const noexcept(false)
 STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const>, ebd::fn_ref<void()>>::value);
@@ -54,8 +60,10 @@ STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const>, ebd::fn_ref<void() 
 STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const>, void (*)()>::value);
 STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, void (*)(int)>::value);
 
-// STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const>, std::constant_wrapper<[] { return 42; }>>::value);
-// STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, std::constant_wrapper<[](int) { return 42; }>>::value);
+#if __cpp_lib_constant_wrapper >= 202603L
+  STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void() const>, std::constant_wrapper<[] { return 42; }>>);
+  STATIC_ASSERT_(!std::is_assignable_v<ebd::fn_ref<void() const>, std::constant_wrapper<[](int) { return 42; }>>);
+#endif
 
 // non-const noexcept(true)
 #if __cpp_noexcept_function_type >= 201510L
@@ -67,8 +75,10 @@ STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, void (*)(int)>::va
   STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() noexcept>, void (*)() noexcept>::value);
   STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() noexcept>, void (*)(int) noexcept>::value);
 
-  // STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() noexcept>, std::constant_wrapper<[] noexcept {} >>);
-  // STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() noexcept>, std::constant_wrapper<[](int) noexcept {}>>);
+# if __cpp_lib_constant_wrapper >= 202603L
+    STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void() noexcept>, std::constant_wrapper<[] noexcept {} >>);
+    STATIC_ASSERT_(!std::is_assignable_v<ebd::fn_ref<void() noexcept>, std::constant_wrapper<[](int) noexcept {}>>);
+# endif
 
   // const noexcept(true)
   STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const noexcept>, ebd::fn_ref<void()>>::value);
@@ -79,9 +89,12 @@ STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, void (*)(int)>::va
   STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const noexcept>, void (*)() noexcept>::value);
   STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const noexcept>, void (*)(int) noexcept>::value);
 
-  // STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const noexcept>, std::constant_wrapper<[] noexcept {}>>::value);
-  // STATIC_ASSERT_(
-  //     !std::is_assignable<ebd::fn_ref<void() const noexcept>, std::constant_wrapper<[](int) noexcept {}>>::value);
+# if __cpp_lib_constant_wrapper >= 202603L
+
+    STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void() const noexcept>, std::constant_wrapper<[] noexcept {}>>);
+    STATIC_ASSERT_(
+        !std::is_assignable_v<ebd::fn_ref<void() const noexcept>, std::constant_wrapper<[](int) noexcept {}>>);
+# endif
 #endif
 
 static int forty_two() { return 42; }
@@ -89,7 +102,7 @@ static int forty_two() { return 42; }
 TEST(Conformance_fn_ref, assign_delete_pass) {
   static_cast<void>(&forty_two);
 
-#if 0 && __cpp_lib_function_ref >= 202603L
+#if __cpp_lib_constant_wrapper >= 202603L
   {
     ebd::fn_ref<int()> f(std::cw<[] { return 41; }>);
     f = ebd::fn_ref<int()>(std::cw<[] { return 42; }>);

--- a/test/conformance/fn_ref/clang.bug.pass.cpp
+++ b/test/conformance/fn_ref/clang.bug.pass.cpp
@@ -1,0 +1,44 @@
+#include <functional>
+#include <utility>
+#include <type_traits>
+
+#include "__constant_wrapper.hpp"
+
+#include "embed/embed_function.hpp"
+#include "gtest/gtest.h"
+
+#include "test_function.hpp"
+
+/// @todo experimental @bug Clang 20 has a bug here.
+/// In Clang 20, when a user creates two static free functions that have the
+/// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+/// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+/// `std::cw<&free_fn>` is called.
+
+// if defined EBD_TEST_TRY_BUG__Clang_SameNameStaticFunction and use Clang20
+// FAIL is expected:
+// [ RUN      ] Conformance_fn_ref.copy_pass
+// ninja: build stopped: subcommand failed.
+
+// In copy.pass.cpp, there exists an identical static function 
+// `this_name_should_not_be_changed` (with the same parameters and return type).
+static double this_name_should_not_be_changed(int x, double y) noexcept { return x + y; }
+
+TEST(Conformance_fn_ref, clang_bug_pass) {
+
+    static_cast<void>(&this_name_should_not_be_changed);
+
+#if __cpp_lib_constant_wrapper >= 202603L
+
+# if defined(__clang__) && !defined(EBD_TEST_TRY_BUG__Clang_SameNameStaticFunction)
+    ebd::fn_ref<double(int,double)> f = std::cw<+[](int x, double y) { return x + y; }>;
+    ASSERT_DOUBLE_EQ(f(1, 2.0), 3.0);
+# else
+    ebd::fn_ref<double(int,double)> f = std::cw<&this_name_should_not_be_changed>;
+    ASSERT_DOUBLE_EQ(f(1, 2.0), 3.0);
+# endif
+
+#endif
+
+}
+

--- a/test/conformance/fn_ref/copy.pass.cpp
+++ b/test/conformance/fn_ref/copy.pass.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -36,7 +38,9 @@ STATIC_ASSERT_(std::is_copy_constructible<ebd::fn_ref<void() const>>::value);
   STATIC_ASSERT_(std::is_copy_constructible<ebd::fn_ref<void() const noexcept>>::value);
 #endif
 
-static double f1(int x, double y) noexcept { return x + y; }
+// In clang.bug.pass.cpp, there exists an identical static function 
+// `this_name_should_not_be_changed` (with the same parameters and return type).
+static double this_name_should_not_be_changed(int x, double y) noexcept { return x + y; }
 
 struct Int {
   int i;
@@ -47,13 +51,18 @@ struct NeedsConversion {
   int operator()(Int x, Int y, Int z) const noexcept { return x.i + y.i + z.i; }
 };
 
-static int needs_conversion(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
+/// @bug In Clang 20, when a user creates two static free functions that have the
+/// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+/// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+/// `std::cw<&free_fn>` is called.
+/// Add _2 to avoid the same name.
+static int needs_conversion_2(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
 
 TEST(Conformance_fn_ref, copy_pass) {
-  static_cast<void>(&f1);
-  static_cast<void>(&needs_conversion);
+  static_cast<void>(&this_name_should_not_be_changed);
+  static_cast<void>(&needs_conversion_2);
 
-#if 0 && __cpp_lib_function_ref >= 202603L
+#if __cpp_lib_constant_wrapper >= 202603L
   {
     ebd::fn_ref<void()> f(std::cw<[] {}>);
     auto f2 = f;
@@ -72,7 +81,7 @@ TEST(Conformance_fn_ref, copy_pass) {
   }
   {
     // noexcept
-    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&f1>);
+    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&this_name_should_not_be_changed>);
     auto f2 = f;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f2(1, 2.0) == 3.0);
@@ -80,7 +89,7 @@ TEST(Conformance_fn_ref, copy_pass) {
   }
   {
     // const noexcept
-    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&f1>);
+    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&this_name_should_not_be_changed>);
     auto f2 = f;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f2(1, 2.0) == 3.0);
@@ -114,25 +123,25 @@ TEST(Conformance_fn_ref, copy_pass) {
   }
   {
     // with conversions function pointer
-    ebd::fn_ref<Int(int, int, int)> f(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int)> f(std::cw<&needs_conversion_2>);
     auto f_copy = f;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f_copy(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) const> f2(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) const> f2(std::cw<&needs_conversion_2>);
     auto f2_copy = f2;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f2_copy(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) noexcept> f3(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) noexcept> f3(std::cw<&needs_conversion_2>);
     auto f3_copy = f3;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f3_copy(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) const noexcept> f4(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) const noexcept> f4(std::cw<&needs_conversion_2>);
     auto f4_copy = f4;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f4_copy(1, 2, 3).i == 6);

--- a/test/conformance/fn_ref/copy_assign.pass.cpp
+++ b/test/conformance/fn_ref/copy_assign.pass.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -36,8 +38,13 @@ STATIC_ASSERT_(std::is_copy_assignable<ebd::fn_ref<void() const>>::value);
   STATIC_ASSERT_(std::is_copy_assignable<ebd::fn_ref<void() const noexcept>>::value);
 #endif
 
-static double plus(int x, double y) noexcept { return x + y; }
-static double minus(int x, double y) noexcept { return x - y; }
+/// @bug In Clang 20, when a user creates two static free functions that have the
+/// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+/// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+/// `std::cw<&free_fn>` is called.
+/// Add _1 to avoid the same name.
+static double plus_1(int x, double y) noexcept { return x + y; }
+static double minus_1(int x, double y) noexcept { return x - y; }
 
 struct Int {
   int i;
@@ -48,16 +55,16 @@ struct NeedsConversion {
   int operator()(Int x, Int y, Int z) const noexcept { return x.i + y.i + z.i; }
 };
 
-static int needs_conversion(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
-static int zero(Int, Int, Int) noexcept { return 0; }
+static int needs_conversion_1(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
+static int zero_1(Int, Int, Int) noexcept { return 0; }
 
 TEST(Conformance_fn_ref, copy_assign_pass) {
-  static_cast<void>(&plus);
-  static_cast<void>(&minus);
-  static_cast<void>(&needs_conversion);
-  static_cast<void>(&zero);
+  static_cast<void>(&plus_1);
+  static_cast<void>(&minus_1);
+  static_cast<void>(&needs_conversion_1);
+  static_cast<void>(&zero_1);
 
-#if 0 && __cpp_lib_function_ref >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202603L
   {
     ebd::fn_ref<void()> f(std::cw<[] {}>);
     ebd::fn_ref<void()> f2(std::cw<[] {}>);
@@ -80,8 +87,8 @@ TEST(Conformance_fn_ref, copy_assign_pass) {
   }
   {
     // noexcept
-    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&plus>);
-    ebd::fn_ref<double(int, double) noexcept> f2(std::cw<&minus>);
+    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&plus_1>);
+    ebd::fn_ref<double(int, double) noexcept> f2(std::cw<&minus_1>);
     f2 = f;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f(1, 2.0) == 3.0);
@@ -90,8 +97,8 @@ TEST(Conformance_fn_ref, copy_assign_pass) {
   }
   {
     // const noexcept
-    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&plus>);
-    ebd::fn_ref<double(int, double) const noexcept> f2(std::cw<&minus>);
+    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&plus_1>);
+    ebd::fn_ref<double(int, double) const noexcept> f2(std::cw<&minus_1>);
     f2 = f;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f(1, 2.0) == 3.0);
@@ -135,32 +142,32 @@ TEST(Conformance_fn_ref, copy_assign_pass) {
   }
   {
     // with conversions function pointer
-    ebd::fn_ref<Int(int, int, int)> f(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int)> f2(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int)> f(std::cw<&zero_1>);
+    ebd::fn_ref<Int(int, int, int)> f2(std::cw<&needs_conversion_1>);
     f = f2;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f(1, 2, 3).i == 6);
       ASSERT_(f2(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) const> f_const(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int) const> f2_const(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) const> f_const(std::cw<&zero_1>);
+    ebd::fn_ref<Int(int, int, int) const> f2_const(std::cw<&needs_conversion_1>);
     f_const = f2_const;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f_const(1, 2, 3).i == 6);
       ASSERT_(f2_const(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) noexcept> f_noexcept(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int) noexcept> f2_noexcept(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) noexcept> f_noexcept(std::cw<&zero_1>);
+    ebd::fn_ref<Int(int, int, int) noexcept> f2_noexcept(std::cw<&needs_conversion_1>);
     f_noexcept = f2_noexcept;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f_noexcept(1, 2, 3).i == 6);
       ASSERT_(f2_noexcept(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) const noexcept> f_const_noexcept(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int) const noexcept> f2_const_noexcept(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) const noexcept> f_const_noexcept(std::cw<&zero_1>);
+    ebd::fn_ref<Int(int, int, int) const noexcept> f2_const_noexcept(std::cw<&needs_conversion_1>);
     f_const_noexcept = f2_const_noexcept;
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f_const_noexcept(1, 2, 3).i == 6);

--- a/test/conformance/fn_ref/function_ptr.pass.cpp
+++ b/test/conformance/fn_ref/function_ptr.pass.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -111,7 +113,12 @@ struct Int {
   Int(int ii) noexcept : i(ii) {}
 };
 
-static int needs_conversion(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
+/// @bug In Clang 20, when a user creates two static free functions that have the
+/// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+/// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+/// `std::cw<&free_fn>` is called.
+/// Add _3 to avoid the same name.
+static int needs_conversion_3(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
 
 TEST(Conformance_fn_ref, function_ptr_pass) {
   {
@@ -146,16 +153,16 @@ TEST(Conformance_fn_ref, function_ptr_pass) {
   }
 
   {
-    ebd::fn_ref<Int(int, int, int)> f(&needs_conversion);
+    ebd::fn_ref<Int(int, int, int)> f(&needs_conversion_3);
     ASSERT_(f(1, 2, 3).i == 6);
 
-    ebd::fn_ref<Int(int, int, int) const> f2(&needs_conversion);
+    ebd::fn_ref<Int(int, int, int) const> f2(&needs_conversion_3);
     ASSERT_(f2(1, 2, 3).i == 6);
 
-    ebd::fn_ref<Int(int, int, int) noexcept> f3(&needs_conversion);
+    ebd::fn_ref<Int(int, int, int) noexcept> f3(&needs_conversion_3);
     ASSERT_(f3(1, 2, 3).i == 6);
 
-    ebd::fn_ref<Int(int, int, int) const noexcept> f4(&needs_conversion);
+    ebd::fn_ref<Int(int, int, int) const noexcept> f4(&needs_conversion_3);
     ASSERT_(f4(1, 2, 3).i == 6);
 
     {

--- a/test/conformance/fn_ref/move.pass.cpp
+++ b/test/conformance/fn_ref/move.pass.cpp
@@ -16,6 +16,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -34,7 +36,7 @@ STATIC_ASSERT_(std::is_move_constructible<ebd::fn_ref<void() const>>::value);
   STATIC_ASSERT_(std::is_move_constructible<ebd::fn_ref<void() const noexcept>>::value);
 #endif
 
-static double f1(int x, double y) noexcept { return x + y; }
+static double f2(int x, double y) noexcept { return x + y; }
 
 struct Int {
   int i;
@@ -45,12 +47,17 @@ struct NeedsConversion {
   int operator()(Int x, Int y, Int z) const noexcept { return x.i + y.i + z.i; }
 };
 
-static int needs_conversion(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
+/// @bug In Clang 20, when a user creates two static free functions that have the
+/// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+/// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+/// `std::cw<&free_fn>` is called.
+/// Add _5 to avoid the same name.
+static int needs_conversion_5(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
 
 TEST(Conformance_fn_ref, move_pass) {
-  static_cast<void>(&f1);
-  static_cast<void>(&needs_conversion);
-#if 0 && __cpp_lib_function_ref >= 202603L
+  static_cast<void>(&f2);
+  static_cast<void>(&needs_conversion_5);
+#if 1 && __cpp_lib_constant_wrapper >= 202603L
   {
     ebd::fn_ref<void()> f(std::cw<[] {}>);
     auto f2 = std::move(f);
@@ -69,7 +76,7 @@ TEST(Conformance_fn_ref, move_pass) {
   }
   {
     // noexcept
-    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&f1>);
+    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&f2>);
     auto f2 = std::move(f);
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f2(1, 2.0) == 3.0);
@@ -77,7 +84,7 @@ TEST(Conformance_fn_ref, move_pass) {
   }
   {
     // const noexcept
-    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&f1>);
+    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&f2>);
     auto f2 = std::move(f);
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f2(1, 2.0) == 3.0);
@@ -111,25 +118,25 @@ TEST(Conformance_fn_ref, move_pass) {
   }
   {
     // with conversions function pointer
-    ebd::fn_ref<Int(int, int, int)> f(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int)> f(std::cw<&needs_conversion_5>);
     auto f_copy = std::move(f);
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f_copy(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) const> f2(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) const> f2(std::cw<&needs_conversion_5>);
     auto f2_copy = std::move(f2);
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f2_copy(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) noexcept> f3(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) noexcept> f3(std::cw<&needs_conversion_5>);
     auto f3_copy = std::move(f3);
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f3_copy(1, 2, 3).i == 6);
     }
 
-    ebd::fn_ref<Int(int, int, int) const noexcept> f4(std::cw<&needs_conversion>);
+    ebd::fn_ref<Int(int, int, int) const noexcept> f4(std::cw<&needs_conversion_5>);
     auto f4_copy = std::move(f4);
     if (!TEST_IS_CONSTANT_EVALUATED) {
       ASSERT_(f4_copy(1, 2, 3).i == 6);

--- a/test/conformance/fn_ref/move_assign.pass.cpp
+++ b/test/conformance/fn_ref/move_assign.pass.cpp
@@ -16,6 +16,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -34,8 +36,8 @@ STATIC_ASSERT_(std::is_move_assignable<ebd::fn_ref<void() const>>::value);
   STATIC_ASSERT_(std::is_move_assignable<ebd::fn_ref<void() const noexcept>>::value);
 #endif
 
-static double plus(int x, double y) noexcept { return x + y; }
-static double minus(int x, double y) noexcept { return x - y; }
+static double plus_2(int x, double y) noexcept { return x + y; }
+static double minus_2(int x, double y) noexcept { return x - y; }
 
 struct Int {
   int i;
@@ -46,125 +48,139 @@ struct NeedsConversion {
   int operator()(Int x, Int y, Int z) const noexcept { return x.i + y.i + z.i; }
 };
 
-static int needs_conversion(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
+/// @bug In Clang 20, when a user creates two static free functions that have the
+/// same name in two compile units and wraps them into two `std::cw<&free_fn>`
+/// objects, a segmentation fault ( @e SIGSEGV ) occurs if one of the
+/// `std::cw<&free_fn>` is called.
+/// Add _4 to avoid the same name.
+static int needs_conversion_4(Int x, Int y, Int z) noexcept { return x.i + y.i + z.i; }
 static int zero(Int, Int, Int) noexcept { return 0; }
 
 TEST(Conformance_fn_ref, move_assign_pass) {
-  static_cast<void>(&plus);
-  static_cast<void>(&minus);
-  static_cast<void>(&needs_conversion);
+  static_cast<void>(&plus_2);
+  static_cast<void>(&minus_2);
+  static_cast<void>(&needs_conversion_4);
   static_cast<void>(&zero);
-
-#if 0 && __cpp_lib_function_ref >= 202603L
-  {
-    ebd::fn_ref<void()> f(std::cw<[] {}>);
-    ebd::fn_ref<void()> f2(std::cw<[] {}>);
-    f2 = std::move(f);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      f();
-      f2();
-    }
-  }
-  {
-    // const
-    ebd::fn_ref<int() const> f(std::cw<[] { return 42; }>);
-    ebd::fn_ref<int() const> f2(std::cw<[] { return 41; }>);
-    f2 = std::move(f);
-
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f() == 42);
-      ASSERT_(f2() == 42);
-    }
-  }
-  {
-    // noexcept
-    ebd::fn_ref<double(int, double) noexcept> f(std::cw<&plus>);
-    ebd::fn_ref<double(int, double) noexcept> f2(std::cw<&minus>);
-    f2 = std::move(f);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f(1, 2.0) == 3.0);
-      ASSERT_(f2(1, 2.0) == 3.0);
-    }
-  }
-  {
-    // const noexcept
-    ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&plus>);
-    ebd::fn_ref<double(int, double) const noexcept> f2(std::cw<&minus>);
-    f2 = std::move(f);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f(1, 2.0) == 3.0);
-      ASSERT_(f2(1, 2.0) == 3.0);
-    }
-  }
-  {
-    // with conversions
-    ebd::fn_ref<Int(int, int, int)> f(std::cw<[](int, int, int) { return Int{1}; }>);
-    ebd::fn_ref<Int(int, int, int)> f2(std::cw<NeedsConversion{}>);
-    f = std::move(f2);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f(1, 2, 3).i == 6);
-      ASSERT_(f2(1, 2, 3).i == 6);
-    }
-
-    ebd::fn_ref<Int(int, int, int) const> f_const(std::cw<[](int, int, int) { return Int{1}; }>);
-    ebd::fn_ref<Int(int, int, int) const> f2_const(std::cw<NeedsConversion{}>);
-    f_const = std::move(f2_const);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f_const(1, 2, 3).i == 6);
-      ASSERT_(f2_const(1, 2, 3).i == 6);
-    }
-
-    ebd::fn_ref<Int(int, int, int) noexcept> f_noexcept(std::cw<[](int, int, int) noexcept { return Int{1}; }>);
-    ebd::fn_ref<Int(int, int, int) noexcept> f2_noexcept(std::cw<NeedsConversion{}>);
-    f_noexcept = std::move(f2_noexcept);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f_noexcept(1, 2, 3).i == 6);
-      ASSERT_(f2_noexcept(1, 2, 3).i == 6);
-    }
-
-    ebd::fn_ref<Int(int, int, int) const noexcept> f_const_noexcept(
-        std::cw<[](int, int, int) noexcept { return Int{1}; }>);
-    ebd::fn_ref<Int(int, int, int) const noexcept> f2_const_noexcept(std::cw<NeedsConversion{}>);
-    f_const_noexcept = std::move(f2_const_noexcept);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f_const_noexcept(1, 2, 3).i == 6);
-      ASSERT_(f2_const_noexcept(1, 2, 3).i == 6);
-    }
-  }
-  {
-    // with conversions function pointer
-    ebd::fn_ref<Int(int, int, int)> f(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int)> f2(std::cw<&needs_conversion>);
-    f = std::move(f2);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f(1, 2, 3).i == 6);
-      ASSERT_(f2(1, 2, 3).i == 6);
-    }
-
-    ebd::fn_ref<Int(int, int, int) const> f_const(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int) const> f2_const(std::cw<&needs_conversion>);
-    f_const = std::move(f2_const);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f_const(1, 2, 3).i == 6);
-      ASSERT_(f2_const(1, 2, 3).i == 6);
-    }
-
-    ebd::fn_ref<Int(int, int, int) noexcept> f_noexcept(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int) noexcept> f2_noexcept(std::cw<&needs_conversion>);
-    f_noexcept = std::move(f2_noexcept);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f_noexcept(1, 2, 3).i == 6);
-      ASSERT_(f2_noexcept(1, 2, 3).i == 6);
-    }
-
-    ebd::fn_ref<Int(int, int, int) const noexcept> f_const_noexcept(std::cw<&zero>);
-    ebd::fn_ref<Int(int, int, int) const noexcept> f2_const_noexcept(std::cw<&needs_conversion>);
-    f_const_noexcept = std::move(f2_const_noexcept);
-    if (!TEST_IS_CONSTANT_EVALUATED) {
-      ASSERT_(f_const_noexcept(1, 2, 3).i == 6);
-      ASSERT_(f2_const_noexcept(1, 2, 3).i == 6);
-    }
-  }
-#endif
   SUCCEED();
 }
+
+#if __cpp_lib_constant_wrapper >= 202603L
+
+TEST(Conformance_fn_ref, move_assign_pass_0) {
+  ebd::fn_ref<void()> f(std::cw<[] {}>);
+  ebd::fn_ref<void()> f2(std::cw<[] {}>);
+  f2 = std::move(f);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    f();
+    f2();
+  }
+}
+
+TEST(Conformance_fn_ref, move_assign_pass_1) {
+  // const
+  ebd::fn_ref<int() const> f(std::cw<[] { return 42; }>);
+  ebd::fn_ref<int() const> f2(std::cw<[] { return 41; }>);
+  f2 = std::move(f);
+
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f() == 42);
+    ASSERT_(f2() == 42);
+  }
+}
+
+TEST(Conformance_fn_ref, move_assign_pass_2) {
+  // noexcept
+  ebd::fn_ref<double(int, double) noexcept> f(std::cw<&plus_2>);
+  ebd::fn_ref<double(int, double) noexcept> f2(std::cw<&minus_2>);
+  f2 = std::move(f);
+  auto ret1 = f(1, 2.0);
+  auto ret2 = f2(1, 2.0);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_DOUBLE_EQ(ret1, 3.0);
+    ASSERT_DOUBLE_EQ(ret2, 3.0);
+  }
+}
+
+TEST(Conformance_fn_ref, move_assign_pass_3) {
+  // const noexcept
+  ebd::fn_ref<double(int, double) const noexcept> f(std::cw<&plus_2>);
+  ebd::fn_ref<double(int, double) const noexcept> f2(std::cw<&minus_2>);
+  f2 = std::move(f);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_DOUBLE_EQ(f(1, 2.0), 3.0);
+    ASSERT_DOUBLE_EQ(f2(1, 2.0), 3.0);
+  }
+}
+
+TEST(Conformance_fn_ref, move_assign_pass_4) {
+  // with conversions
+  ebd::fn_ref<Int(int, int, int)> f(std::cw<[](int, int, int) { return Int{1}; }>);
+  ebd::fn_ref<Int(int, int, int)> f2(std::cw<NeedsConversion{}>);
+  f = std::move(f2);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f(1, 2, 3).i == 6);
+    ASSERT_(f2(1, 2, 3).i == 6);
+  }
+
+  ebd::fn_ref<Int(int, int, int) const> f_const(std::cw<[](int, int, int) { return Int{1}; }>);
+  ebd::fn_ref<Int(int, int, int) const> f2_const(std::cw<NeedsConversion{}>);
+  f_const = std::move(f2_const);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f_const(1, 2, 3).i == 6);
+    ASSERT_(f2_const(1, 2, 3).i == 6);
+  }
+
+  ebd::fn_ref<Int(int, int, int) noexcept> f_noexcept(std::cw<[](int, int, int) noexcept { return Int{1}; }>);
+  ebd::fn_ref<Int(int, int, int) noexcept> f2_noexcept(std::cw<NeedsConversion{}>);
+  f_noexcept = std::move(f2_noexcept);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f_noexcept(1, 2, 3).i == 6);
+    ASSERT_(f2_noexcept(1, 2, 3).i == 6);
+  }
+
+  ebd::fn_ref<Int(int, int, int) const noexcept> f_const_noexcept(
+      std::cw<[](int, int, int) noexcept { return Int{1}; }>);
+  ebd::fn_ref<Int(int, int, int) const noexcept> f2_const_noexcept(std::cw<NeedsConversion{}>);
+  f_const_noexcept = std::move(f2_const_noexcept);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f_const_noexcept(1, 2, 3).i == 6);
+    ASSERT_(f2_const_noexcept(1, 2, 3).i == 6);
+  }
+}
+
+TEST(Conformance_fn_ref, move_assign_pass_5) {
+  // with conversions function pointer
+  ebd::fn_ref<Int(int, int, int)> f(std::cw<&zero>);
+  ebd::fn_ref<Int(int, int, int)> f2(std::cw<&needs_conversion_4>);
+  f = std::move(f2);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f(1, 2, 3).i == 6);
+    ASSERT_(f2(1, 2, 3).i == 6);
+  }
+
+  ebd::fn_ref<Int(int, int, int) const> f_const(std::cw<&zero>);
+  ebd::fn_ref<Int(int, int, int) const> f2_const(std::cw<&needs_conversion_4>);
+  f_const = std::move(f2_const);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f_const(1, 2, 3).i == 6);
+    ASSERT_(f2_const(1, 2, 3).i == 6);
+  }
+
+  ebd::fn_ref<Int(int, int, int) noexcept> f_noexcept(std::cw<&zero>);
+  ebd::fn_ref<Int(int, int, int) noexcept> f2_noexcept(std::cw<&needs_conversion_4>);
+  f_noexcept = std::move(f2_noexcept);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f_noexcept(1, 2, 3).i == 6);
+    ASSERT_(f2_noexcept(1, 2, 3).i == 6);
+  }
+
+  ebd::fn_ref<Int(int, int, int) const noexcept> f_const_noexcept(std::cw<&zero>);
+  ebd::fn_ref<Int(int, int, int) const noexcept> f2_const_noexcept(std::cw<&needs_conversion_4>);
+  f_const_noexcept = std::move(f2_const_noexcept);
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_(f_const_noexcept(1, 2, 3).i == 6);
+    ASSERT_(f2_const_noexcept(1, 2, 3).i == 6);
+  }
+}
+
+#endif

--- a/test/conformance/fn_ref/ref.pass.cpp
+++ b/test/conformance/fn_ref/ref.pass.cpp
@@ -87,7 +87,10 @@ STATIC_ASSERT_(std::is_constructible<ebd::fn_ref<void()>, L2&>::value);
 STATIC_ASSERT_(std::is_constructible<ebd::fn_ref<void()>, ebd::fn_ref<int()>&>::value);
 
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void()>, L3&>::value);
-// STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void()>>::value); // CANNOT IMPLEMENT
+#if __cpp_concepts >= 202002L
+  STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void()>>::value);
+  STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void()>, std::nullptr_t>::value);
+#endif
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void()>, void (A::*)()>::value);
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(A*)>, void (A::*)()>::value);
 
@@ -131,7 +134,10 @@ STATIC_ASSERT_(
 STATIC_ASSERT_(std::is_constructible<ebd::fn_ref<void(int, double)>, NonConstInvocable&>::value);
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(int, double)>, const NonConstInvocable&>::value);
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(int, double) const>, NonConstInvocable&>::value);
-// STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(int, double) const>>::value); // CANNOT IMPLEMENT
+#if __cpp_concepts >= 202002L
+  STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(int, double) const>>::value);
+  STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(int, double) const>, std::nullptr_t>::value);
+#endif
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(int, double) const>, void (A::*)()>::value);
 STATIC_ASSERT_(!std::is_constructible<ebd::fn_ref<void(A*) const>, void (A::*)()>::value);
 

--- a/test/conformance/fn_ref/ref.pass.cpp
+++ b/test/conformance/fn_ref/ref.pass.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "__constant_wrapper.hpp"
+
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
@@ -203,7 +205,7 @@ int fn() { return 5; }
 #if __cpp_noexcept_function_type >= 201510L && __cpp_constexpr >= 201603L
   constexpr auto fn_noexcept = []() noexcept { return 6; };
 
-# if 0 && __cpp_lib_function_ref >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202603L
   const auto one = []() noexcept { return 1; };
   const auto two = []() noexcept { return 2; };
 # endif
@@ -355,7 +357,7 @@ TEST(Conformance_fn_ref, ref_pass) {
     }
   }
 #endif
-#if 0 && __cpp_lib_function_ref >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202603L
   {
     // P3961R1 Less double indirection in function_ref
     // double unwrapping


### PR DESCRIPTION
- add std::constant_wrapper(C++26) support for conformance.

- Clang 20 has bug here.