### PR TITLE
Add specialization for `is_reg_passible` for Windows x64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,28 @@ auto main() -> int {
 
 ```cpp
 /// The definition of method of a function wrapper is as follows:
-ebd::fn<int (int, float, char) const, 3*sizeof(void*)> fn_;
-//       ^     ^     ^     ^     ^        ^
-//       |     |     |     |     |        |
-// Return type |     |     |     |        |
-// Parameters ~|~~~~~|~~~~~|     |        |
-// Qualifier ~~~~~~~~~~~~~~~~~~~~|        |
-// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~|
+        FnWrapper <void(int, float, char) const, 3*sizeof(void*)> fn_ = +[](int, float, char){};
+//          ^       ^   ^~~~~~~~~~~~~      ^     ^~~~~~                 ^~~~~~~~~~~~~~~~~~~~~~~
+//          |       |   |                  |     |                      |
+// Function wrapper |   |                  |     |                      |
+// Return type ~~~~~|   |                  |     |                      |
+// Parameters ~~~~~~~~~~|                  |     |                      |
+// Qualifier ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|     |                      |
+// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|                      |
+// Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
 ```
 
-> The *`Qualifier`* is used to restrict the callable objects wrapped within `ebd::fn`, rather than `ebd::fn` itself. In other words, the `operator()` of the `ebd::fn` object will be qualified with the `Qualifier` modifier.
+- *`Function wrapper`*: One of `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn` and `ebd::fn_ref`.
 
-> The *`Buffer size`* is the size used to store the callable object, which can be omitted.
-> If omitted, this parameter will be set to *DefaultSize* by default, which is sufficient to store most common callable objects, including function pointers, simple non-capturing and capturing lambdas, and lightweight custom classes.
-> *If the buffer size is insufficient, a `static_assert` will be triggered.*
+- *`Return type`*: A type that can be implicitly converted from the direct return type of *`Callable object`*.
+
+- *`Parameters`*: Types that can implicitly converts to the parameter types of *`Callable object`*.
+
+- *`Qualifier`*: Applies to the wrapper's `operator()` (e.g., `const`, `noexcept`, `&`, `&&`), restricting which callable objects can be stored.
+
+- *`Buffer size`*: Size (in bytes) of the internal storage. Defaults to `DefaultSize`. Triggers `static_assert` if insufficient - no heap allocation.
+
+- *`Callable object`*: Any entity callable with the target signature (function pointer, lambda, function object, `std::reference_wrapper`). Copied or moved into the buffer depending on wrapper type.
 
 ## 🧠 Design goals driving the design
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ auto main() -> int {
 
 ```cpp
 /// The definition of method of a function wrapper is as follows:
-        FnWrapper <void(int, float, char) const, 3*sizeof(void*)> fn_ = +[](int, float, char){};
-//          ^       ^   ^~~~~~~~~~~~~      ^     ^~~~~~                 ^~~~~~~~~~~~~~~~~~~~~~~
-//          |       |   |                  |     |                      |
-// Function wrapper |   |                  |     |                      |
-// Return type ~~~~~|   |                  |     |                      |
-// Parameters ~~~~~~~~~~|                  |     |                      |
-// Qualifier ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|     |                      |
-// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|                      |
-// Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
+        FnWrapper <void(int, char) const, 3*sizeof(void*)> fn_ = +[](int, char) {};
+//          ^       ^   ^~~~~~~      ^     ^~~~~~                 ^~~~~~~~~~~~~
+//          |       |   |            |     |                      |
+// Function wrapper |   |            |     |                      |
+// Return type ~~~~~|   |            |     |                      |
+// Parameters ~~~~~~~~~~|            |     |                      |
+// Qualifier ~~~~~~~~~~~~~~~~~~~~~~~~|     |                      |
+// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~~|                      |
+// Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
 ```
 
 - *`Function wrapper`*: One of `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn` and `ebd::fn_ref`.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1464,17 +1464,24 @@ inline namespace fn_traits {
   // optimization for each platform, we create `is_reg_passable`.
   template <typename T>
   struct is_reg_passable {
-    static constexpr std::size_t reg_size = sizeof(void*);
     static constexpr std::size_t obj_size = sizeof(T);
     static constexpr bool is_trivial_obj = is_trivial_for_call<T>::value;
     static constexpr bool is_scalar_obj = std::is_scalar<T>::value;
+
 #if defined(__sparc_v8__) || defined(__sparcv8)
-    // class and union object are not allowed to pass by reg in SPARC V8 (32bit).
-    static constexpr bool value = is_scalar_obj;
+    // Class and union object are not allowed to pass by reg in SPARC V8 (32bit).
+    static constexpr bool aggregate_passable = false;
+#elif defined(_WIN64) && defined(_M_X64)
+    static_assert(sizeof(void*) == 8, EMBED_DETAIL_REPORT_IE("sizeof(void*) != 8 in Windows x64."));
+    // See <https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-180#parameter-passing>.
+    static constexpr bool aggregate_passable = is_trivial_obj
+      && (obj_size == 1 || obj_size == 2 || obj_size == 4 || obj_size == 8);
 #else
-    static constexpr bool value =
-      is_scalar_obj || (obj_size <= 2 * reg_size && is_trivial_obj);
+    static constexpr bool aggregate_passable = is_trivial_obj
+      && obj_size <= 2 * sizeof(void*);
 #endif
+
+    static constexpr bool value = is_scalar_obj || aggregate_passable;
   };
 
   // Used to choose either perfect forwarding or pass-by-value.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -801,10 +801,10 @@ inline namespace fn_traits {
   // See <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial-parameters>
   // and <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial>.
   template <typename T>
-  struct is_call_trivial : public bool_constant<
+  struct is_trivial_for_call : public bool_constant<
     std::is_trivially_destructible<T>::value
-      && std::is_trivially_copy_constructible<T>::value
-      && std::is_trivially_move_constructible<T>::value
+    && std::is_trivially_copy_constructible<T>::value
+    && std::is_trivially_move_constructible<T>::value
   > {};
 
   // std::is_trivial is deprecated in C++26. But we need it.
@@ -1466,7 +1466,7 @@ inline namespace fn_traits {
   struct is_reg_passable {
     static constexpr std::size_t reg_size = sizeof(void*);
     static constexpr std::size_t obj_size = sizeof(T);
-    static constexpr bool is_trivial_obj = is_call_trivial<T>::value;
+    static constexpr bool is_trivial_obj = is_trivial_for_call<T>::value;
     static constexpr bool is_scalar_obj = std::is_scalar<T>::value;
 #if defined(__sparc_v8__) || defined(__sparcv8)
     // class and union object are not allowed to pass by reg in SPARC V8 (32bit).


### PR DESCRIPTION
MSVC ABI has stricter constrains for the size of struct and union than Itanium ABI.

See <https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-180#parameter-passing>.