### PR TITLE
Avoid storing stateless standard function objects.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1741,12 +1741,12 @@ namespace invocation {
       }                                                                           \
     };                                                                            \
                                                                                   \
-    /* Using for standard operation wrapper (like std::less). */                  \
+    /* Used for standard operator wrapper (like std::less). */                    \
     struct std_op_wrapper {                                                       \
       template <typename StdOperator>                                             \
       static Ret invoke(erasure_base_t*, smart_forward_t<Args>... args) {         \
         static_assert(is_std_op_wrapper<StdOperator>::value,                      \
-          EMBED_DETAIL_REPORT_IE("StdOperator should be std operation wrapper")); \
+          EMBED_DETAIL_REPORT_IE("'StdOperator' should be std operator wrapper"));\
         C V auto fn = StdOperator{};                                              \
         return invoke_r<Ret>(fn, std::forward<Args>(args)...);                    \
       }                                                                           \

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1566,6 +1566,29 @@ inline namespace fn_traits {
   using noexcept_qualify_like_t = 
     typename noexcept_qualify_like<decay_t<Functor>, Fn<void(), sizeof(void(*)())>, Sig>::type;
 
+  // Check if `T` is the stateless standard operator wrapper.
+  template <typename T> struct is_std_op_wrapper : std::false_type {};
+
+  template <typename T> struct is_std_op_wrapper<std::equal_to<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::not_equal_to<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::greater<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::less<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::greater_equal<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::less_equal<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::plus<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::minus<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::multiplies<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::divides<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::modulus<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::negate<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::logical_and<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::logical_or<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::logical_not<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::bit_and<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::bit_or<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::bit_xor<T>> : std::true_type {};
+  template <typename T> struct is_std_op_wrapper<std::bit_not<T>> : std::true_type {};
+
 } // end namespace fn_traits
 
 // In the namespace "erasure_type", we define a series of 
@@ -1715,6 +1738,17 @@ namespace invocation {
         auto& fn = *(erased->template access<Functor*>());                        \
         using Fn = C V remove_reference_t<decltype(fn)>&;                         \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
+      }                                                                           \
+    };                                                                            \
+                                                                                  \
+    /* Using for standard operation wrapper (like std::less). */                  \
+    struct std_op_wrapper {                                                       \
+      template <typename StdOperator>                                             \
+      static Ret invoke(erasure_base_t*, smart_forward_t<Args>... args) {         \
+        static_assert(is_std_op_wrapper<StdOperator>::value,                      \
+          EMBED_DETAIL_REPORT_IE("StdOperator should be std operation wrapper")); \
+        C V auto fn = StdOperator{};                                              \
+        return invoke_r<Ret>(fn, std::forward<Args>(args)...);                    \
       }                                                                           \
     };                                                                            \
                                                                                   \
@@ -1943,11 +1977,19 @@ namespace command {
     }
 
     template <typename Functor, typename DecFunctor = decay_t<Functor>>
-    void init(erasure_base_t* target, Functor&& obj)
+    enable_if_t<!is_std_op_wrapper<DecFunctor>::value>
+    init(erasure_base_t* target, Functor&& obj)
     noexcept(std::is_nothrow_constructible<DecFunctor, Functor&&>::value) {
       manager_impl_t::template create<DecFunctor>(target, std::forward<Functor>(obj));
       m_invoker = &invoker_impl_t::inplace::template invoke<DecFunctor>;
       m_manager = &manager_impl_t::inplace::template manage<DecFunctor, Config::isCopyable>;
+    }
+
+    template <typename Functor, typename DecFunctor = decay_t<Functor>>
+    EMBED_CXX20_CONSTEXPR enable_if_t<is_std_op_wrapper<DecFunctor>::value>
+    init(erasure_base_t*, Functor&&) noexcept {
+      m_invoker = &invoker_impl_t::std_op_wrapper::template invoke<DecFunctor>;
+      m_manager = &manager_impl_t::empty::manage;
     }
 
 #if EMBED_CXX_VERSION >= 201703L
@@ -2003,7 +2045,7 @@ namespace command {
       // Do nothing here
     }
 
-    // Enable if Functor is stored origin.
+    // Enable if Functor is stored origin. (Enable if the functor is function pointer(FP))
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
     enable_if_t<IsStoredOrigin> /* Enable if the functor is function pointer(FP) */
     init(erasure_base_t* target, Functor&& obj) noexcept {
@@ -2013,14 +2055,21 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }
 
-    // Enable if Functor is stored by pointer.
+    // Enable if Functor is stored by pointer. (Enable if the functor is neither FP or std-op-wrapper)
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
-    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin> /* Enable if the functor is not FP */
+    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && !is_std_op_wrapper<DecFunctor>::value>
     init(erasure_base_t* target, Functor&& obj) noexcept {
       static_assert(!std::is_rvalue_reference<Functor&&>::value,
         "function in view mode cannot be initialized with rvalue reference.");
       manager_impl_t::template ref_create<>(target, std::addressof(obj));
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
+    }
+
+    // Enable if Functor is not stored. (Enable if the functor is std-op-wrapper)
+    template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
+    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && is_std_op_wrapper<DecFunctor>::value>
+    init(erasure_base_t*, Functor&&) noexcept {
+      m_invoker = &invoker_impl_t::std_op_wrapper::template invoke<DecFunctor>;
     }
 
 #if __cpp_lib_constant_wrapper >= 202603L

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -174,4 +174,20 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     ASSERT_EQ(f6(2, 42), 44);
     ASSERT_EQ(f7(2, 42), 44);
   }
+
+  {
+    auto f = ebd::make_fn<ebd::fn_ref>(std::less<int>{});
+    ASSERT_EQ(f(3, 4), true);
+    ASSERT_EQ(f(4, 3), false);
+  }
+
+# if (EMBED_CXX_VERSION >= 202002L && __cpp_constexpr >= 202002L)
+  {
+    static constexpr auto l = [] {};
+    constexpr ebd::fn_ref<void()> f1 = l;
+
+    constexpr ebd::fn_ref<int(int, int)> f2 = std::plus{};
+    ASSERT_EQ(f2(1, 2), 3);
+  }
+#endif
 }

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -598,3 +598,11 @@ TEST(InitFunction, Functor_noexcept_make_fn) {
     ASSERT_EQ(f1(1), 1);
     ASSERT_EQ(f1(1), 2);
 }
+
+// InitFunction[34]
+TEST(InitFunction, std_op_wrapper) {
+    auto f1 = ebd::make_fn(std::greater<int>{});
+
+    ASSERT_EQ(f1(1, 0), true);
+    ASSERT_EQ(f1(1, 2), false);
+}


### PR DESCRIPTION
## Avoid storing stateless standard function objects in fn_ref

### Description:
This patch adds a trait is_std_op_wrapper that recognizes all standard arithmetic, comparison, logical, and bitwise function objects (e.g., std::less, std::plus) as empty and stateless. When constructing an fn_ref (or similar type-erased wrapper) from such an object, we now bypass storage entirely and instead use a default-constructed temporary instance at invocation time. This eliminates unnecessary memory usage, removes an indirection, and enables constexpr construction of the wrapper. The generated assembly reflects the savings (e.g., one fewer lea instruction). All existing behavior and type requirements are preserved.

current:
```asm
"main":
        lea     rax, [rsp-25]
        pxor    xmm0, xmm0
        mov     edx, OFFSET FLAT:"std::enable_if<!ebd::detail::fn_traits::is_stored_origin<std::less<int>, true, std::decay<std::less<int> >::type, (true)?ebd::detail::fn_traits::is_function_ptr<std::decay<std::less<int> >::type>::value : (true)>::value, bool>::type ebd::detail::invocation::InvokerImpl<8ul, ebd::detail::fn_traits::config_package<true, true, false, false>, bool (int const&, int const&) const>::view::invoke<std::less<int> >(ebd::detail::erasure_type::ErasureBase const*, int const&, int const&)"
        movaps  XMMWORD PTR [rsp-24], xmm0
        mov     QWORD PTR [rsp-24], rax
        xor     eax, eax
        mov     QWORD PTR [rsp-16], rdx
        ret
```

new:
```asm
"main":
        pxor    xmm0, xmm0
        xor     eax, eax
        mov     edx, OFFSET FLAT:"bool ebd::detail::invocation::InvokerImpl<8ul, ebd::detail::fn_traits::config_package<true, true, false, false>, bool (int const&, int const&) const>::std_op_wrapper::invoke<std::less<int> >(ebd::detail::erasure_type::ErasureBase const*, int const&, int const&)"
        movaps  XMMWORD PTR [rsp-24], xmm0
        mov     QWORD PTR [rsp-24], rax
        mov     QWORD PTR [rsp-16], rdx
        ret
```