### PR TITLE
Version 2.1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.1.5 LANGUAGES CXX)
+project(embedded_function VERSION 2.1.6 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
 
 ## 📌 Overview
 
-*Embedded Function* is a **lightweight** and **no-heap-allocation** function wrapper collection implemented based on the C++11 standard, tailored specifically for embedded systems.
+*Embedded Function* is a **lightweight** and **no-heap-allocation** function wrapper collection implemented based on the C++11 standard, optimized([see below](#-performance-optimization)) for resource-constrained or high-performance environments.
 
-In only **one** [header file](./include/embed/embed_function.hpp), **4** function wrappers are provided as follows:
+The library is [freestanding](https://en.cppreference.com/w/cpp/freestanding), making it feasible for embedded development or kernel design of an operating system.
+
+In a [single header file](./include/embed/embed_function.hpp), **four** function wrappers are provided as follows:
 
 ```cpp
 namespace ebd {
@@ -87,7 +89,9 @@ ebd::fn<int (int, float, char) const, 3*sizeof(void*)> fn_;
 
 > The *`Qualifier`* is used to restrict the callable objects wrapped within `ebd::fn`, rather than `ebd::fn` itself. In other words, the `operator()` of the `ebd::fn` object will be qualified with the `Qualifier` modifier.
 
-> The *`Buffer size`* is the size used to store the callable object, which can be omitted. If omitted, this parameter will be set to `detail::default_buffer_size::value` by default, which is sufficient to store most common callable objects, including function pointers, simple non-capturing and capturing lambdas, and lightweight custom classes.
+> The *`Buffer size`* is the size used to store the callable object, which can be omitted.
+> If omitted, this parameter will be set to *DefaultSize* by default, which is sufficient to store most common callable objects, including function pointers, simple non-capturing and capturing lambdas, and lightweight custom classes.
+> *If the buffer size is insufficient, a `static_assert` will be triggered.*
 
 ## 🧠 Design goals driving the design
 
@@ -138,25 +142,19 @@ ebd::fn<int (int, float, char) const, 3*sizeof(void*)> fn_;
 
 4. **Triviality**: `fn_ref` is trivially copyable (same as `std::function_ref`).
 
-## 🚀 Performance optimization
+### Convertibility
 
-### Branch elimination
+- `Yes-D`: Convertible and direct wrapping (`To.BufferSize` >= `From.BufferSize`);
+- `Yes-I`: Convertible and indirect wrapping (`To.BufferSize` >= `sizeof(From)`);
+- `Yes-R`: Convertible and non-owning wrapping.
+- `No`: Inconvertible
 
-`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` completely eliminate runtime checks for empty function states during invocation, significantly boosting performance of frequent function calls.
-
-### Smart forwarding
-
-`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` enable scalar arguments and small-sized trivial arguments to be passed via registers instead of having to be passed via the stack as in `std::function`. This significantly reduces the memory access overhead during parameter passing.
-
-### Zero-stack overhead
-
-`ebd::fn_ref` occupies no stack space when used as a function parameter; it is passed entirely in registers. This allows the compiler to directly tail-call the wrapped target, removing the cost of an extra stack frame. See [x86_64-asm](./docs/perf/x86_64_gcc_fn_ref_zero_stack.md).
-
-### Stateless elimination
-
-`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` do not store the functor or its pointer if the functor is stateless (e.g., empty classes with trivial operations). This reduces memory access operations and improves cache efficiency.
-
-> Click [x64-asm](./docs/perf/x86_64_msvc_asm_analysis.md), [rv32-asm](./docs/perf/riscv_gcc_asm_analysis.md) and [arm32-asm](./docs/perf/arm_gcc_asm_analysis.md) to see more details.
+| From \ To | `ebd::fn` | `ebd::unique_fn` | `ebd::safe_fn` | `ebd::fn_ref` |
+| :---: | :---: | :---: | :---: | :---: |
+| `ebd::fn` | Yes-D | Yes-D | No | Yes-R |
+| `ebd::unique_fn` | No | Yes-D | No | Yes-R |
+| `ebd::safe_fn` | Yes-I | Yes-I | Yes-D | Yes-R |
+| `ebd::fn_ref` | Yes-I | Yes-I | Yes-I | Yes-D |
 
 ## 🧩 Automatic deduction
 
@@ -291,73 +289,53 @@ Every compiler with modern C++11 support should work.
 
 Go to the `<root>/test/` directory, and follow the instructions in [`HOW-TO-TEST.md`](./test/HOW-TO-TEST.md) to run the tests.
 
+## 🚀 Performance optimization
+
+### Branch elimination
+
+`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` completely eliminate runtime checks for empty function states during invocation, significantly boosting performance of frequent function calls.
+
+### Smart forwarding
+
+`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` enable scalar arguments and small-sized trivial arguments to be passed via registers instead of having to be passed via the stack as in `std::function`. This significantly reduces the memory access overhead during parameter passing.
+
+### Zero-stack overhead
+
+`ebd::fn_ref` occupies no stack space when used as a function parameter; it is passed entirely in registers. This allows the compiler to directly tail-call the wrapped target, removing the cost of an extra stack frame. See [x86_64-asm](./docs/perf/x86_64_gcc_fn_ref_zero_stack.md).
+
+### Stateless elimination
+
+`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` do not store the functor or its pointer if the functor is stateless (e.g., empty classes with trivial operations). This reduces memory access operations and improves cache efficiency.
+
+> Click [x64-asm](./docs/perf/x86_64_msvc_asm_analysis.md), [rv32-asm](./docs/perf/riscv_gcc_asm_analysis.md) and [arm32-asm](./docs/perf/arm_gcc_asm_analysis.md) to see more details.
+
 ## ⏱️ Benchmark
 
-Go to the `<root>/benchmark/` directory, and follow the instructions in [`HOW-TO-BENCHMARK.md`](./benchmark/HOW-TO-BENCHMARK.md) to run the tests.
+**Embedded-Function has 5%~30% performance enhancement over `std::function`.**
 
-> *( Compiler: `MSVC` Standard: `C++14` Config: `Release` Tool: [picobench](https://github.com/iboB/picobench) )* 
+> *( `Compiler`: GCC-14 `Standard`: C++14 `Config`: -Os `Tool`: [picobench](https://github.com/iboB/picobench) `fu2`: [function2](https://github.com/Naios/function2) )*
 
-> **std**: `std::function`, **ebd**: `ebd::fn`, **fu2**: [`fu2::function`](https://github.com/Naios/function2)
-
-```md
-## FreeFunction.ScalarParameters:
+### StdOperatorWrapper.FunctionWrapperAsParams:
 
  Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
 --------------------------|--------:|----------:|--------:|-------:|----------:
- free_scalar_std *        |   10000 |     0.030 |       3 |      - |332225913.6
- free_scalar_ebd          |   10000 |     0.028 |       2 |  0.930 |357142857.1
- free_scalar_fu2          |   10000 |     0.052 |       5 |  1.731 |191938579.7
- free_scalar_std *        |  100000 |     0.301 |       3 |      - |332667997.3
- free_scalar_ebd          |  100000 |     0.265 |       2 |  0.881 |377643504.5
- free_scalar_fu2          |  100000 |     0.523 |       5 |  1.742 |191021967.5
- free_scalar_std *        | 1000000 |     3.006 |       3 |      - |332712270.4
- free_scalar_ebd          | 1000000 |     2.708 |       2 |  0.901 |369317132.6
- free_scalar_fu2          | 1000000 |     5.264 |       5 |  1.751 |189958778.9
+ `std::function` *        |   10000 |     0.090 |       8 |      - |111671952.5
+ `fu2::function`          |   10000 |     0.176 |      17 |  1.968 | 56744349.7
+ **`ebd::fn`**            |   10000 |     0.068 |       6 |  0.758 |147412179.2
+ `fu2::function_view`     |   10000 |     0.034 |       3 |  0.379 |294602875.3
+ **`ebd::fn_ref`**        |   10000 |     0.034 |       3 |  0.375 |297424305.5
+ `std::function` *        |  100000 |     0.895 |       8 |      - |111756442.5
+ `fu2::function`          |  100000 |     1.765 |      17 |  1.973 | 56644386.5
+ **`ebd::fn`**            |  100000 |     0.678 |       6 |  0.758 |147444347.1
+ `fu2::function_view`     |  100000 |     0.340 |       3 |  0.380 |294061429.4
+ **`ebd::fn_ref`**        |  100000 |     0.308 |       3 |  0.345 |324361494.4
+ `std::function` *        | 1000000 |     9.952 |       9 |      - |100481295.4
+ `fu2::function`          | 1000000 |    17.733 |      17 |  1.782 | 56391833.9
+ **`ebd::fn`**            | 1000000 |     6.832 |       6 |  0.686 |146378186.5
+ `fu2::function_view`     | 1000000 |     3.420 |       3 |  0.344 |292392274.6
+ **`ebd::fn_ref`**        | 1000000 |     3.249 |       3 |  0.326 |307826614.8
 
-## FreeFunction.TrivialParameters:
-
- Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
---------------------------|--------:|----------:|--------:|-------:|----------:
- free_trivial_std *       |   10000 |     0.032 |       3 |      - |311526479.8
- free_trivial_ebd         |   10000 |     0.024 |       2 |  0.754 |413223140.5
- free_trivial_fu2         |   10000 |     0.052 |       5 |  1.626 |191570881.2
- free_trivial_std *       |  100000 |     0.322 |       3 |      - |310366232.2
- free_trivial_ebd         |  100000 |     0.240 |       2 |  0.746 |415800415.8
- free_trivial_fu2         |  100000 |     0.510 |       5 |  1.583 |196001568.0
- free_trivial_std *       | 1000000 |     3.222 |       3 |      - |310375865.2
- free_trivial_ebd         | 1000000 |     2.508 |       2 |  0.778 |398692289.3
- free_trivial_fu2         | 1000000 |     5.792 |       5 |  1.798 |172660876.8
-
-## FreeFunction.CopyHardParameters:
-
- Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
---------------------------|--------:|----------:|--------:|-------:|----------:
- free_copyhard_std *      |   10000 |     0.197 |      19 |      - | 50684237.2
- free_copyhard_ebd        |   10000 |     0.198 |      19 |  1.004 | 50505050.5
- free_copyhard_fu2        |   10000 |     0.303 |      30 |  1.537 | 32981530.3
- free_copyhard_std *      |  100000 |     1.976 |      19 |      - | 50604726.5
- free_copyhard_ebd        |  100000 |     1.982 |      19 |  1.003 | 50456632.5
- free_copyhard_fu2        |  100000 |     3.044 |      30 |  1.541 | 32849352.9
- free_copyhard_std *      | 1000000 |    19.898 |      19 |      - | 50256307.2
- free_copyhard_ebd        | 1000000 |    20.052 |      20 |  1.008 | 49870088.4
- free_copyhard_fu2        | 1000000 |    31.358 |      31 |  1.576 | 31889890.6
-
-## FreeFunction.CallTrivialParameters:
-
- Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
---------------------------|--------:|----------:|--------:|-------:|----------:
- free_calltrivial_std *   |   10000 |     0.032 |       3 |      - |311526479.8
- free_calltrivial_ebd     |   10000 |     0.024 |       2 |  0.751 |414937759.3
- free_calltrivial_fu2     |   10000 |     0.056 |       5 |  1.757 |177304964.5
- free_calltrivial_std *   |  100000 |     0.320 |       3 |      - |312597686.8
- free_calltrivial_ebd     |  100000 |     0.257 |       2 |  0.802 |389711613.4
- free_calltrivial_fu2     |  100000 |     0.584 |       5 |  1.827 |171115674.2
- free_calltrivial_std *   | 1000000 |     3.223 |       3 |      - |310269934.8
- free_calltrivial_ebd     | 1000000 |     2.407 |       2 |  0.747 |415506710.4
- free_calltrivial_fu2     | 1000000 |     5.934 |       5 |  1.841 |168517551.1
-```
-
-> See [here](https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/benchmark.yml) for more benchmark results.
+> See [here](https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/benchmark.yml) for more benchmark results. Follow [`HOW-TO-BENCHMARK.md`](./benchmark/HOW-TO-BENCHMARK.md) to run the benchmark in your platform.
 
 ## 🧭 Future learning & evolution reference
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ auto f = ebd::make_fn<Signature>(Ambiguous_Callable_Object);
 
 ```cpp
 // Create specified function wrapper and automatically deduce the template arguments.
-// The Callable_Object should be unambiguously callable (non-overload).
-auto f = ebd::make_fn<ebd::fn>(Callable_Object);
-auto f = ebd::make_fn<ebd::unique_fn>(Callable_Object);
-auto f = ebd::make_fn<ebd::safe_fn>(Callable_Object);
-auto f = ebd::make_fn<ebd::fn_ref>(Callable_Object);
+// The Callable_Object should be unambiguously callable (non-overload) if `Signature` is omitted.
+auto f = ebd::make_fn<ebd::fn[, Signature]>(Callable_Object);
+auto f = ebd::make_fn<ebd::unique_fn[, Signature]>(Callable_Object);
+auto f = ebd::make_fn<ebd::safe_fn[, Signature]>(Callable_Object);
+auto f = ebd::make_fn<ebd::fn_ref[, Signature]>(Callable_Object);
 ```
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.1.5-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.5">
+  <img src="https://img.shields.io/badge/Version-2.1.6-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.6">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23">
 </p>

--- a/README.md
+++ b/README.md
@@ -78,20 +78,28 @@ auto main() -> int {
 
 ```cpp
 /// The definition of method of a function wrapper is as follows:
-ebd::fn<int (int, float, char) const, 3*sizeof(void*)> fn_;
-//       ^     ^     ^     ^     ^        ^
-//       |     |     |     |     |        |
-// Return type |     |     |     |        |
-// Parameters ~|~~~~~|~~~~~|     |        |
-// Qualifier ~~~~~~~~~~~~~~~~~~~~|        |
-// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~|
+        FnWrapper <void(int, char) const, 3*sizeof(void*)> fn_ = +[](int, char) {};
+//          ^       ^   ^~~~~~~      ^     ^~~~~~                 ^~~~~~~~~~~~~
+//          |       |   |            |     |                      |
+// Function wrapper |   |            |     |                      |
+// Return type ~~~~~|   |            |     |                      |
+// Parameters ~~~~~~~~~~|            |     |                      |
+// Qualifier ~~~~~~~~~~~~~~~~~~~~~~~~|     |                      |
+// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~~|                      |
+// Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
 ```
 
-> The *`Qualifier`* is used to restrict the callable objects wrapped within `ebd::fn`, rather than `ebd::fn` itself. In other words, the `operator()` of the `ebd::fn` object will be qualified with the `Qualifier` modifier.
+- *`Function wrapper`*: One of `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn` and `ebd::fn_ref`.
 
-> The *`Buffer size`* is the size used to store the callable object, which can be omitted.
-> If omitted, this parameter will be set to *DefaultSize* by default, which is sufficient to store most common callable objects, including function pointers, simple non-capturing and capturing lambdas, and lightweight custom classes.
-> *If the buffer size is insufficient, a `static_assert` will be triggered.*
+- *`Return type`*: A type that can be implicitly converted from the direct return type of *`Callable object`*.
+
+- *`Parameters`*: Types that can implicitly converts to the parameter types of *`Callable object`*.
+
+- *`Qualifier`*: Applies to the wrapper's `operator()` (e.g., `const`, `noexcept`, `&`, `&&`), restricting which callable objects can be stored.
+
+- *`Buffer size`*: Size (in bytes) of the internal storage. Defaults to `DefaultSize`. Triggers `static_assert` if insufficient - no heap allocation.
+
+- *`Callable object`*: Any entity callable with the target signature (function pointer, lambda, function object, `std::reference_wrapper`). Copied or moved into the buffer depending on wrapper type.
 
 ## 🧠 Design goals driving the design
 

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -2,152 +2,187 @@
 
 ## Overview
 
-`ebd::make_fn` is a factory function that creates function wrapper objects. It automatically deduces the signature and buffer size of the callable object, and returns an appropriate function wrapper (`ebd::fn` or `ebd::unique_fn`).
+`ebd::make_fn` is a factory for creating Embedded Function wrappers from callable objects, function pointers, member pointers, and existing wrappers.
+
+It can:
+
+- deduce the signature of a lambda or other uniquely callable functor,
+- choose `ebd::fn` or `ebd::unique_fn` automatically,
+- build an empty wrapper with an explicit signature,
+- create a wrapper with a specific wrapper type such as `ebd::safe_fn` or `ebd::fn_ref`.
 
 ## Overloads
 
-### 1. Make function with specified signature for copyable functor
+### 1. Copyable functor with explicit signature
 
 ```cpp
-template <typename Signature, typename Functor>
-EMBED_NODISCARD inline fn<Signature, sizeof(Functor)>
-make_fn(Functor&& functor) noexcept;
+template <typename Signature, typename Functor,
+          typename Class = detail::remove_cvref_t<Functor>,
+          std::size_t BufferSize = sizeof(Class),
+          typename Fn = detail::conditional_t<
+              std::is_copy_constructible<Class>::value,
+              fn<Signature, BufferSize>,
+              unique_fn<Signature, BufferSize>>,
+          bool NoThrow = detail::is_nothrow_construct_from_functor<Functor&&>::value>
+EMBED_NODISCARD inline Fn make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
-Creates an `ebd::fn` with the specified signature for a copyable functor.
+Creates a wrapper for a class-type callable when the signature is specified explicitly. For copyable functors, the resulting type is `ebd::fn<Signature, BufferSize>`.
 
-### 2. Make function with specified signature for move-only functor
+### 2. Move-only functor with explicit signature
 
 ```cpp
-template <typename Signature, typename Functor>
+template <typename Signature, typename Functor,
+          bool NoThrow = std::is_nothrow_move_constructible<Functor>::value>
 EMBED_NODISCARD inline unique_fn<Signature, sizeof(Functor)>
-make_fn(Functor&& functor) noexcept;
+make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
-Creates an `ebd::unique_fn` with the specified signature for a move-only functor.
+Creates an `ebd::unique_fn` for a move-only functor when the signature is specified explicitly.
 
-### 3. Make an empty function with specified signature and buffer size
+### 3. Empty wrapper with explicit signature
 
 ```cpp
-template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+template <typename Signature,
+          std::size_t BufferSize = detail::default_buffer_size::value>
 EMBED_NODISCARD inline fn<Signature, BufferSize>
 make_fn(std::nullptr_t = nullptr) noexcept;
 ```
 
-Creates an empty `ebd::fn` with the specified signature and buffer size.
+Creates an empty `ebd::fn` with the given signature and buffer size.
 
-### 4. Make function for function pointer (auto deduce signature and buffer size)
+### 4. Function pointer with deduced signature
 
 ```cpp
 template <typename Ret, typename... Args>
 EMBED_NODISCARD inline fn<Ret(Args...) const, sizeof(Ret(*)(Args...))>
-make_fn(Ret (*func_ptr) (Args...)) noexcept;
+make_fn(Ret (*func_ptr)(Args...)) noexcept;
 ```
 
-Creates an `ebd::fn` from a function pointer, automatically deducing the signature and buffer size.
+Creates an `ebd::fn` from a free-function pointer and deduces both signature and buffer size.
 
-### 5. Make function for function pointer with specified signature
+### 5. Function pointer with explicit signature
 
 ```cpp
-template <typename Signature, typename FunctionPtr = typename detail::unwrap_signature<Signature>::pure_sig*>
+template <typename Signature,
+          typename FunctionPtr = typename detail::unwrap_signature<Signature>::pure_sig*>
 EMBED_NODISCARD inline fn<Signature, sizeof(FunctionPtr)>
 make_fn(FunctionPtr func_ptr) noexcept;
 ```
 
-Creates an `ebd::fn` from a function pointer with the specified signature.
+Creates an `ebd::fn` from a free-function pointer using the specified signature.
 
-### 6. Create a function from another function (Copy)
-
-```cpp
-template <std::size_t Buf, typename Cfg, typename Sig>
-EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
-make_fn(const detail::function<Buf, Cfg, Sig>& fn) noexcept;
-```
-
-Creates a function wrapper by copying another function wrapper.
-
-### 7. Create a function from another function (Move)
+### 6. Copy from another wrapper
 
 ```cpp
 template <std::size_t Buf, typename Cfg, typename Sig>
 EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
-make_fn(detail::function<Buf, Cfg, Sig>&& fn) noexcept;
+make_fn(const detail::function<Buf, Cfg, Sig>& fn)
+noexcept(Cfg::isView || Cfg::assertNoThrow);
 ```
 
-Creates a function wrapper by moving another function wrapper.
+Creates a wrapper by copying another `ebd::detail::function`.
 
-### 8. Make a function from lambda or unique-operator() functor
+### 7. Move from another wrapper
 
 ```cpp
-template <typename Lambda, typename Class = detail::remove_cvref_t<Lambda>,
+template <std::size_t Buf, typename Cfg, typename Sig>
+EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
+make_fn(detail::function<Buf, Cfg, Sig>&& fn)
+noexcept(Cfg::isView || Cfg::assertNoThrow);
+```
+
+Creates a wrapper by moving another `ebd::detail::function`.
+
+### 8. Lambda or uniquely callable functor
+
+```cpp
+template <typename Lambda,
+          typename Class = detail::remove_cvref_t<Lambda>,
           std::size_t BufferSize = sizeof(Class),
           typename Signature = detail::get_unique_signature_t<Class>,
           typename Fn = detail::conditional_t<
               std::is_copy_constructible<Class>::value,
-              fn<Signature, BufferSize>, unique_fn<Signature, BufferSize>
-          >>
-EMBED_NODISCARD inline Fn make_fn(Lambda&& fn) noexcept;
+              fn<Signature, BufferSize>,
+              unique_fn<Signature, BufferSize>>,
+          bool NoThrow = detail::is_nothrow_construct_from_functor<Lambda&&>::value>
+EMBED_NODISCARD inline Fn make_fn(Lambda&& fn) noexcept(NoThrow);
 ```
 
-Creates a function wrapper from a lambda or functor with a unique `operator()`, automatically deducing the signature and buffer size.
+Creates a wrapper from a lambda or other functor with exactly one viable `operator()`. The signature is deduced automatically.
 
-### 9. Make function for pointer to member function
+### 9. Pointer to member function
 
 ```cpp
 template <typename Class, typename Ret, typename... Args>
 EMBED_NODISCARD inline auto
 make_fn(Ret(Class::* memfunc)(Args...) C V REF NOEXCEPT) noexcept
--> fn<Ret(detail::get_qualified_with_t<int REF, C V Class>, Args...) const, sizeof(memfunc)>;
+-> fn<
+    Ret(detail::get_qualified_with_t<int REF, C V Class>, Args...) const,
+    sizeof(memfunc)
+   >;
 ```
 
-Creates an `ebd::fn` from a pointer to member function, automatically deducing the signature and buffer size.
+Creates an `ebd::fn` from a pointer to member function. Cv/ref/noexcept qualifiers are preserved in the generated signature family.
 
-### 10. Make function for member function pointer with specified signature
+### 10. Member function pointer with explicit signature
 
 ```cpp
-template <typename Signature, typename MemFuncPtr = detail::get_member_fn_type_t<Signature>,
+template <typename Signature,
+          typename MemFuncPtr = detail::get_member_fn_type_t<Signature>,
           std::size_t BufferSize = sizeof(MemFuncPtr)>
 EMBED_NODISCARD inline fn<Signature, BufferSize>
 make_fn(MemFuncPtr memfunc_ptr) noexcept;
 ```
 
-Creates an `ebd::fn` from a member function pointer with the specified signature.
+Creates an `ebd::fn` from a pointer to member function using the specified signature.
 
-### 11. Make function for pointer to member object
+### 11. Pointer to member object
 
 ```cpp
-template <typename Class, typename T>
+template <typename Class, typename T,
+          typename Ret = typename detail::invoke_result<T Class::*, Class&>::type>
 EMBED_NODISCARD inline auto make_fn(T Class::* ptr_memobj) noexcept
--> fn<T(Class&) const, sizeof(ptr_memobj)>;
+-> fn<Ret(Class&) const, sizeof(ptr_memobj)>;
 ```
 
-Creates an `ebd::fn` from a pointer to member object.
+Creates an `ebd::fn` that reads a member object from an instance.
 
-### 12. In-place make function (C++17+)
+### 12. In-place construction (C++17+)
 
 ```cpp
 template <typename Functor, typename... CArgs>
-EMBED_NODISCARD inline auto make_fn(std::in_place_type_t<Functor>, CArgs&&... args) noexcept;
+EMBED_NODISCARD inline auto
+make_fn(std::in_place_type_t<Functor>, CArgs&&... args)
+noexcept(std::is_nothrow_constructible<Functor, CArgs...>::value);
 
 template <typename Functor, typename U, typename... CArgs>
 EMBED_NODISCARD inline auto
-make_fn(std::in_place_type_t<Functor>, std::initializer_list<U> il, CArgs&&... args) noexcept;
+make_fn(std::in_place_type_t<Functor>, std::initializer_list<U> il, CArgs&&... args)
+noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs...>::value);
 ```
 
-Creates a function wrapper by in-place constructing the callable object within the internal buffer.
+Constructs the callable directly inside the wrapper buffer. The returned wrapper type is deduced from the functor.
 
-### 13. Make function with specified wrapper
+### 13. Explicit wrapper type
 
 ```cpp
-template <template <class, std::size_t> class Fn, typename Functor,
+template <template <class, std::size_t> class Fn,
+          typename SpecifiedSig = void,
+          typename Functor,
           typename Deduction = decltype(make_fn(std::declval<Functor>())),
-          typename Signature = typename detail::is_ebd_fn<Deduction>::signature,
+          typename RawSig = typename detail::is_ebd_fn<Deduction>::signature,
+          typename Signature = detail::conditional_t<
+              std::is_void<SpecifiedSig>::value,
+              detail::noexcept_qualify_like_t<Functor, Fn, RawSig>,
+              SpecifiedSig>,
           std::size_t BufferSize = sizeof(detail::decay_t<Functor>),
-          typename FnWrapper = Fn<Signature, BufferSize>>
-EMBED_NODISCARD inline FnWrapper make_fn(Functor&& functor) noexcept;
+          typename FnWrapper = Fn<Signature, BufferSize>,
+          bool NoThrow = noexcept(FnWrapper(std::declval<Functor>()))>
+EMBED_NODISCARD inline FnWrapper make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
-Creates a function wrapper with the specified wrapper type (e.g., `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, or `ebd::fn_view`).
+Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, or `ebd::fn_ref`. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(functor)`.
 
 ## Usage Examples
 
@@ -156,75 +191,75 @@ Creates a function wrapper with the specified wrapper type (e.g., `ebd::fn`, `eb
 ```cpp
 #include "embed/embed_function.hpp"
 
-// Create a function wrapper from a function pointer
-void foo() { /* do something */ }
+void foo() {}
+
 auto fn1 = ebd::make_fn(&foo);
 fn1();
 
-// Create a function wrapper from a lambda
-auto fn2 = ebd::make_fn([]() { /* do something */ });
-fn2();
+auto fn2 = ebd::make_fn([](int x) { return x + 1; });
+int y = fn2(41);
 
-// Create a function wrapper with specified signature
-auto fn3 = ebd::make_fn<void(int)>([](int x) { /* do something */ });
+auto fn3 = ebd::make_fn<void(int)>([](int x) { /* ... */ });
 fn3(42);
 
-// Create an empty function wrapper
 auto fn4 = ebd::make_fn<void()>();
 if (!fn4) {
-    // Handle empty function
+    // Handle empty wrapper
 }
 ```
 
-### With Member Functions
+### Member Pointers
 
 ```cpp
 struct MyClass {
-    void method(int x) { /* do something */ }
+    void method(int x) { value += x; }
     int value = 42;
 };
 
 MyClass obj;
 
-// Create a function wrapper for a member function
 auto mem_fn = ebd::make_fn(&MyClass::method);
-mem_fn(obj, 100); // Call obj.method(100)
+mem_fn(obj, 8);
 
-// Create a function wrapper for a member variable
 auto mem_obj = ebd::make_fn(&MyClass::value);
-int val = mem_obj(obj); // Get obj.value
+int value = mem_obj(obj);
 ```
 
-### With Custom Wrapper Type
+### Explicit Wrapper Type
 
 ```cpp
-// Create a safe_fn from a lambda
-auto safe_fn = ebd::make_fn<ebd::safe_fn>([]() noexcept { /* do something */ });
+auto safe = ebd::make_fn<ebd::safe_fn>([]() noexcept { /* ... */ });
 
-// Create a fn_view from a function pointer
-void bar() { /* do something */ }
-auto view = ebd::make_fn<ebd::fn_view>(&bar);
+void bar() {}
+auto ref = ebd::make_fn<ebd::fn_ref>(&bar);
+
+auto ref2 = ebd::make_fn<ebd::fn_ref, void()>(bar);
 ```
 
-### In-place Construction (C++17+)
+### In-place Construction
 
 ```cpp
-// In-place construct a functor within the function wrapper
-auto fn = ebd::make_fn(std::in_place_type<MyFunctor>, /* constructor arguments */);
+struct Functor {
+    explicit Functor(int x) : value(x) {}
+    int operator()() const { return value; }
+    int value;
+};
+
+auto fn = ebd::make_fn(std::in_place_type<Functor>, 42);
+int value = fn();
 ```
 
 ## Notes
 
-- `ebd::make_fn` automatically deduces the appropriate function wrapper type based on the callable object:
-  - Returns `ebd::fn` for copyable callables
-  - Returns `ebd::unique_fn` for move-only callables
-- The buffer size is automatically set to the size of the callable object.
-- For ambiguous callables (e.g., overloaded functions), you must specify the signature explicitly.
-- If `ebd::make_fn` cannot deduce an appropriate function wrapper, it will trigger a static assertion with a helpful error message.
+- `ebd::make_fn` returns `ebd::fn` for copyable deduced callables and `ebd::unique_fn` for move-only deduced callables.
+- When the callable is ambiguous, such as an overloaded function, specify the signature explicitly.
+- The explicit-wrapper overload accepts `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, and `ebd::fn_ref`.
+- `ebd::fn_view` is still available as a deprecated alias of `ebd::fn_ref`.
+- When deduction fails, the fallback overload triggers a static assertion with guidance.
 
 ## See Also
 
-- [`ebd::fn`](./fn.md) - Copyable function wrapper
-- [`ebd::unique_fn`](./unique_fn.md) - Move-only function wrapper
-- [`ebd::safe_fn`](./safe_fn.md) - Exception-safe function wrapper
-- [`ebd::fn_ref`](./fn_ref.md) - For non-owning views of callables
+- [`ebd::fn`](./fn.md) - Copyable owning wrapper
+- [`ebd::unique_fn`](./unique_fn.md) - Move-only owning wrapper
+- [`ebd::safe_fn`](./safe_fn.md) - Non-throwing wrapper
+- [`ebd::fn_ref`](./fn_ref.md) - Non-owning wrapper

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,19 +1,15 @@
 ## Fixed
 
-- Fixed a bug where empty and trivial functor could be incorrectly treated as stateless.
-
-- Fixed MSVC 19.10–19.14 compatibility issue.
+- 
 
 ## Changed
 
-- `fn_ref` now accepts temporary callable objects (previously disallowed rvalue references).
-
-- `basic_fn` no longer automatically aligns `BufferSize`.
+- 
 
 ## Added
 
-- Added CTAD guides for `fn_ref` with `std::constant_wrapper`.
+- 
 
 ## Notes
 
-- `std::constant_wrapper` support is experimental as of v2.1.5.
+- `std::constant_wrapper` support is experimental as of v2.1.6.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,14 +1,18 @@
 ## Fixed
 
-- 
+- No swap in copy assignment.
 
 ## Changed
 
-- 
+- Rename `is_trivial_for_call` as `is_itanium_trivial_for_calls` and `is_reg_passable` as `is_register_passable`.
+- Refactor `is_callable_from` and `is_invocable_using`.
+- Add specialization for `is_register_passable` for Windows x64.
+- Update README.md and make_fn.md.
 
 ## Added
 
-- 
+- Add static call operator test.
+- Add stateless assign test.
 
 ## Notes
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -801,7 +801,7 @@ inline namespace fn_traits {
   // See <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial-parameters>
   // and <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial>.
   template <typename T>
-  struct is_trivial_for_call : public bool_constant<
+  struct is_itanium_trivial_for_calls : public bool_constant<
     std::is_trivially_destructible<T>::value
     && std::is_trivially_copy_constructible<T>::value
     && std::is_trivially_move_constructible<T>::value
@@ -1461,27 +1461,24 @@ inline namespace fn_traits {
 
   // MSVC 19.21 and earlier have a bug when using `sizeof(T) <= sizeof(void*)`
   // in `conditional_t`. To work around this issue and facilitate targeted
-  // optimization for each platform, we create `is_reg_passable`.
+  // optimization for each platform, we create `is_register_passable`.
   template <typename T>
-  struct is_reg_passable {
+  struct is_register_passable {
     static constexpr std::size_t obj_size = sizeof(T);
-    static constexpr bool is_trivial_obj = is_trivial_for_call<T>::value;
-    static constexpr bool is_scalar_obj = std::is_scalar<T>::value;
+    static constexpr bool is_trivial_for_calls = is_itanium_trivial_for_calls<T>::value;
 
 #if defined(__sparc_v8__) || defined(__sparcv8)
     // Class and union object are not allowed to pass by reg in SPARC V8 (32bit).
-    static constexpr bool aggregate_passable = false;
+    static constexpr bool value = std::is_scalar<T>::value;
 #elif defined(_WIN64) && defined(_M_X64)
-    static_assert(sizeof(void*) == 8, EMBED_DETAIL_REPORT_IE("sizeof(void*) != 8 in Windows x64."));
     // See <https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-180#parameter-passing>.
-    static constexpr bool aggregate_passable = is_trivial_obj
-      && (obj_size == 1 || obj_size == 2 || obj_size == 4 || obj_size == 8);
+    static_assert(sizeof(void*) == 8, EMBED_DETAIL_REPORT_IE("sizeof(void*) != 8 in Windows x64."));
+    static constexpr bool size_is_ok = obj_size == 1 || obj_size == 2 || obj_size == 4 || obj_size == 8;
+    static constexpr bool value = !std::is_reference<T>::value && is_trivial_for_calls && size_is_ok;
 #else
-    static constexpr bool aggregate_passable = is_trivial_obj
-      && obj_size <= 2 * sizeof(void*);
+    static constexpr bool size_is_ok = sizeof(T) <= 2 * sizeof(void*);
+    static constexpr bool value = !std::is_reference<T>::value && is_trivial_for_calls && size_is_ok;
 #endif
-
-    static constexpr bool value = is_scalar_obj || aggregate_passable;
   };
 
   // Used to choose either perfect forwarding or pass-by-value.
@@ -1490,7 +1487,7 @@ inline namespace fn_traits {
 #if !defined(EMBED_FN_CONFIG_DISABLE_SMART_FORWARD)
   template <typename T>
   using smart_forward_t = // vvv MSVC 19.10~19.14 workaround: avoid using `conditional_t`.
-    typename std::conditional<is_reg_passable<T>::value, T, T&&>::type;
+    typename std::conditional<is_register_passable<T>::value, T, T&&>::type;
 #else
   template <typename T>
   using smart_forward_t = T&&;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -801,10 +801,10 @@ inline namespace fn_traits {
   // See <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial-parameters>
   // and <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial>.
   template <typename T>
-  struct is_call_trivial : public bool_constant<
+  struct is_trivial_for_call : public bool_constant<
     std::is_trivially_destructible<T>::value
-      && std::is_trivially_copy_constructible<T>::value
-      && std::is_trivially_move_constructible<T>::value
+    && std::is_trivially_copy_constructible<T>::value
+    && std::is_trivially_move_constructible<T>::value
   > {};
 
   // std::is_trivial is deprecated in C++26. But we need it.
@@ -1464,17 +1464,24 @@ inline namespace fn_traits {
   // optimization for each platform, we create `is_reg_passable`.
   template <typename T>
   struct is_reg_passable {
-    static constexpr std::size_t reg_size = sizeof(void*);
     static constexpr std::size_t obj_size = sizeof(T);
-    static constexpr bool is_trivial_obj = is_call_trivial<T>::value;
+    static constexpr bool is_trivial_obj = is_trivial_for_call<T>::value;
     static constexpr bool is_scalar_obj = std::is_scalar<T>::value;
+
 #if defined(__sparc_v8__) || defined(__sparcv8)
-    // class and union object are not allowed to pass by reg in SPARC V8 (32bit).
-    static constexpr bool value = is_scalar_obj;
+    // Class and union object are not allowed to pass by reg in SPARC V8 (32bit).
+    static constexpr bool aggregate_passable = false;
+#elif defined(_WIN64) && defined(_M_X64)
+    static_assert(sizeof(void*) == 8, EMBED_DETAIL_REPORT_IE("sizeof(void*) != 8 in Windows x64."));
+    // See <https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-180#parameter-passing>.
+    static constexpr bool aggregate_passable = is_trivial_obj
+      && (obj_size == 1 || obj_size == 2 || obj_size == 4 || obj_size == 8);
 #else
-    static constexpr bool value =
-      is_scalar_obj || (obj_size <= 2 * reg_size && is_trivial_obj);
+    static constexpr bool aggregate_passable = is_trivial_obj
+      && obj_size <= 2 * sizeof(void*);
 #endif
+
+    static constexpr bool value = is_scalar_obj || aggregate_passable;
   };
 
   // Used to choose either perfect forwarding or pass-by-value.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1086,7 +1086,7 @@ inline namespace fn_traits {
   // Check the functor is callable with given arguments.
   // [func.wrap.move.ctor]/1
   template <typename Functor, typename Signature>
-  struct is_callable_from {
+  struct is_callable_from_impl {
     using unwrap_sig = unwrap_signature<Signature>;
     using ret       = typename unwrap_sig::ret;
     using args_pack = typename unwrap_sig::args;
@@ -1549,22 +1549,18 @@ inline namespace fn_traits {
 #endif
 
   // <https://eel.is/c++draft/func.wrap#ref.ctor-1>.
-  template <typename Sig, typename Tuple, 
+  // [func.wrap.ref.ctor]/1 is-invocable-using
+  template <typename Sig, typename Tuple,
     typename PureSig = typename unwrap_signature<Sig>::pure_sig>
   struct is_invocable_using_impl;
   template <typename Sig, typename... TArgs, typename Ret, typename... Args>
-  struct is_invocable_using_impl<Sig, std::tuple<TArgs...>, Ret(Args...)> {
-    using type = conditional_t<
+  struct is_invocable_using_impl<Sig, std::tuple<TArgs...>, Ret(Args...)>
+  : conditional_t<
       unwrap_signature<Sig>::isNoexcept,
       is_nothrow_invocable_r<Ret, TArgs..., Args...>,
       is_invocable_r<Ret, TArgs..., Args...>
-    >;
-  };
-
-  // [func.wrap.ref.ctor]/1 is-invokable-using
-  template <typename Signature, typename... T>
-  using is_invocable_using_t = 
-    typename is_invocable_using_impl<Signature, std::tuple<T...>>::type;
+    >
+  {};
 
   template <typename T>
   struct is_constant_wrapper : std::false_type {};
@@ -2695,6 +2691,17 @@ namespace crtp_mixins {
     // `true` if self is copyable.
     static constexpr bool internal_is_copyable = Config::isCopyable || Config::isView;
 
+    // [func.wrap.move.ctor]/1 is-callable-from
+    template <typename Functor>
+    using is_callable_from = is_callable_from_impl<Functor, Signature>;
+
+    // [func.wrap.ref.ctor]/1 is-invocable-using
+    template <typename... T>
+    using is_invocable_using = is_invocable_using_impl<Signature, std::tuple<T...>>;
+
+    template <typename T>
+    using add_cv_like_sig_t = typename unwrap_signature<Signature>::template add_cv_like<T>;
+
   public:
 
     // The return type.
@@ -2807,7 +2814,7 @@ namespace crtp_mixins {
       (!fn_can_convert<function, Functor>::value)
       && (!is_self<Functor, function>::value)
       && (!is_in_place_type<decay_t<Functor>>::value)
-      && is_callable_from<Functor, Signature>::value
+      && is_callable_from<Functor>::value
       && (!Config::isView)
     ) function(Functor&& functor)
     noexcept(is_nothrow_construct_from_functor<Functor&&>::value) {
@@ -2829,7 +2836,7 @@ namespace crtp_mixins {
     EMBED_DETAIL_TEMPLATE_BEGIN(typename Func)
     EMBED_DETAIL_REQUIRES_END(
       std::is_function<Func>::value
-      && is_invocable_using_t<Signature, Func>::value
+      && is_invocable_using<Func>::value
       && Config::isView
     ) function(Func* function_ptr) noexcept {
 
@@ -2850,10 +2857,10 @@ namespace crtp_mixins {
     /// @note Used for function reference only. (NON-OWNING)
     EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, 
       typename Tp = remove_reference_t<Functor>,
-      typename Tp_cv = typename unwrap_signature<Signature>::template add_cv_like<Tp>)
+      typename Tp_cv = add_cv_like_sig_t<Tp>)
     EMBED_DETAIL_REQUIRES_END(
       (!is_self<Functor, function>::value)
-      && is_invocable_using_t<Signature, Tp_cv&>::value
+      && is_invocable_using<Tp_cv&>::value
       && (!std::is_member_pointer<Tp>::value)
       && (!fn_can_convert<function, Functor>::value)
       && Config::isView
@@ -2875,7 +2882,7 @@ namespace crtp_mixins {
     EMBED_DETAIL_TEMPLATE_BEGIN(typename Fn, typename... CArgs)
     EMBED_DETAIL_REQUIRES_END(
       std::is_constructible<Fn, CArgs...>::value
-      && is_callable_from<Fn, Signature>::value
+      && is_callable_from<Fn>::value
       && (!Config::isView)
     ) explicit function(std::in_place_type_t<Fn>, CArgs&&... args)
     noexcept(std::is_nothrow_constructible<Fn, CArgs...>::value) {
@@ -2895,7 +2902,7 @@ namespace crtp_mixins {
     EMBED_DETAIL_TEMPLATE_BEGIN(typename Fn, typename U, typename... CArgs)
     EMBED_DETAIL_REQUIRES_END(
       std::is_constructible<Fn, std::initializer_list<U>&, CArgs...>::value
-      && is_callable_from<Fn, Signature>::value
+      && is_callable_from<Fn>::value
       && (!Config::isView)
     ) explicit function(std::in_place_type_t<Fn>, std::initializer_list<U> il, CArgs&&... args)
     noexcept(std::is_nothrow_constructible<Fn, CArgs...>::value) {
@@ -2917,7 +2924,7 @@ namespace crtp_mixins {
 
     // Create function reference with given `std::constant_wrapper` param.
     template <auto CwVal, typename Fn>
-      requires is_invocable_using_t<Signature, const Fn&>::value
+      requires is_invocable_using<const Fn&>::value
         && Config::isView
     constexpr function(std::constant_wrapper<CwVal, Fn>) noexcept
     : MemberVariableBase(nullptr) {
@@ -2933,8 +2940,7 @@ namespace crtp_mixins {
     // Create function reference with given `std::constant_wrapper` and object params.
     template <auto CwVal, typename Fn, typename Up, typename Tp = remove_reference_t<Up>>
       requires (!std::is_rvalue_reference_v<Up&&>)
-        && is_invocable_using_t<Signature, const Fn&, 
-          typename unwrap_signature<Signature>::template add_cv_like<Tp>&>::value
+        && is_invocable_using<const Fn&, add_cv_like_sig_t<Tp>&>::value
         && Config::isView
     constexpr function(std::constant_wrapper<CwVal, Fn>, Up&& obj) noexcept
     : MemberVariableBase(nullptr) {
@@ -2948,11 +2954,9 @@ namespace crtp_mixins {
     }
 
     // Create function reference with given `std::constant_wrapper` and pointer params.
-    template <auto CwVal, typename Fn, typename Tp,
-      typename Tp_cv = typename unwrap_signature<Signature>::template add_cv_like<Tp>
-    >
+    template <auto CwVal, typename Fn, typename Tp, typename Tp_cv = add_cv_like_sig_t<Tp>>
       requires std::is_convertible_v<Tp*, Tp_cv*>
-        && is_invocable_using_t<Signature, const Fn&, Tp_cv*>::value
+        && is_invocable_using<const Fn&, Tp_cv*>::value
         && Config::isView
     constexpr function(std::constant_wrapper<CwVal, Fn>, Tp* obj) noexcept
     : MemberVariableBase(nullptr) {

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3,7 +3,7 @@
  * 
  * @date        2026-2-7
  * 
- * @version     2.1.5
+ * @version     2.1.6
  * 
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1465,7 +1465,6 @@ inline namespace fn_traits {
   template <typename T>
   struct is_register_passable {
     static constexpr std::size_t obj_size = sizeof(T);
-    static constexpr bool is_trivial_for_calls = is_itanium_trivial_for_calls<T>::value;
 
 #if defined(__sparc_v8__) || defined(__sparcv8)
     // Class and union object are not allowed to pass by reg in SPARC V8 (32bit).
@@ -1474,10 +1473,10 @@ inline namespace fn_traits {
     // See <https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-180#parameter-passing>.
     static_assert(sizeof(void*) == 8, EMBED_DETAIL_REPORT_IE("sizeof(void*) != 8 in Windows x64."));
     static constexpr bool size_is_ok = obj_size == 1 || obj_size == 2 || obj_size == 4 || obj_size == 8;
-    static constexpr bool value = !std::is_reference<T>::value && is_trivial_for_calls && size_is_ok;
+    static constexpr bool value = is_itanium_trivial_for_calls<T>::value && size_is_ok;
 #else
     static constexpr bool size_is_ok = sizeof(T) <= 2 * sizeof(void*);
-    static constexpr bool value = !std::is_reference<T>::value && is_trivial_for_calls && size_is_ok;
+    static constexpr bool value = is_itanium_trivial_for_calls<T>::value && size_is_ok;
 #endif
   };
 
@@ -2853,13 +2852,12 @@ namespace crtp_mixins {
     /// and returns a value convertible to `Ret`. (The Signature is `Ret(Args...)`)
     /// @note Used for function reference only. (NON-OWNING)
     EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, 
-      typename Tp = remove_reference_t<Functor>,
-      typename Tp_cv = add_cv_like_sig_t<Tp>)
+      typename Tp = remove_reference_t<Functor>)
     EMBED_DETAIL_REQUIRES_END(
       (!is_self<Functor, function>::value)
-      && is_invocable_using<Tp_cv&>::value
-      && (!std::is_member_pointer<Tp>::value)
       && (!fn_can_convert<function, Functor>::value)
+      && (!std::is_member_pointer<Tp>::value)
+      && is_invocable_using<add_cv_like_sig_t<Tp>&>::value
       && Config::isView
     ) EMBED_CXX20_CONSTEXPR function(Functor&& functor) noexcept
     : MemberVariableBase(nullptr) {

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -204,9 +204,8 @@
 
 /// @brief Similar to `requires` in C++20.
 /// Using SFINAE trait `enable_if_t` to require the template arguments.
-#define EMBED_DETAIL_REQUIRES_IMPL(require_condition) \
-  ::ebd::detail::enable_if_t<(require_condition), int> = 0
-#define EMBED_DETAIL_REQUIRES(...)  EMBED_DETAIL_REQUIRES_IMPL((__VA_ARGS__))
+#define EMBED_DETAIL_REQUIRES(...) \
+  ::ebd::detail::enable_if_t<(__VA_ARGS__), int> = 0
 
 #if defined(_MSC_VER)
 # define EMBED_DETAIL_FORCE_EBO __declspec(empty_bases)
@@ -298,8 +297,8 @@
 
 // Guidelines for reporting internal errors.
 #define EMBED_DETAIL_REPORT_IE(error) \
-  "An internal error has occurred: " error " This is unexpected. " \
-  "Please report this bug at <https://github.com/Kim-J-Smith/Embedded-Function/issues>."
+  "An internal library error has occurred: " error " This is unexpected.\n" \
+  "PLEASE report this bug at <https://github.com/Kim-J-Smith/Embedded-Function/issues>."
 
 namespace ebd EMBED_ABI_VISIBILITY(default) {
 namespace detail {
@@ -799,7 +798,8 @@ inline namespace fn_traits {
   struct always_false { static constexpr bool value = false; };
 
   // Is trivial for the purposes of calls. (trivially destruct, copy and move)
-  // See <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial-parameters>.
+  // See <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial-parameters>
+  // and <https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial>.
   template <typename T>
   struct is_call_trivial : public bool_constant<
     std::is_trivially_destructible<T>::value
@@ -1163,25 +1163,25 @@ inline namespace fn_traits {
   // Utility struct to check if a callable object is not empty.
   struct check_not_empty {
     template <typename T>
-    static constexpr bool check(T* f) noexcept { return f != nullptr; }
+    static constexpr bool not_empty(T* f) noexcept { return f != nullptr; }
     template <typename Class, typename T>
-    static constexpr bool check(T Class::* f) noexcept { return f != nullptr; }
+    static constexpr bool not_empty(T Class::* f) noexcept { return f != nullptr; }
     template <typename T>
-    static constexpr bool check(const T&) noexcept { return true; }
+    static constexpr bool not_empty(const T&) noexcept { return true; }
 
     template <typename Sig>
-    static bool check(const ::std::function<Sig>& f) noexcept
+    static bool not_empty(const ::std::function<Sig>& f) noexcept
     { return static_cast<bool>(f); }
 
     template <std::size_t Buf, typename Cfg, typename Sig,
       EMBED_DETAIL_REQUIRES(!Cfg::isView) /*OWNING*/> static
-    EMBED_CXX14_CONSTEXPR bool check(const function<Buf, Cfg, Sig>& f) noexcept
+    EMBED_CXX14_CONSTEXPR bool not_empty(const function<Buf, Cfg, Sig>& f) noexcept
     { return static_cast<bool>(f); }
 
 #if __cpp_lib_move_only_function >= 202110L
 
     template <typename Sig>
-    static bool check(const ::std::move_only_function<Sig>& f) noexcept
+    static bool not_empty(const ::std::move_only_function<Sig>& f) noexcept
     { return static_cast<bool>(f); }
 
 #endif // ^^^ __cpp_lib_move_only_function >= 202110L
@@ -1189,7 +1189,7 @@ inline namespace fn_traits {
 #if __cpp_lib_copyable_function >= 202306L
 
     template <typename Sig>
-    static bool check(const ::std::copyable_function<Sig>& f) noexcept
+    static bool not_empty(const ::std::copyable_function<Sig>& f) noexcept
     { return static_cast<bool>(f); }
 
 #endif // ^^^ __cpp_lib_copyable_function >= 202306L
@@ -1503,8 +1503,14 @@ inline namespace fn_traits {
   struct asserts_for_function : public std::true_type {
 
     static_assert(align_size_is_ok<Functor, Config, BufferSize, ErasureT>::value,
-      "The size of Functor is too large, and the BufferSize is too small."
-      " Try use greater 'BufferSize' as the template argument");
+      "The `BufferSize` is smaller than the callable object. Please use bigger "
+      "`BufferSize` and try again:\n\n"
+      "        FnWrapper<Signature, Bigger-BufferSize> f = CallableObject;\n"
+      "                             ^^^^^^^^^^^^^^^^^\n"
+      "                                     |\n"
+      "             should be greater than `sizeof(CallableObject)`\n\n"
+      "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, etc."
+    );
 
     static_assert(assert_throwing_is_ok<Functor, Object, Config>::value,
       "The 'Functor' may throw exceptions during construction and destruction,"
@@ -1666,7 +1672,7 @@ inline namespace fn_traits {
   // Lambda has trivially default constructor since C++20.
   // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0624r2.pdf>.
   template <typename Fn>
-  struct is_empty_normal : bool_constant<
+  struct is_empty_trivial : bool_constant<
     std::is_empty<Fn>::value && std::is_trivially_default_constructible<Fn>::value
     && std::is_trivially_destructible<Fn>::value
   > {};
@@ -1676,25 +1682,29 @@ inline namespace fn_traits {
   struct is_stateless : bool_constant<
     is_static_callable_functor<Fn, Args...>::value
     || is_std_op_wrapper<Fn>::value
-    || (is_empty_normal<Fn>::value && !IsView)
+    || (is_empty_trivial<Fn>::value && !IsView)
     // ^^^ empty trivial functor may use `this` in operator(). This is
     // not strict stateless and cannot be used in reference semantic.
   > {};
 
   // Log error for make_fn.
   template <typename Unused>
-  EMBED_INLINE constexpr bool make_fn_log_error() noexcept {
+  constexpr bool make_fn_log_error() noexcept {
     static_assert(always_false<Unused>::value,
-      "`make_fn()` CANNOT infer the template arguments of `ebd::basic_fn` by given arguments.\n"
-      "You can specified the signature and try again:\n\n"
+      "`make_fn()` CANNOT infer the template arguments of `ebd::basic_fn` from the given "
+      "arguments.\nYou can specify the signature and try again:\n\n"
       "        auto f = ebd::make_fn<Signature>(CallableObject);\n"
-      "        auto f = ebd::make_fn<FnWrapper, Signature>(CallableObject);\n\n"
+      "                              ^^^^^^^^^\n"
+      "        auto f = ebd::make_fn<FnWrapper, Signature>(CallableObject);\n"
+      "                                         ^^^^^^^^^\n\n"
       "The `Signature` is like `void()`, `float(int,int) const`;\n"
       "The `FnWrapper` is an alias of `ebd::basic_fn` and has `template <class, std::size_t>` "
-      "as template arguments list, such as `ebd::fn_ref`, `ebd::safe_fn`, etc."
+      "as a template argument list, such as `ebd::fn_ref`, `ebd::safe_fn`, etc. If omitted, "
+      "the `FnWrapper` will be inferred to be `ebd::fn` if the `CallableObject` is copyable, "
+      "and `ebd::unique_fn` otherwise."
     );
     return true;
-  };
+  }
 
   // `true` if Cfg::assertNoThrow || Cfg::isView
   template <typename Cfg>
@@ -1886,7 +1896,7 @@ namespace invocation {
     };                                                                            \
                                                                                   \
     /* Used for stateless(empty) Functor (like std::less). */                     \
-    struct empty_normal {                                                         \
+    struct empty_trivial_class {                                                  \
       template <typename EmptyFn>                                                 \
       static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) {          \
         C V EmptyFn fn{};  /* Empty and trivial class. It is stateless */         \
@@ -2139,7 +2149,7 @@ namespace command {
       using invoker_impl_target_t = conditional_t<
         is_static_callable_functor<DecFunctor, Args...>::value,
         typename invoker_impl_t::static_call,
-        typename invoker_impl_t::empty_normal
+        typename invoker_impl_t::empty_trivial_class
       >;
       m_invoker = &invoker_impl_target_t::template invoke<DecFunctor>;
       m_manager = &manager_impl_t::empty::manage;
@@ -2221,7 +2231,7 @@ namespace command {
       using invoker_impl_target_t = conditional_t<
         is_static_callable_functor<DecFunctor, Args...>::value,
         typename invoker_impl_t::static_call,
-        typename invoker_impl_t::empty_normal
+        typename invoker_impl_t::empty_trivial_class
       >;
       m_invoker = &invoker_impl_target_t::template invoke<DecFunctor>;
     }
@@ -2380,7 +2390,7 @@ namespace crtp_mixins {
     copy_impl& operator=(const copy_impl& other_raw) noexcept(Config::assertNoThrow) {
       auto& other = static_cast<const Self&>(other_raw);
       if (!other.is_empty() && this != std::addressof(other)) {
-        Self(other).swap(static_cast<Self&>(*this));
+        Self(other).swap(static_cast<Self&>(*this)); // TODO: avoid using `swap`.
       }
       return *this;
     }
@@ -2751,8 +2761,7 @@ namespace crtp_mixins {
       // Suppress GCC warning: "-Wmaybe-uninitialized".
       std::memset(&m_erasure, 0, sizeof(void*));
 
-      other.m_command.clone(
-        &m_erasure, const_cast<other_erasure_t*>(&other.m_erasure));
+      other.m_command.clone(&m_erasure, const_cast<other_erasure_t*>(&other.m_erasure));
       std::memcpy(&m_command, &other.m_command, sizeof(command_t));
     }
 
@@ -2792,7 +2801,7 @@ namespace crtp_mixins {
           BufferSize, Config, Signature, Functor, Functor&&, erasure_t>::value,
         EMBED_DETAIL_REPORT_IE("asserts_for_function<...>::value should be always true."));
 
-      if (check_not_empty::check(functor)) {
+      if (check_not_empty::not_empty(functor)) {
         m_command.template init<>(&m_erasure, std::forward<Functor>(functor));
       } else {
         m_command.set_empty();
@@ -2947,46 +2956,6 @@ namespace crtp_mixins {
 
 #endif
 
-    // Assign a callable object to the object.
-    EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)
-    EMBED_DETAIL_REQUIRES_END(
-      (!fn_can_convert<function, Functor>::value)
-      && (!is_self<Functor, function>::value)
-      && (!Config::isView)
-    ) function& operator=(Functor&& fn)
-    noexcept(is_nothrow_construct_from_functor<Functor&&>::value) {
-      /// Call move assignment in @e `crtp_mixins::move_impl`.
-      *this = function(std::forward<Functor>(fn));
-      return *this;
-    }
-
-    // Assign another `function` object to this object.
-    // Enable if the `function` object can be converted to the current object.
-    EMBED_DETAIL_TEMPLATE_BEGIN(
-      std::size_t OtherSize, typename OtherCfg, typename OtherSig)
-    EMBED_DETAIL_REQUIRES_END(
-      fn_can_convert<function, function<OtherSize, OtherCfg, OtherSig>>::value
-      && (!Config::isView) // OWNING
-    )
-    function& operator=(const function<OtherSize, OtherCfg, OtherSig>& other)
-    noexcept(is_cfg_noexcept<Config>::value && is_cfg_noexcept<OtherCfg>::value) {
-      function(other).swap(*this);
-      return *this;
-    }
-
-    // Assign another `function` object to this object.
-    // Enable if the `function` object can be converted to the current object.
-    EMBED_DETAIL_TEMPLATE_BEGIN(
-      std::size_t OtherSize, typename OtherCfg, typename OtherSig)
-    EMBED_DETAIL_REQUIRES_END(
-      fn_can_convert<function, function<OtherSize, OtherCfg, OtherSig>>::value
-      && Config::isView && OtherCfg::isView // NON-OWNING
-    )
-    function& operator=(const function<OtherSize, OtherCfg, OtherSig>& other) noexcept {
-      std::memcpy(&m_erasure, &other.m_erasure, default_buffer_size::ref_buf);
-      std::memcpy(&m_command, &other.m_command, sizeof(command_t));
-      return *this;
-    }
   };
 
   // `true` if the wrapper has no target, `false` otherwise. (noexcept)
@@ -3483,7 +3452,6 @@ namespace detail {
 #undef EMBED_DETAIL_FN_EXPAND
 #undef EMBED_DETAIL_FN_EXPAND_IMPL
 #undef EMBED_DETAIL_REQUIRES
-#undef EMBED_DETAIL_REQUIRES_IMPL
 #undef EMBED_DETAIL_FORCE_EBO
 #undef EMBED_DETAIL_VIRTUAL_INHERITANCE
 #undef EMBED_DETAIL_MOVE_FUNCTION

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2357,11 +2357,12 @@ namespace crtp_mixins {
       auto&& other = static_cast<Self&&>(other_raw);
       using command_t = typename Self::command_t;
 
-      // Clear and move from `other` to `self`.
-      self.clear();
-      if (!other.is_empty() && this != std::addressof(other)) {
+      if (this != std::addressof(other_raw)) {
+        self.m_command.destroy(&self.m_erasure);
+
         other.m_command.move(&self.m_erasure, &other.m_erasure);
         std::memcpy(&self.m_command, &other.m_command, sizeof(command_t));
+
         other.m_command.destroy(&other.m_erasure);
         other.m_command.set_empty();
       }
@@ -2388,9 +2389,16 @@ namespace crtp_mixins {
     }
 
     copy_impl& operator=(const copy_impl& other_raw) noexcept(Config::assertNoThrow) {
+      auto& self = static_cast<Self&>(*this);
       auto& other = static_cast<const Self&>(other_raw);
-      if (!other.is_empty() && this != std::addressof(other)) {
-        Self(other).swap(static_cast<Self&>(*this)); // TODO: avoid using `swap`.
+      using erasure_t = typename Self::erasure_t;
+      using command_t = typename Self::command_t;
+
+      if (this != std::addressof(other_raw)) {
+        self.m_command.destroy(&self.m_erasure);
+
+        other.m_command.clone(&self.m_erasure, const_cast<erasure_t*>(&other.m_erasure));
+        std::memcpy(&self.m_command, &other.m_command, sizeof(command_t));
       }
       return *this;
     }

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -26,6 +26,15 @@ struct empty_trivial_but_state {
   std::uintptr_t operator()() const { return reinterpret_cast<std::uintptr_t>(this); }
 };
 
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+
+struct Static_call_operator_test {
+  int operator()(int) const { return 0; }
+  static int operator()(long) { return 1; }
+};
+
+#endif
+
 TEST(Conformance_fn_ref, conformance_addition_pass) {
 
   {
@@ -204,6 +213,14 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     auto f2 = ebd::make_fn<ebd::fn_ref>(ebd_test_static_call_operator{});
     static_assert(std::is_same_v<decltype(f2), ebd::fn_ref<int(int, int) const noexcept>>, "BUG");
     ASSERT_EQ(f2(1, 42), 43);
+  }
+  {
+    // static call operator
+    Static_call_operator_test obj{};
+    ebd::fn_ref<int(long)> f = obj;
+    ASSERT_EQ(f(0), 1);
+    ebd::fn_ref<int(long) const> f1 = obj;
+    ASSERT_EQ(f1(0), 1);
   }
 #endif
 

--- a/test/test_AssignAndConvert.cpp
+++ b/test/test_AssignAndConvert.cpp
@@ -81,3 +81,46 @@ TEST(AssignAndConvert, ConstToNonConst) {
     f_non_const = f_const; // OK
     // f_const = f_non_const; // Error
 }
+
+// AssignAndConvert[5]
+TEST(AssignAndConvert, StatelessAssign) {
+    {
+        ebd::fn<bool(int, int)> f1 = std::less<int>{};
+        auto f2 = f1;
+        ASSERT_EQ(f1(1, 2), true);
+        ASSERT_EQ(f1(2, 1), false);
+        ASSERT_EQ(f2(1, 2), true);
+        ASSERT_EQ(f2(2, 1), false);
+        auto f3 = std::move(f2);
+        ASSERT_EQ(f3(1, 2), true);
+        ASSERT_EQ(f3(2, 1), false);
+    }
+    {
+        ebd::safe_fn<bool(int, int)> f1 = std::less<int>{};
+        auto f2 = f1;
+        ASSERT_EQ(f1(1, 2), true);
+        ASSERT_EQ(f1(2, 1), false);
+        ASSERT_EQ(f2(1, 2), true);
+        ASSERT_EQ(f2(2, 1), false);
+        auto f3 = std::move(f2);
+        ASSERT_EQ(f3(1, 2), true);
+        ASSERT_EQ(f3(2, 1), false);
+    }
+    {
+        ebd::fn_ref<bool(int, int)> f1 = std::less<int>{};
+        auto f2 = f1;
+        ASSERT_EQ(f1(1, 2), true);
+        ASSERT_EQ(f1(2, 1), false);
+        ASSERT_EQ(f2(1, 2), true);
+        ASSERT_EQ(f2(2, 1), false);
+        auto f3 = std::move(f2);
+        ASSERT_EQ(f3(1, 2), true);
+        ASSERT_EQ(f3(2, 1), false);
+    }
+    {
+        ebd::unique_fn<bool(int, int)> f1 = std::less<int>{};
+        auto f2 = std::move(f1);
+        ASSERT_EQ(f2(1, 2), true);
+        ASSERT_EQ(f2(2, 1), false);
+    }
+}

--- a/test/test_fallback_macros.hpp
+++ b/test/test_fallback_macros.hpp
@@ -15,6 +15,10 @@
 
 #endif // defined(EBD_TEST_USE_FALLBACK)
 
+#if defined(__GNUC__) && __GNUC__ >= 16
+# define EBD_TEST_TRY_BUG__GCC_106067
+#endif
+
 #if defined(__clang__) && __clang_major__ >= 22
 # define EBD_TEST_TRY_BUG__Clang_SameNameStaticFunction
 #endif


### PR DESCRIPTION
## Fixed

- No swap in copy assignment.

## Changed

- Rename `is_trivial_for_call` as `is_itanium_trivial_for_calls` and `is_reg_passable` as `is_register_passable`.
- Refactor `is_callable_from` and `is_invocable_using`.
- Add specialization for `is_register_passable` for Windows x64.
- Update README.md and make_fn.md.

## Added

- Add static call operator test.
- Add stateless assign test.

## Notes

- `std::constant_wrapper` support is experimental as of v2.1.6.
