### PR TITLE
Relax `fn_ref` construction to allow safe temporary callables.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1482,7 +1482,8 @@ inline namespace fn_traits {
   // be passed by the register rather than the stack.
 #if !defined(EMBED_FN_CONFIG_DISABLE_SMART_FORWARD)
   template <typename T>
-  using smart_forward_t = conditional_t<is_reg_passable<T>::value, T, T&&>;
+  using smart_forward_t = // vvv MSVC 19.10~19.14 workaround: avoid using `conditional_t`.
+    typename std::conditional<is_reg_passable<T>::value, T, T&&>::type;
 #else
   template <typename T>
   using smart_forward_t = T&&;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2163,14 +2163,8 @@ namespace command {
       );
     }
 
-    void move(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src)
-    const noexcept {
-      clone(dst, src); // Trivial move is same as copy.
-    }
-
-    void destroy(erasure_base_t* /*dst*/) const noexcept {
-      // Do nothing here
-    }
+    void move(erasure_base_t*, erasure_base_t*) = delete;
+    void destroy(erasure_base_t*) = delete;
 
     // Initialize non-owning function wrapper. (Enable if the functor is function pointer(FP))
     template <bool IsStoredOrigin, typename Functor, typename DecFunctor = decay_t<Functor>>

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2182,8 +2182,7 @@ namespace command {
     EMBED_CXX20_CONSTEXPR
     enable_if_t<!IsStoredOrigin && !is_stateless</*IsView*/true, DecFunctor, Args...>::value>
     init(erasure_base_t* target, Functor&& obj) noexcept {
-      static_assert(!std::is_rvalue_reference<Functor&&>::value,
-        "function in view mode cannot be initialized with rvalue reference.");
+      // User has to make sure the callable object must remain alive while the function_ref is in use.
       manager_impl_t::template ref_create<>(target, std::addressof(obj));
       m_invoker = &invoker_impl_t::view::template invoke<DecFunctor>;
     }

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1273,9 +1273,7 @@ inline namespace fn_traits {
 
 # undef EMBED_DETAIL_ADD_QUALIFIER_WITH_THIS_DEFINE
 
-  // MSVC (as of 19.50.35717) cannot write `requires (...) {...}` in
-  // enable_if_t<> in the template argument list. To work around this,
-  // we use `is_explicit_this_call_v` instead.
+  // `true` if the operator() of Fn is deducing this.
   template <typename Fn, typename This, typename Sig, typename... Args>
   constexpr bool is_explicit_this_call_v = requires (Fn f, Args&&... args) {
     static_cast<typename unwrap_signature<
@@ -1285,15 +1283,15 @@ inline namespace fn_traits {
 
   // noexcept(false)
   template <typename Fn, typename This, typename Ret, typename... Args>
-  struct get_unique_signature_impl<Fn, Ret(*)(This, Args...),
-    enable_if_t<is_explicit_this_call_v<Fn, This, Ret(Args...), Args...>>
-  > : public add_qualifier_with_this<This, Ret(Args...)> {};
+    requires is_explicit_this_call_v<Fn, This, Ret(Args...), Args...>
+  struct get_unique_signature_impl<Fn, Ret(*)(This, Args...)>
+  : public add_qualifier_with_this<This, Ret(Args...)> {};
 
   // noexcept(true)
   template <typename Fn, typename This, typename Ret, typename... Args>
-  struct get_unique_signature_impl<Fn, Ret(*)(This, Args...) noexcept,
-    enable_if_t<is_explicit_this_call_v<Fn, This, Ret(Args...) noexcept, Args...>>
-  > : public add_qualifier_with_this<This, Ret(Args...) noexcept> {};
+    requires is_explicit_this_call_v<Fn, This, Ret(Args...) noexcept, Args...>
+  struct get_unique_signature_impl<Fn, Ret(*)(This, Args...) noexcept>
+  : public add_qualifier_with_this<This, Ret(Args...) noexcept> {};
 
 #endif
 
@@ -1304,18 +1302,16 @@ inline namespace fn_traits {
 
   // noexcept(false)
   template <typename Fn, typename Ret, typename... Args>
-  struct get_unique_signature_impl<Fn, Ret(*)(Args...), enable_if_t<
-    is_static_callable_functor<Fn, Args...>::value
-  >> { // ^^^ Cannot simply write `requires (...) {...}` due to MSVC(as of 19.50.35717) bug.
+    requires is_static_callable_functor<Fn, Args...>::value
+  struct get_unique_signature_impl<Fn, Ret(*)(Args...)> {
     using type = Ret(Args...) const;
     using sig_with_noexcept = Ret(Args...) const;
   };
 
   // noexcept(true)
   template <typename Fn, typename Ret, typename... Args>
-  struct get_unique_signature_impl<Fn, Ret(*)(Args...) noexcept, enable_if_t<
-    is_static_callable_functor<Fn, Args...>::value
-  >> { // ^^^ Cannot simply write `requires (...) {...}` due to MSVC(as of 19.50.35717) bug.
+    requires is_static_callable_functor<Fn, Args...>::value
+  struct get_unique_signature_impl<Fn, Ret(*)(Args...) noexcept> {
     using type = Ret(Args...) const;
     using sig_with_noexcept = Ret(Args...) const noexcept;
   };
@@ -1895,7 +1891,6 @@ namespace management {
   struct ManagerImpl {
   private:
     using invoke_impl_t = invocation::InvokerImpl<Size, Config, Signature>;
-    using invoke_t        = typename invoke_impl_t::invoker_type;
     using erasure_base_t  = typename invoke_impl_t::erasure_base_t;
     using erasure_t       = typename invoke_impl_t::erasure_t;
   public:

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -259,11 +259,8 @@
 #if __cpp_lib_launder >= 201606L
 # define EMBED_DETAIL_LAUNDER(x) ( ::std::launder(x) )
 #elif EMBED_HAS_BUILTIN(__builtin_launder)
-namespace ebd { namespace detail {
-  template <typename T> EMBED_NODISCARD EMBED_INLINE constexpr
-  T* launder(T* ptr) noexcept { return __builtin_launder(ptr); }
-}} // end namespace ebd::detail
 # define EMBED_DETAIL_LAUNDER(x) ( ::ebd::detail::launder(x) )
+# define EMBED_DETAIL__NEED_LAUNDER
 #else
 # define EMBED_DETAIL_LAUNDER(x) ( x )
 #endif
@@ -778,6 +775,15 @@ inline namespace cxx_traits {
     return invoke_impl<invoke_t>(tag_t{}, std::forward<Callee>(fn),
       std::forward<Args>(args)...);
   }
+
+#ifdef EMBED_DETAIL__NEED_LAUNDER
+
+  // [ptr.launder]
+  template <typename T> EMBED_NODISCARD EMBED_INLINE constexpr
+  T* launder(T* ptr) noexcept { return __builtin_launder(ptr); }
+
+#undef EMBED_DETAIL__NEED_LAUNDER
+#endif
 
 } // end namespace cxx_traits
 
@@ -1722,7 +1728,7 @@ namespace erasure_type {
     // Access the pointer of erasureCore that qualified with nothing or const.
     void* access() noexcept { return &m_core.pod[0]; }
     const void* access() const noexcept { return &m_core.pod[0]; }
-    
+
     // Access the pointer of erasureCore that qualified with volatile or const volatile.
     volatile void* access() volatile noexcept { return &m_core.pod[0]; }
     const volatile void* access() const volatile noexcept { return &m_core.pod[0]; }

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -225,4 +225,9 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     auto f1 = ebd::make_fn<ebd::fn_ref>(obj);
     ASSERT_EQ(f1(), obj());
   }
+
+  {
+    int result = 42;
+    ASSERT_EQ(ebd_test_safe_tmp_fn([result]{ return result; }), result);
+  }
 }

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -221,3 +221,5 @@ struct ebd_test_static_call_operator {
     static int operator()(int a, int b) noexcept { return a + b; }
 };
 #endif
+
+inline int ebd_test_safe_tmp_fn(ebd::fn_ref<int()> f) { return f(); }


### PR DESCRIPTION
https://github.com/Kim-J-Smith/Embedded-Function/discussions/54#discussion-10081124