### PR TITLE
Move the `erasure_pass_t` to the end the invoker's parameter list.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2181,8 +2181,7 @@ namespace command {
     EMBED_CXX20_CONSTEXPR
     enable_if_t<!IsStoredOrigin && !is_stateless</*IsView*/true, DecFunctor, Args...>::value>
     init(erasure_base_t* target, Functor&& obj) noexcept {
-      static_assert(!std::is_rvalue_reference<Functor&&>::value,
-        "function in view mode cannot be initialized with rvalue reference.");
+      // User has to make sure the callable object must remain alive while the function_ref is in use.
       manager_impl_t::template ref_create<>(target, std::addressof(obj));
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1482,7 +1482,8 @@ inline namespace fn_traits {
   // be passed by the register rather than the stack.
 #if !defined(EMBED_FN_CONFIG_DISABLE_SMART_FORWARD)
   template <typename T>
-  using smart_forward_t = conditional_t<is_reg_passable<T>::value, T, T&&>;
+  using smart_forward_t = // vvv MSVC 19.10~19.14 workaround: avoid using `conditional_t`.
+    typename std::conditional<is_reg_passable<T>::value, T, T&&>::type;
 #else
   template <typename T>
   using smart_forward_t = T&&;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2163,14 +2163,8 @@ namespace command {
       );
     }
 
-    void move(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src)
-    const noexcept {
-      clone(dst, src); // Trivial move is same as copy.
-    }
-
-    void destroy(erasure_base_t* /*dst*/) const noexcept {
-      // Do nothing here
-    }
+    void move(erasure_base_t*, erasure_base_t*) = delete;
+    void destroy(erasure_base_t*) = delete;
 
     // Initialize non-owning function wrapper. (Enable if the functor is function pointer(FP))
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -259,11 +259,8 @@
 #if __cpp_lib_launder >= 201606L
 # define EMBED_DETAIL_LAUNDER(x) ( ::std::launder(x) )
 #elif EMBED_HAS_BUILTIN(__builtin_launder)
-namespace ebd { namespace detail {
-  template <typename T> EMBED_NODISCARD EMBED_INLINE constexpr
-  T* launder(T* ptr) noexcept { return __builtin_launder(ptr); }
-}} // end namespace ebd::detail
 # define EMBED_DETAIL_LAUNDER(x) ( ::ebd::detail::launder(x) )
+# define EMBED_DETAIL__NEED_LAUNDER
 #else
 # define EMBED_DETAIL_LAUNDER(x) ( x )
 #endif
@@ -778,6 +775,15 @@ inline namespace cxx_traits {
     return invoke_impl<invoke_t>(tag_t{}, std::forward<Callee>(fn),
       std::forward<Args>(args)...);
   }
+
+#ifdef EMBED_DETAIL__NEED_LAUNDER
+
+  // [ptr.launder]
+  template <typename T> EMBED_NODISCARD EMBED_INLINE constexpr
+  T* launder(T* ptr) noexcept { return __builtin_launder(ptr); }
+
+#undef EMBED_DETAIL__NEED_LAUNDER
+#endif
 
 } // end namespace cxx_traits
 
@@ -1722,7 +1728,7 @@ namespace erasure_type {
     // Access the pointer of erasureCore that qualified with nothing or const.
     void* access() noexcept { return &m_core.pod[0]; }
     const void* access() const noexcept { return &m_core.pod[0]; }
-    
+
     // Access the pointer of erasureCore that qualified with volatile or const volatile.
     volatile void* access() volatile noexcept { return &m_core.pod[0]; }
     const volatile void* access() const volatile noexcept { return &m_core.pod[0]; }

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1768,7 +1768,7 @@ namespace invocation {
 # define EMBED_DETAIL_STATIC_CALL_INVOKER_IMPL(C, V, REF, NOEXCEPT)             \
   struct static_call {                                                          \
     template <typename Functor>                                                 \
-    static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) NOEXCEPT { \
+    static Ret invoke(smart_forward_t<Args>... args, erasure_pass_t) NOEXCEPT { \
       return Functor::operator()(std::forward<Args>(args)...);                  \
     }                                                                           \
   }; /* end static_call */
@@ -1782,11 +1782,11 @@ namespace invocation {
 # define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                            \
   struct view_cw {                                                                    \
     template <typename Cw>                                                            \
-    static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) NOEXCEPT {       \
+    static Ret invoke(smart_forward_t<Args>... args, erasure_pass_t) NOEXCEPT {       \
       return invoke_r<Ret>(Cw::value, std::forward<Args>(args)...);                   \
     }                                                                                 \
     template <typename Cw, typename Obj, bool CallPointer>                            \
-    static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) NOEXCEPT {  \
+    static Ret invoke(smart_forward_t<Args>... args, erasure_pass_t base) NOEXCEPT {  \
       if constexpr (CallPointer) {                                                    \
         auto* obj_ptr = static_cast<Obj C V*>(base.val.fill_ptr);                     \
         return invoke_r<Ret>(Cw::value, obj_ptr, std::forward<Args>(args)...);        \
@@ -1814,11 +1814,11 @@ namespace invocation {
     static constexpr bool is_rvalue_ref =                                         \
       std::is_rvalue_reference<int REF>::value;                                   \
     using invoker_type =                                                          \
-      Ret (*) (erasure_pass_t erased, smart_forward_t<Args>... args);             \
+      Ret (*) (smart_forward_t<Args>... args, erasure_pass_t erased);             \
                                                                                   \
     /* Using when M_erasure is empty. */                                          \
     struct empty {                                                                \
-      static Ret invoke(erasure_pass_t, smart_forward_t<Args>...) {               \
+      static Ret invoke(smart_forward_t<Args>..., erasure_pass_t) {               \
         throw_or_terminate<Config::isThrowing>();                                 \
         /* Unreachable: throw_or_terminate() is [[noreturn]] */                   \
       }                                                                           \
@@ -1827,7 +1827,7 @@ namespace invocation {
     /* Using when Config::isView == false. */                                     \
     struct inplace {                                                              \
       template <typename Functor>                                                 \
-      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
+      static Ret invoke(smart_forward_t<Args>... args, erasure_pass_t base) {     \
         auto* erased = static_cast<erasure_t C V*>(base.ptr);                     \
         auto& fn = erased->template access<Functor>();                            \
         using Fn = conditional_t<is_rvalue_ref,                                   \
@@ -1842,7 +1842,7 @@ namespace invocation {
       /* Using when Functor::is_stored_origin == true. */                         \
       template <typename Functor>                                                 \
       static enable_if_t<is_stored_origin<Functor, true>::value, Ret>             \
-      invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
+      invoke(smart_forward_t<Args>... args, erasure_pass_t base) {                \
         auto* fn = reinterpret_cast<Functor>(base.val.fill_func_ptr);             \
         using Fn = remove_reference_t<decltype(fn)>&;                             \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
@@ -1851,7 +1851,7 @@ namespace invocation {
       /* Using when Functor::is_stored_origin == false. */                        \
       template <typename Functor>                                                 \
       static enable_if_t<!is_stored_origin<Functor, true>::value, Ret>            \
-      invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
+      invoke(smart_forward_t<Args>... args, erasure_pass_t base) {                \
         auto& fn = *(static_cast<Functor C V*>(base.val.fill_ptr));               \
         using Fn = remove_reference_t<decltype(fn)>&;                             \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
@@ -1861,7 +1861,7 @@ namespace invocation {
     /* Used for stateless(empty) Functor (like std::less). */                     \
     struct empty_normal {                                                         \
       template <typename EmptyFn>                                                 \
-      static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) {          \
+      static Ret invoke(smart_forward_t<Args>... args, erasure_pass_t) {          \
         C V EmptyFn fn{};  /* Empty and trivial class. It is stateless */         \
         using Fn = conditional_t<is_rvalue_ref,                                   \
           remove_reference_t<decltype(fn)>&&,                                     \
@@ -1895,7 +1895,6 @@ namespace management {
   struct ManagerImpl {
   private:
     using invoke_impl_t = invocation::InvokerImpl<Size, Config, Signature>;
-    using invoke_t        = typename invoke_impl_t::invoker_type;
     using erasure_base_t  = typename invoke_impl_t::erasure_base_t;
     using erasure_t       = typename invoke_impl_t::erasure_t;
   public:
@@ -2067,7 +2066,7 @@ namespace command {
     auto invoke(erasure_pass_t erased, Args&&... args) const
     noexcept(unwrap_signature<Signature>::isNoexcept)
     -> typename unwrap_signature<Signature>::ret {
-      return m_invoker(erased, std::forward<Args>(args)...);
+      return m_invoker(std::forward<Args>(args)..., erased);
     }
 
     void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src) const
@@ -2150,7 +2149,7 @@ namespace command {
     auto invoke(erasure_pass_t erased, Args&&... args) const
     noexcept(unwrap_signature<Signature>::isNoexcept)
     -> typename unwrap_signature<Signature>::ret {
-      return m_invoker(erased, std::forward<Args>(args)...);
+      return m_invoker(std::forward<Args>(args)..., erased);
     }
 
     void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src)

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -225,4 +225,9 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     auto f1 = ebd::make_fn<ebd::fn_ref>(obj);
     ASSERT_EQ(f1(), obj());
   }
+
+  {
+    int result = 42;
+    ASSERT_EQ(ebd_test_safe_tmp_fn([result]{ return result; }), result);
+  }
 }

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -221,3 +221,5 @@ struct ebd_test_static_call_operator {
     static int operator()(int a, int b) noexcept { return a + b; }
 };
 #endif
+
+inline int ebd_test_safe_tmp_fn(ebd::fn_ref<int()> f) { return f(); }


### PR DESCRIPTION
Same reason: https://github.com/llvm/llvm-project/pull/186692#discussion_r3267977393