### PR TITLE
Enhance the performance of `fn_ref`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,36 @@ jobs:
         working-directory: test
         run: cmake --build build --config Debug --target test -j100
 
-  # Windows check
-  test-on-windows:
+  # Windows-vs2026 check
+  test-on-windows-vs2026:
     if: github.repository_owner == 'Kim-J-Smith'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
+    strategy:
+      matrix:
+        cpp_standards: [14, 17, 20, 23]
+        arch: [x64]
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Config with C++${{ matrix.cpp_standards }}
+        working-directory: test
+        shell: bash
+        run: |
+          cmake -B build -S . \
+            -G "Visual Studio 18 2026" \
+            -A ${{ matrix.arch }} \
+            -DCMAKE_CXX_STANDARD=${{ matrix.cpp_standards }}
+
+      - name: Build and test
+        working-directory: test
+        run: cmake --build build --config Debug --target test
+
+  # Windows-vs2022 check
+  test-on-windows-vs2022:
+    if: github.repository_owner == 'Kim-J-Smith'
+    runs-on: windows-2022
     strategy:
       matrix:
         cpp_standards: [14, 17, 20, 23]

--- a/benchmark/runtime/benchmark_std_op.cpp
+++ b/benchmark/runtime/benchmark_std_op.cpp
@@ -1,0 +1,75 @@
+#include "benchmark.hpp"
+
+#include <functional>
+
+static void std_op_wrapper_fn_std(picobench::state& s) {
+    auto less = std::less<int>{};
+    auto greater = std::greater<int>{};
+
+    auto f = [](std::function<bool(int, int)> f) { return f(0x111, 0x222); };
+
+    for (auto _ : s) {
+        volatile bool res1 = f(less);
+        volatile bool res2 = f(greater);
+        (void)res1; (void)res2;
+    }
+}
+
+static void std_op_wrapper_fn_ebd(picobench::state& s) {
+    auto less = std::less<int>{};
+    auto greater = std::greater<int>{};
+
+    auto f = [](ebd::fn<bool(int, int)> f) { return f(0x111, 0x222); };
+
+    for (auto _ : s) {
+        volatile bool res1 = f(less);
+        volatile bool res2 = f(greater);
+        (void)res1; (void)res2;
+    }
+}
+
+static void std_op_wrapper_fn_fu2(picobench::state& s) {
+    auto less = std::less<int>{};
+    auto greater = std::greater<int>{};
+
+    auto f = [](fu2::function<bool(int, int)> f) { return f(0x111, 0x222); };
+
+    for (auto _ : s) {
+        volatile bool res1 = f(less);
+        volatile bool res2 = f(greater);
+        (void)res1; (void)res2;
+    }
+}
+
+static void std_op_wrapper_fn_ref_ebd(picobench::state& s) {
+    auto less = std::less<int>{};
+    auto greater = std::greater<int>{};
+
+    auto f = [](ebd::fn_ref<bool(int, int)> f) { return f(0x111, 0x222); };
+
+    for (auto _ : s) {
+        volatile bool res1 = f(less);
+        volatile bool res2 = f(greater);
+        (void)res1; (void)res2;
+    }
+}
+
+static void std_op_wrapper_fn_view_fu2(picobench::state& s) {
+    auto less = std::less<int>{};
+    auto greater = std::greater<int>{};
+
+    auto f = [](fu2::function_view<bool(int, int)> f) { return f(0x111, 0x222); };
+
+    for (auto _ : s) {
+        volatile bool res1 = f(less);
+        volatile bool res2 = f(greater);
+        (void)res1; (void)res2;
+    }
+}
+
+BENCHMARK_UNIT(StdOperatorWrapper.FunctionWrapperAsParams);
+BENCHMARK_BASELINE(std_op_wrapper_fn_std);
+BENCHMARK_NOTBASE(std_op_wrapper_fn_fu2);
+BENCHMARK_NOTBASE(std_op_wrapper_fn_ebd);
+BENCHMARK_NOTBASE(std_op_wrapper_fn_view_fu2);
+BENCHMARK_NOTBASE(std_op_wrapper_fn_ref_ebd);

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,13 +1,17 @@
 ## Fixed
 
-- Fixed a constructor bug in `fn_ref`.
+- Fixed bug in deducing `noexcept` functor when using `make_fn`.
+
+- Fixed bug in converting from `fn_ref` to `fn` / `unique_fn` / `safe_fn`.
 
 ## Changed
 
-- `fn`, `unique_fn`, and `safe_fn` now use `is-callable-from` as the constraint, aligning with [func.wrap.move.ctor]/1. This tightens overload resolution and avoids incorrect constructor participation.
+- **Embedded-Function now supports MSVC 19.20+ (previously required MSVC 19.34+).**
 
-- Added negative compilation tests for the above constraints.
+- Provided better ambiguity error log for `make_fn`.
+
+- Enhanced the performance of `fn_ref` / `fn` / `unique_fn` / `safe_fn`.
 
 ## Notes
 
-- `std::constant_wrapper` support is experimental as of v2.1.3.
+- `std::constant_wrapper` support is experimental as of v2.1.4.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,16 +1,16 @@
 ## Fixed
 
-- Fixed bug in deducing `noexcept` functor when using `make_fn`.
+- Fixed a bug where `make_fn` failed to correctly deduce a `noexcept` functor.
 
-- Fixed bug in converting from `fn_ref` to `fn` / `unique_fn` / `safe_fn`.
+- Fixed a bug in converting from `fn_ref` to `fn` / `unique_fn` / `safe_fn`.
 
 ## Changed
 
-- **Embedded-Function now supports MSVC 19.20+ (previously required MSVC 19.34+).**
+- **Lowered MSVC requirement to 19.20+** (previously required 19.34+).
 
-- Provided better ambiguity error log for `make_fn`.
+- Improved ambiguity error diagnostics for `make_fn` when the callable is ambiguous.
 
-- Enhanced the performance of `fn_ref` / `fn` / `unique_fn` / `safe_fn`.
+- Enhanced the performance of `fn_ref`, `fn`, `unique_fn`, and `safe_fn`.
 
 - `make_fn` now supports automatic deduction of callable objects with a `static operator()`.
 

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -12,6 +12,8 @@
 
 - Enhanced the performance of `fn_ref` / `fn` / `unique_fn` / `safe_fn`.
 
+- `make_fn` now supports automatic deduction of callable objects with a `static operator()`.
+
 ## Notes
 
 - `std::constant_wrapper` support is experimental as of v2.1.4.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1215,8 +1215,19 @@ inline namespace fn_traits {
     Functor, void_t<decltype(&Functor::operator())>>
   : public std::true_type {};
 
+  // Check static callable functor.
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+  template <typename Fn, typename... Args>
+  struct is_static_callable_functor : bool_constant<
+    requires (Args&&... args) { Fn::operator()(std::forward<Args>(args)...); }
+  > {};
+#else
+  template <typename Fn, typename... Args>
+  struct is_static_callable_functor : std::false_type {};
+#endif
+
   // Implement the `get_unique_signature`.
-  template <typename T>
+  template <typename Fn, typename T, typename = void>
   struct get_unique_signature_impl {
     static_assert(always_false<T>::value,
       "T must be a function pointer or pointer to member function.");
@@ -1224,11 +1235,11 @@ inline namespace fn_traits {
 
   // The Config::isThrowing of ebd::fn and ebd::unique_fn is true.
   // So `get_unique_signature_impl` will ignore the `noexcept` specifier.
-#define EMBED_DETAIL_GET_UNIQUE_SIGNATURE_IMPL_DEFINE(C, V, REF, NOEXCEPT)    \
-  template <typename Class, typename Ret, typename... Args>                   \
-  struct get_unique_signature_impl<Ret(Class::*)(Args...) C V REF NOEXCEPT> { \
-    using type = Ret(Args...) C V REF;                                        \
-    using sig_with_noexcept = Ret(Args...) C V REF NOEXCEPT;                  \
+#define EMBED_DETAIL_GET_UNIQUE_SIGNATURE_IMPL_DEFINE(C, V, REF, NOEXCEPT)        \
+  template <typename Fn, typename Class, typename Ret, typename... Args>          \
+  struct get_unique_signature_impl<Fn, Ret(Class::*)(Args...) C V REF NOEXCEPT> { \
+    using type = Ret(Args...) C V REF;                                            \
+    using sig_with_noexcept = Ret(Args...) C V REF NOEXCEPT;                      \
   };
 
   EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_GET_UNIQUE_SIGNATURE_IMPL_DEFINE)
@@ -1237,7 +1248,7 @@ inline namespace fn_traits {
 
 #if ( __cpp_explicit_this_parameter >= 202110L ) || ( EMBED_CXX_VERSION >= 202302L )
 
-  // [dcl.fct]/6 function/packaged_task deduction guides and deducing this.
+  // [dcl.fct]/6 Deducing this.
   // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0847r7.html>.
 
   // Trait to add qualifiers (const, volatile, &, &&, noexcept) to a function
@@ -1256,13 +1267,52 @@ inline namespace fn_traits {
 
 # undef EMBED_DETAIL_ADD_QUALIFIER_WITH_THIS_DEFINE
 
-  template <typename This, typename Ret, typename... Args>
-  struct get_unique_signature_impl<Ret(*)(This, Args...)>
-  : public add_qualifier_with_this<This, Ret(Args...)> {};
+  // MSVC (as of 19.50.35717) cannot write `requires (...) {...}` in
+  // enable_if_t<> in the template argument list. To work around this,
+  // we use `is_explicit_this_call` instead.
+  template <typename Fn, typename This, typename Sig, typename... Args>
+  constexpr bool is_explicit_this_call_v = requires (Fn f, Args&&... args) {
+    static_cast<typename unwrap_signature<
+      typename add_qualifier_with_this<This, Sig>::type
+    >::template add_cvref_like<Fn>>(f)(std::forward<Args>(args)...);
+  };
 
-  template <typename This, typename Ret, typename... Args>
-  struct get_unique_signature_impl<Ret(*)(This, Args...) noexcept>
-  : public add_qualifier_with_this<This, Ret(Args...) noexcept> {};
+  // noexcept(false)
+  template <typename Fn, typename This, typename Ret, typename... Args>
+  struct get_unique_signature_impl<Fn, Ret(*)(This, Args...),
+    enable_if_t<is_explicit_this_call_v<Fn, This, Ret(Args...), Args...>>
+  > : public add_qualifier_with_this<This, Ret(Args...)> {};
+
+  // noexcept(true)
+  template <typename Fn, typename This, typename Ret, typename... Args>
+  struct get_unique_signature_impl<Fn, Ret(*)(This, Args...) noexcept,
+    enable_if_t<is_explicit_this_call_v<Fn, This, Ret(Args...) noexcept, Args...>>
+  > : public add_qualifier_with_this<This, Ret(Args...) noexcept> {};
+
+#endif
+
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+
+  // [func.wrap.func.con]/16.2 Static operator().
+  // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1169r4.html>.
+
+  // noexcept(false)
+  template <typename Fn, typename Ret, typename... Args>
+  struct get_unique_signature_impl<Fn, Ret(*)(Args...), enable_if_t<
+    is_static_callable_functor<Fn, Args...>::value
+  >> { // ^^^ Cannot simply write `requires (...) {...}` due to MSVC(as of 19.50.35717) bug.
+    using type = Ret(Args...) const;
+    using sig_with_noexcept = Ret(Args...) const;
+  };
+
+  // noexcept(true)
+  template <typename Fn, typename Ret, typename... Args>
+  struct get_unique_signature_impl<Fn, Ret(*)(Args...) noexcept, enable_if_t<
+    is_static_callable_functor<Fn, Args...>::value
+  >> { // ^^^ Cannot simply write `requires (...) {...}` due to MSVC(as of 19.50.35717) bug.
+    using type = Ret(Args...) const;
+    using sig_with_noexcept = Ret(Args...) const noexcept;
+  };
 
 #endif
 
@@ -1276,7 +1326,7 @@ inline namespace fn_traits {
 
   template <typename Functor>
   struct get_unique_signature<Functor, /* Unique = */ true> {
-    using impl_t = get_unique_signature_impl<decltype(&Functor::operator())>;
+    using impl_t = get_unique_signature_impl<Functor, decltype(&Functor::operator())>;
     using type = typename impl_t::type;
     using sig_with_noexcept = typename impl_t::sig_with_noexcept;
   };
@@ -1587,6 +1637,12 @@ inline namespace fn_traits {
   template <typename T> struct is_std_op_wrapper<std::bit_xor<T>> : std::true_type {};
   template <typename T> struct is_std_op_wrapper<std::bit_not<T>> : std::true_type {};
 
+  // Check whether the functor is stateless.
+  template <typename Fn, typename... Args>
+  struct is_stateless : bool_constant<
+    is_std_op_wrapper<Fn>::value || is_static_callable_functor<Fn, Args...>::value
+  > {};
+
   // Log error for make_fn.
   template <typename Unused>
   EMBED_INLINE EMBED_CXX14_CONSTEXPR void make_fn_log_error() noexcept {
@@ -1673,6 +1729,20 @@ namespace erasure_type {
 // In the namespace "invocation", we define a series of 
 // types for objects that implement the behaviour of invocation.
 namespace invocation {
+
+// Implement invocation for static call operator.
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+# define EMBED_DETAIL_STATIC_CALL_INVOKER_IMPL(C, V, REF, NOEXCEPT)             \
+  struct static_call {                                                          \
+    template <typename Functor>                                                 \
+    static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) NOEXCEPT { \
+      return Functor::operator()(std::forward<Args>(args)...);                  \
+    }                                                                           \
+  }; /* end static_call */
+#else
+# define EMBED_DETAIL_STATIC_CALL_INVOKER_IMPL(C, V, REF, NOEXCEPT) \
+  struct static_call { /* empty struct */ };
+#endif
 
 // Implement invocation for constant_wrapper.
 #if __cpp_lib_constant_wrapper >= 202603L
@@ -1766,6 +1836,7 @@ namespace invocation {
       }                                                                           \
     };                                                                            \
                                                                                   \
+    EMBED_DETAIL_STATIC_CALL_INVOKER_IMPL(C, V, REF, NOEXCEPT)                    \
     EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                             \
   };
 
@@ -1992,7 +2063,7 @@ namespace command {
     }
 
     template <typename Functor, typename DecFunctor = decay_t<Functor>>
-    enable_if_t<!is_std_op_wrapper<DecFunctor>::value>
+    enable_if_t<!is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t* target, Functor&& obj)
     noexcept(std::is_nothrow_constructible<DecFunctor, Functor&&>::value) {
       manager_impl_t::template create<DecFunctor>(target, std::forward<Functor>(obj));
@@ -2001,9 +2072,14 @@ namespace command {
     }
 
     template <typename Functor, typename DecFunctor = decay_t<Functor>>
-    EMBED_CXX20_CONSTEXPR enable_if_t<is_std_op_wrapper<DecFunctor>::value>
+    EMBED_CXX20_CONSTEXPR enable_if_t<is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t*, Functor&&) noexcept {
-      m_invoker = &invoker_impl_t::std_op_wrapper::template invoke<DecFunctor>;
+      using invoker_impl_target_t = conditional_t<
+        is_static_callable_functor<DecFunctor, Args...>::value,
+        typename invoker_impl_t::static_call,
+        typename invoker_impl_t::std_op_wrapper
+      >;
+      m_invoker = &invoker_impl_target_t::template invoke<DecFunctor>;
       m_manager = &manager_impl_t::empty::manage;
     }
 
@@ -2071,9 +2147,9 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }
 
-    // Enable if Functor is stored by pointer. (Enable if the functor is neither FP nor std-op-wrapper)
+    // Enable if Functor is stored by pointer. (Enable if the functor is neither FP nor stateless-fn)
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
-    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && !is_std_op_wrapper<DecFunctor>::value>
+    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && !is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t* target, Functor&& obj) noexcept {
       static_assert(!std::is_rvalue_reference<Functor&&>::value,
         "function in view mode cannot be initialized with rvalue reference.");
@@ -2081,11 +2157,16 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }
 
-    // Enable if Functor is not stored. (Enable if the functor is std-op-wrapper)
+    // Enable if Functor is not stored. (Enable if the functor is stateless-fn)
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
-    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && is_std_op_wrapper<DecFunctor>::value>
+    EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t*, Functor&&) noexcept {
-      m_invoker = &invoker_impl_t::std_op_wrapper::template invoke<DecFunctor>;
+      using invoker_impl_target_t = conditional_t<
+        is_static_callable_functor<DecFunctor, Args...>::value,
+        typename invoker_impl_t::static_call,
+        typename invoker_impl_t::std_op_wrapper
+      >;
+      m_invoker = &invoker_impl_target_t::template invoke<DecFunctor>;
     }
 
 #if __cpp_lib_constant_wrapper >= 202603L

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1269,7 +1269,7 @@ inline namespace fn_traits {
 
   // MSVC (as of 19.50.35717) cannot write `requires (...) {...}` in
   // enable_if_t<> in the template argument list. To work around this,
-  // we use `is_explicit_this_call` instead.
+  // we use `is_explicit_this_call_v` instead.
   template <typename Fn, typename This, typename Sig, typename... Args>
   constexpr bool is_explicit_this_call_v = requires (Fn f, Args&&... args) {
     static_cast<typename unwrap_signature<
@@ -2062,6 +2062,7 @@ namespace command {
       return m_invoker == &invoker_impl_t::empty::invoke;
     }
 
+    // Initialize owning function wrapper. (Enable if Functor is NOT stateless.)
     template <typename Functor, typename DecFunctor = decay_t<Functor>>
     enable_if_t<!is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t* target, Functor&& obj)
@@ -2071,6 +2072,7 @@ namespace command {
       m_manager = &manager_impl_t::inplace::template manage<DecFunctor, Config::isCopyable>;
     }
 
+    // Initialize owning function wrapper. (Enable if Functor is stateless.)
     template <typename Functor, typename DecFunctor = decay_t<Functor>>
     EMBED_CXX20_CONSTEXPR enable_if_t<is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t*, Functor&&) noexcept {
@@ -2137,7 +2139,7 @@ namespace command {
       // Do nothing here
     }
 
-    // Enable if Functor is stored origin. (Enable if the functor is function pointer(FP))
+    // Initialize non-owning function wrapper. (Enable if the functor is function pointer(FP))
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
     enable_if_t<IsStoredOrigin> /* Enable if the functor is function pointer(FP) */
     init(erasure_base_t* target, Functor&& obj) noexcept {
@@ -2147,7 +2149,7 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }
 
-    // Enable if Functor is stored by pointer. (Enable if the functor is neither FP nor stateless-fn)
+    // Initialize non-owning function wrapper. (Enable if the functor is neither FP nor stateless-fn)
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
     EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && !is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t* target, Functor&& obj) noexcept {
@@ -2157,7 +2159,7 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }
 
-    // Enable if Functor is not stored. (Enable if the functor is stateless-fn)
+    // Initialize non-owning function wrapper. (Enable if the functor is stateless-fn)
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
     EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && is_stateless<DecFunctor, Args...>::value>
     init(erasure_base_t*, Functor&&) noexcept {

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1685,10 +1685,10 @@ namespace invocation {
     template <typename Cw, typename Obj, bool CallPointer>                            \
     static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) NOEXCEPT {  \
       if constexpr (CallPointer) {                                                    \
-        C V auto* obj_ptr = static_cast<Obj*>(base.val.fill_ptr);                     \
+        auto* obj_ptr = static_cast<Obj C V*>(base.val.fill_ptr);                     \
         return invoke_r<Ret>(Cw::value, obj_ptr, std::forward<Args>(args)...);        \
       } else {                                                                        \
-        C V auto& obj = *static_cast<Obj*>(base.val.fill_ptr);                        \
+        auto& obj = *static_cast<Obj C V*>(base.val.fill_ptr);                        \
         return invoke_r<Ret>(Cw::value, obj, std::forward<Args>(args)...);            \
       }                                                                               \
     }                                                                                 \
@@ -1725,11 +1725,11 @@ namespace invocation {
     struct inplace {                                                              \
       template <typename Functor>                                                 \
       static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
-        auto* erased = static_cast<erasure_t*>(base.ptr);                         \
+        auto* erased = static_cast<erasure_t C V*>(base.ptr);                     \
         auto& fn = erased->template access<Functor>();                            \
         using Fn = conditional_t<is_rvalue_ref,                                   \
-          C V remove_reference_t<decltype(fn)>&&,                                 \
-          C V remove_reference_t<decltype(fn)>&>;                                 \
+          remove_reference_t<decltype(fn)>&&,                                     \
+          remove_reference_t<decltype(fn)>&>;                                     \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
       }                                                                           \
     };                                                                            \
@@ -1741,7 +1741,7 @@ namespace invocation {
       static enable_if_t<is_stored_origin<Functor, true>::value, Ret>             \
       invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
         auto* fn = reinterpret_cast<Functor>(base.val.fill_func_ptr);             \
-        using Fn = C V remove_reference_t<decltype(fn)>&;                         \
+        using Fn = remove_reference_t<decltype(fn)>&;                             \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
       }                                                                           \
                                                                                   \
@@ -1749,8 +1749,8 @@ namespace invocation {
       template <typename Functor>                                                 \
       static enable_if_t<!is_stored_origin<Functor, true>::value, Ret>            \
       invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
-        auto& fn = *(static_cast<Functor*>(base.val.fill_ptr));                   \
-        using Fn = C V remove_reference_t<decltype(fn)>&;                         \
+        auto& fn = *(static_cast<Functor C V*>(base.val.fill_ptr));               \
+        using Fn = remove_reference_t<decltype(fn)>&;                             \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
       }                                                                           \
     };                                                                            \

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1411,14 +1411,13 @@ inline namespace fn_traits {
     static constexpr std::size_t reg_size = sizeof(void*);
     static constexpr std::size_t obj_size = sizeof(T);
     static constexpr bool is_trivial_obj = is_call_trivial<T>::value;
+    static constexpr bool is_scalar_obj = std::is_scalar<T>::value;
 #if defined(__sparc_v8__) || defined(__sparcv8)
     // class and union object are not allowed to pass by reg in SPARC V8 (32bit).
-    static constexpr bool value = false;
-#elif defined(__riscv)
-    // There is an abundance of register resources in RISC-V (a0 ~ a7).
-    static constexpr bool value = obj_size <= 2 * reg_size && is_trivial_obj;
+    static constexpr bool value = is_scalar_obj;
 #else
-    static constexpr bool value = obj_size <= reg_size && is_trivial_obj;
+    static constexpr bool value =
+      is_scalar_obj || (obj_size <= 2 * reg_size && is_trivial_obj);
 #endif
   };
 
@@ -1427,8 +1426,7 @@ inline namespace fn_traits {
   // be passed by the register rather than the stack.
 #if !defined(EMBED_FN_CONFIG_DISABLE_SMART_FORWARD)
   template <typename T>
-  using smart_forward_t = conditional_t<
-    std::is_scalar<T>::value || is_reg_passable<T>::value, T, T&&>;
+  using smart_forward_t = conditional_t<is_reg_passable<T>::value, T, T&&>;
 #else
   template <typename T>
   using smart_forward_t = T&&;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1105,7 +1105,7 @@ inline namespace fn_traits {
   // Get aligned size. Rounds up to the nearest word.
   template <std::size_t Size>
   struct get_aligned_size {
-    static constexpr std::size_t min_aligned = sizeof(void*);
+    static constexpr std::size_t min_aligned = sizeof(void (*) ());
     static constexpr std::size_t aligned_size = ((Size - 1) / min_aligned + 1) * min_aligned;
     static constexpr std::size_t value = Size == 0 ? min_aligned : aligned_size;
   };

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1589,6 +1589,20 @@ inline namespace fn_traits {
   template <typename T> struct is_std_op_wrapper<std::bit_xor<T>> : std::true_type {};
   template <typename T> struct is_std_op_wrapper<std::bit_not<T>> : std::true_type {};
 
+  // Log error for make_fn.
+  template <typename Unused>
+  EMBED_INLINE EMBED_CXX14_CONSTEXPR void make_fn_log_error() noexcept {
+    static_assert(always_false<Unused>::value,
+      "[Embedded Function]: The make_fn() cannot automatically deduce an"
+      " appropriate function wrapper based on your input parameters."
+      " This might be because the parameters you passed are ambiguous,"
+      " such as overloaded free functions, member functions, objects"
+      " that overload multiple operator() functions, nullptr, or just"
+      " non-parameters. If so, you can use 'make_fn<Signature>(...)' to"
+      " specify the signature of target callable object to disambiguate."
+      " The 'Signature' is like 'void()', 'float(int,int)'."
+    );
+  };
 } // end namespace fn_traits
 
 // In the namespace "erasure_type", we define a series of 
@@ -3275,19 +3289,13 @@ FnWrapper make_fn(Functor&& functor) noexcept(NoThrow) {
 // When all other make_fn() fail to match the input parameters, 
 // this function will be called as the fall back to avoid the 
 // awful template error flood.
-template <int = 0, typename Unused = void>
-EMBED_INLINE void make_fn(...) noexcept {
-  static_assert(detail::always_false<Unused>::value,
-    "[Embedded Function]: The make_fn() cannot automatically deduce an"
-    " appropriate function wrapper based on your input parameters."
-    " This might be because the parameters you passed are ambiguous,"
-    " such as overloaded free functions, member functions, objects"
-    " that overload multiple operator() functions, nullptr, or just"
-    " non-parameters. If so, you can use 'make_fn<Signature>()' to"
-    " specify the signature of target callable object to disambiguate."
-    " The 'Signature' is like 'void()', 'float(int,int)'."
-  );
-}
+template <typename Unused = void,
+  EMBED_DETAIL_REQUIRES(!detail::unwrap_signature<Unused>::isSignature)>
+EMBED_INLINE EMBED_CXX14_CONSTEXPR void make_fn(...) noexcept
+{ detail::make_fn_log_error<Unused>(); }
+template <template <class, std::size_t> class Unused>
+EMBED_INLINE EMBED_CXX14_CONSTEXPR void make_fn(...) noexcept
+{ detail::make_fn_log_error<Unused<void(), 0>>(); }
 
 } // end namespace ebd
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1607,22 +1607,20 @@ inline namespace fn_traits {
 // types for objects that implement type erasure.
 namespace erasure_type {
 
-  template <std::size_t Size>
-  union ErasureCoreImpl {
-    static_assert(Size > 0, "erasure size must greater than 0");
-
+  // Reference storage, which used in view mode.
+  union ErasureRefStorage {
     void*       fill_ptr;
     const void* fill_const_ptr;
     void (*fill_func_ptr) ();
-    char        fill[Size];
   };
 
   template <std::size_t Size>
   union EMBED_DETAIL_ALIAS ErasureCore {
+    static_assert(Size > 0, "erasure size must greater than 0");
     // An array of `unsigned char` can be used to hold other objects.
     // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0137r1.html>.
-    unsigned char pod[sizeof(ErasureCoreImpl<Size>)];
-    ErasureCoreImpl<Size> ref_storage; // alignas(ref_storage)
+    unsigned char pod[Size];
+    ErasureRefStorage ref_storage; // alignas(ref_storage)
   };
 
   // Passing the `ErasureBase*` as a parameter can avoid the 
@@ -1664,6 +1662,12 @@ namespace erasure_type {
     { return *EMBED_DETAIL_LAUNDER(static_cast<const volatile T*>(access())); }
   };
 
+  // ABI for passing either pointer or value.
+  union ErasurePass {
+    ErasureBase*      ptr;
+    ErasureRefStorage val;
+  };
+
 } // end namespace erasure_type
 
 // In the namespace "invocation", we define a series of 
@@ -1675,17 +1679,16 @@ namespace invocation {
 # define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                            \
   struct view_cw {                                                                    \
     template <typename Cw>                                                            \
-    static Ret invoke(erasure_base_t*, smart_forward_t<Args>... args) NOEXCEPT {      \
+    static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) NOEXCEPT {       \
       return invoke_r<Ret>(Cw::value, std::forward<Args>(args)...);                   \
     }                                                                                 \
     template <typename Cw, typename Obj, bool CallPointer>                            \
-    static Ret invoke(erasure_base_t* base, smart_forward_t<Args>... args) NOEXCEPT { \
-      auto* erased = static_cast<erasure_t*>(base);                                   \
+    static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) NOEXCEPT {  \
       if constexpr (CallPointer) {                                                    \
-        C V auto* obj_ptr = erased->template access<Obj*>();                          \
+        C V auto* obj_ptr = static_cast<Obj*>(base.val.fill_ptr);                     \
         return invoke_r<Ret>(Cw::value, obj_ptr, std::forward<Args>(args)...);        \
       } else {                                                                        \
-        C V auto& obj = *erased->template access<Obj*>();                             \
+        C V auto& obj = *static_cast<Obj*>(base.val.fill_ptr);                        \
         return invoke_r<Ret>(Cw::value, obj, std::forward<Args>(args)...);            \
       }                                                                               \
     }                                                                                 \
@@ -1703,15 +1706,16 @@ namespace invocation {
   struct InvokerImpl<Size, Config, Ret(Args...) C V REF NOEXCEPT> {               \
   public:                                                                         \
     using erasure_base_t = erasure_type::ErasureBase C V;                         \
+    using erasure_pass_t = erasure_type::ErasurePass C;                           \
     using erasure_t = erasure_type::Erasure<Size> C V;                            \
     static constexpr bool is_rvalue_ref =                                         \
       std::is_rvalue_reference<int REF>::value;                                   \
-    using invoker_type = Ret (*) (                                                \
-      erasure_base_t* base, smart_forward_t<Args>... args);                       \
+    using invoker_type =                                                          \
+      Ret (*) (erasure_pass_t erased, smart_forward_t<Args>... args);             \
                                                                                   \
     /* Using when M_erasure is empty. */                                          \
     struct empty {                                                                \
-      static Ret invoke(erasure_base_t*, smart_forward_t<Args>...) {              \
+      static Ret invoke(erasure_pass_t, smart_forward_t<Args>...) {               \
         throw_or_terminate<Config::isThrowing>();                                 \
         /* Unreachable: throw_or_terminate() is [[noreturn]] */                   \
       }                                                                           \
@@ -1720,8 +1724,8 @@ namespace invocation {
     /* Using when Config::isView == false. */                                     \
     struct inplace {                                                              \
       template <typename Functor>                                                 \
-      static Ret invoke(erasure_base_t* base, smart_forward_t<Args>... args) {    \
-        auto* erased = static_cast<erasure_t*>(base);                             \
+      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
+        auto* erased = static_cast<erasure_t*>(base.ptr);                         \
         auto& fn = erased->template access<Functor>();                            \
         using Fn = conditional_t<is_rvalue_ref,                                   \
           C V remove_reference_t<decltype(fn)>&&,                                 \
@@ -1735,9 +1739,8 @@ namespace invocation {
       /* Using when Functor::is_stored_origin == true. */                         \
       template <typename Functor>                                                 \
       static enable_if_t<is_stored_origin<Functor, true>::value, Ret>             \
-      invoke(erasure_base_t* base, smart_forward_t<Args>... args) {               \
-        auto* erased = static_cast<erasure_t*>(base);                             \
-        auto& fn = erased->template access<Functor>();                            \
+      invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
+        auto* fn = reinterpret_cast<Functor>(base.val.fill_func_ptr);             \
         using Fn = C V remove_reference_t<decltype(fn)>&;                         \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
       }                                                                           \
@@ -1745,9 +1748,8 @@ namespace invocation {
       /* Using when Functor::is_stored_origin == false. */                        \
       template <typename Functor>                                                 \
       static enable_if_t<!is_stored_origin<Functor, true>::value, Ret>            \
-      invoke(erasure_base_t* base, smart_forward_t<Args>... args) {               \
-        auto* erased = static_cast<erasure_t*>(base);                             \
-        auto& fn = *(erased->template access<Functor*>());                        \
+      invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
+        auto& fn = *(static_cast<Functor*>(base.val.fill_ptr));                   \
         using Fn = C V remove_reference_t<decltype(fn)>&;                         \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
       }                                                                           \
@@ -1756,7 +1758,7 @@ namespace invocation {
     /* Used for standard operator wrapper (like std::less). */                    \
     struct std_op_wrapper {                                                       \
       template <typename StdOperator>                                             \
-      static Ret invoke(erasure_base_t*, smart_forward_t<Args>... args) {         \
+      static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) {          \
         static_assert(is_std_op_wrapper<StdOperator>::value,                      \
           EMBED_DETAIL_REPORT_IE("'StdOperator' should be std operator wrapper"));\
         C V auto fn = StdOperator{};                                              \
@@ -1951,12 +1953,13 @@ namespace command {
     using manager_impl_t = management::ManagerImpl<Size, Config, Signature>;
     using invoker_t       = typename invoker_impl_t::invoker_type;
     using erasure_base_t  = typename invoker_impl_t::erasure_base_t;
+    using erasure_pass_t  = typename invoker_impl_t::erasure_pass_t;
     using manager_t       = typename manager_impl_t::manager_type;
 
     manager_t m_manager;
     invoker_t m_invoker;
 
-    auto invoke(erasure_base_t* erased, Args&&... args) const
+    auto invoke(erasure_pass_t erased, Args&&... args) const
     noexcept(unwrap_signature<Signature>::isNoexcept)
     -> typename unwrap_signature<Signature>::ret {
       return m_invoker(erased, std::forward<Args>(args)...);
@@ -2026,12 +2029,13 @@ namespace command {
     using manager_impl_t = management::ManagerImpl<Size, Config, Signature>;
     using invoker_t       = typename invoker_impl_t::invoker_type;
     using erasure_base_t  = typename invoker_impl_t::erasure_base_t;
+    using erasure_pass_t  = typename invoker_impl_t::erasure_pass_t;
     using erasure_t       = typename invoker_impl_t::erasure_t;
 
     // No m_manager because IsView = true.
     invoker_t m_invoker;
 
-    auto invoke(erasure_base_t* erased, Args&&... args) const
+    auto invoke(erasure_pass_t erased, Args&&... args) const
     noexcept(unwrap_signature<Signature>::isNoexcept)
     -> typename unwrap_signature<Signature>::ret {
       return m_invoker(erased, std::forward<Args>(args)...);
@@ -2130,10 +2134,13 @@ namespace crtp_mixins {
     EMBED_DETAIL_ALL_DEFAULT(operator_call_impl)                            \
                                                                             \
     Ret operator()(Args... args) C V REF NOEXCEPT {                         \
-      auto* self_q = static_cast<Self C V*>(this);                          \
-      auto* erased = &(self_q->m_erasure);                                  \
+      using erasure_t = typename Self::erasure_t;                           \
       using command_t = const typename Self::command_t;                     \
+      using pass_t = typename command_t::erasure_pass_t;                    \
+      remove_cv_t<pass_t> erased;                                           \
+      auto* self_q = static_cast<Self C V*>(this);                          \
       auto& cmd = const_cast<command_t&>(self_q->m_command);                \
+      erased.ptr = const_cast<erasure_t*>(&(self_q->m_erasure));            \
       return cmd.invoke(erased, std::forward<Args>(args)...);               \
     }                                                                       \
   };                                                                        \
@@ -2148,10 +2155,13 @@ namespace crtp_mixins {
                                                                             \
     Ret operator()(Args... args) const V NOEXCEPT {                         \
       using erasure_t = typename Self::erasure_t;                           \
-      auto* self_q = static_cast<Self const V*>(this);                      \
-      auto* erased = const_cast<erasure_t*>(&(self_q->m_erasure));          \
       using command_t = const typename Self::command_t;                     \
+      using pass_t = typename command_t::erasure_pass_t;                    \
+      remove_cv_t<pass_t> erased;                                           \
+      auto* self_q = static_cast<Self const V*>(this);                      \
+      auto& erasure = const_cast<erasure_t&>(self_q->m_erasure);            \
       auto& cmd = const_cast<command_t&>(self_q->m_command);                \
+      erased.val = erasure.m_core.ref_storage;                              \
       return cmd.invoke(erased, std::forward<Args>(args)...);               \
     }                                                                       \
   };

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1122,7 +1122,7 @@ inline namespace fn_traits {
     static constexpr std::size_t ref_buf = sizeof(void (*) ());
     static constexpr std::size_t view_buf = ref_buf;
 #if defined(EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER)
-    // The CommandTable size plus the buffer size is about 8 * sizeof(void).
+    // The CommandTable size plus the buffer size is about 8 * sizeof(void*).
     // TODO: The size of this buffer zone needs further examination.
     static constexpr std::size_t value_c1 = 6 * sizeof(void*);
     static constexpr std::size_t value_c2 = sizeof(::std::function<void()>);
@@ -1987,7 +1987,7 @@ namespace command {
     }
 
     // Check the `m_invoker` is empty::invoke. (constexpr && noexcept)
-    constexpr bool is_empty() const noexcept {
+    EMBED_NODISCARD constexpr bool is_empty() const noexcept {
       return m_invoker == &invoker_impl_t::empty::invoke;
     }
 
@@ -2071,7 +2071,7 @@ namespace command {
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }
 
-    // Enable if Functor is stored by pointer. (Enable if the functor is neither FP or std-op-wrapper)
+    // Enable if Functor is stored by pointer. (Enable if the functor is neither FP nor std-op-wrapper)
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>
     EMBED_CXX20_CONSTEXPR enable_if_t<!IsStoredOrigin && !is_std_op_wrapper<DecFunctor>::value>
     init(erasure_base_t* target, Functor&& obj) noexcept {
@@ -2358,7 +2358,7 @@ namespace crtp_mixins {
     }
 
     // Return `true` if the object is empty.
-    EMBED_CXX14_CONSTEXPR bool is_empty() const noexcept {
+    EMBED_NODISCARD EMBED_CXX14_CONSTEXPR bool is_empty() const noexcept {
       auto const& self = static_cast<const Self&>(*this);
       return self.m_command.is_empty();
     }
@@ -2541,7 +2541,7 @@ namespace crtp_mixins {
     EMBED_NODISCARD EMBED_INLINE static constexpr std::size_t
     get_buffer_size() noexcept { return buffer_size; }
 
-    /// @brief Return `true` if the function is capyable.
+    /// @brief Return `true` if the function is copyable.
     EMBED_NODISCARD EMBED_INLINE static constexpr bool
     is_copyable() noexcept { return internal_is_copyable; }
 
@@ -3154,7 +3154,7 @@ EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Lambda, // [Auto] The lambda or functor that overloads operator() only once.
   // [Auto] The basic type of the functor.
   typename Class = detail::remove_cvref_t<Lambda>,
-  // [Auto] The buffersize of functor.
+  // [Auto] The buffer size of functor.
   std::size_t BufferSize = sizeof(Class),
   // [Auto] The signature of functor.
   typename Signature = detail::get_unique_signature_t<Class>,

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2863,7 +2863,8 @@ namespace crtp_mixins {
 
   // Make a function.
   template <typename Fn, bool NoThrow, typename... CArgs>
-  inline Fn make_function_impl(CArgs&&... args) noexcept(NoThrow) {
+  EMBED_CXX20_CONSTEXPR inline
+  Fn make_function_impl(CArgs&&... args) noexcept(NoThrow) {
     static_assert(is_ebd_fn<Fn>::value,
       "Fn must be the alias of `ebd::detail::function`.");
     return Fn{std::forward<CArgs>(args)...};
@@ -3264,7 +3265,8 @@ EMBED_DETAIL_REQUIRES_END(
   detail::is_ebd_fn<FnWrapper>::value
   && detail::unwrap_signature<Signature>::isSignature
 )
-EMBED_NODISCARD inline FnWrapper make_fn(Functor&& functor) noexcept(NoThrow) {
+EMBED_NODISCARD EMBED_CXX20_CONSTEXPR inline
+FnWrapper make_fn(Functor&& functor) noexcept(NoThrow) {
   return detail::make_function_impl<
     /* Fn = */ FnWrapper, /* NoThrow = */ NoThrow
   >(std::forward<Functor>(functor));

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -191,4 +191,15 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     ASSERT_EQ(f2(1, 2), 3);
   }
 #endif
+
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+  {
+    ebd::fn_ref<int(int, int)> f1 = ebd_test_static_call_operator{};
+    ASSERT_EQ(f1(0, 42), 42);
+
+    auto f2 = ebd::make_fn<ebd::fn_ref>(ebd_test_static_call_operator{});
+    static_assert(std::is_same_v<decltype(f2), ebd::fn_ref<int(int, int) const noexcept>>, "BUG");
+    ASSERT_EQ(f2(1, 42), 43);
+  }
+#endif
 }

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -183,8 +183,9 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
 
 # if (EMBED_CXX_VERSION >= 202002L && __cpp_constexpr >= 202002L)
   {
-    static constexpr auto l = [] {};
-    constexpr ebd::fn_ref<void()> f1 = l;
+    static constexpr auto l = [] { return 42; };
+    constexpr ebd::fn_ref<int()> f1 = l;
+    ASSERT_EQ(f1(), 42);
 
     constexpr ebd::fn_ref<int(int, int)> f2 = std::plus{};
     ASSERT_EQ(f2(1, 2), 3);

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -605,4 +605,44 @@ TEST(InitFunction, std_op_wrapper) {
 
     ASSERT_EQ(f1(1, 0), true);
     ASSERT_EQ(f1(1, 2), false);
+
+    auto f2 = ebd::make_fn<ebd::unique_fn>(std::greater<int>{});
+
+    ASSERT_EQ(f2(1, 0), true);
+    ASSERT_EQ(f2(1, 2), false);
+
+    auto f3 = ebd::make_fn<ebd::safe_fn>(std::greater<int>{});
+
+    ASSERT_EQ(f3(1, 0), true);
+    ASSERT_EQ(f3(1, 2), false);
+
+    auto f4 = ebd::make_fn<ebd::fn_ref>(std::greater<int>{});
+
+    ASSERT_EQ(f4(1, 0), true);
+    ASSERT_EQ(f4(1, 2), false);
 }
+
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+// InitFunction[35]
+TEST(InitFunction, static_operator_call) {
+    auto f1 = ebd::make_fn(ebd_test_static_call_operator{});
+
+    ASSERT_EQ(f1(1, 0), 1);
+    ASSERT_EQ(f1(1, 2), 3);
+
+    auto f2 = ebd::make_fn<ebd::unique_fn>(ebd_test_static_call_operator{});
+
+    ASSERT_EQ(f2(1, 0), 1);
+    ASSERT_EQ(f2(1, 2), 3);
+
+    auto f3 = ebd::make_fn<ebd::safe_fn>(ebd_test_static_call_operator{});
+
+    ASSERT_EQ(f3(1, 0), 1);
+    ASSERT_EQ(f3(1, 2), 3);
+
+    auto f4 = ebd::make_fn<ebd::fn_ref>(ebd_test_static_call_operator{});
+
+    ASSERT_EQ(f4(1, 0), 1);
+    ASSERT_EQ(f4(1, 2), 3);
+}
+#endif // #if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -215,3 +215,9 @@ public:
 
     int operator()(char) const { return OVL_CHAR; }
 };
+
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+struct ebd_test_static_call_operator {
+    static int operator()(int a, int b) noexcept { return a + b; }
+};
+#endif


### PR DESCRIPTION
In previous implementation, both `fn_ref` and `fn` will pass the address of `m_erasure` when calling `operator()`. However, it is actually an ODR use of `m_erasure`, which means that the compiler CANNOT optimize the object stack space of `fn_ref`.

In new implementation, `erasure_type::ErasurePass` is added as the new first parameter for the ABI of `m_invoker` to take place of `erasure_type::ErasureBase*`. This allows `operator()` to pass `m_erasure` by value in `fn_ref` to avoid ODR use of the object.

Here is the assembly difference.

- old(GCC 16.1 -std=c++26 -Os) <https://godbolt.org/z/EadE5813z> :
```asm
"check1(ebd::detail::function<8ul, ebd::detail::fn_traits::config_package<true, true, false, false>, bool (int, int)>)":
        sub     rsp, 24
        mov     edx, 3
        mov     QWORD PTR [rsp], rdi ; extra stack frame and indirection
        mov     rdi, rsp
        mov     QWORD PTR [rsp+8], rsi ; extra stack frame and indirection
        mov     esi, 2
        call    [QWORD PTR [rsp+8]]
        add     rsp, 24
        ret
"check2(std::function_ref<bool (int, int)>)":
        mov     rax, rdi
        mov     edx, 3
        mov     rdi, rsi
        mov     esi, 2
        jmp     rax
```

- new(GCC 16.1 -std=c++26 -Os) <https://godbolt.org/z/Yrzsvz3G9> :
```asm
"check1(ebd::detail::function<8ul, ebd::detail::fn_traits::config_package<true, true, false, false>, bool (int, int)>)":
        mov     rax, rsi
        mov     edx, 3
        mov     esi, 2
        jmp     rax
"check2(std::function_ref<bool (int, int)>)":
        mov     rax, rdi
        mov     edx, 3
        mov     rdi, rsi
        mov     esi, 2
        jmp     rax
```
