### PR TITLE
Relax the constraint in the manager: use `is_trivially_copyable` instead of `is_trivial`.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2032,14 +2032,15 @@ namespace management {
 
     // Using when Config::isView == false.
     struct inplace {
-      // TODO: @performance @optimize @enhancement
-      // Maybe `is_traditional_trivial` is too restrictive.
-      // `is_itanium_trivial_for_calls` can be better?
-      // or just `is_trivially_copyable` ?
+      // The `manage` function only call the copy-Ctor, move-Ctor and Dtor, so
+      // a functor is trivial-for-manager if all of them are trivial. This
+      // requirement is the same as `is_itanium_trivial_for_calls`.
+      template <typename T>
+      using is_trivial_for_manager = is_itanium_trivial_for_calls<T>;
 
       // Using when the Functor is copyable and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!is_traditional_trivial<Functor>::value))
+        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!is_trivial_for_manager<Functor>::value))
       /* copyable */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2061,7 +2062,7 @@ namespace management {
 
       // Using when the Functor is move only and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!is_traditional_trivial<Functor>::value))
+        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!is_trivial_for_manager<Functor>::value))
       /* move-only */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2083,7 +2084,7 @@ namespace management {
 
       // Used when the Functor is trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END(is_traditional_trivial<Functor>::value)
+        EMBED_DETAIL_REQUIRES_END(is_trivial_for_manager<Functor>::value)
       /* trivial */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2032,11 +2032,11 @@ namespace management {
 
     // Using when Config::isView == false.
     struct inplace {
-      // The `manage` function only call the copy-Ctor, move-Ctor and Dtor, so
-      // a functor is trivial-for-manager if all of them are trivial. This
-      // requirement is the same as `is_itanium_trivial_for_calls`.
+      /// @attention [basic.types.general]
+      /// Only trivially copyable objects can be copied or moved by
+      /// `std::memcpy`; otherwise, this would be undefined behaviour.
       template <typename T>
-      using is_trivial_for_manager = is_itanium_trivial_for_calls<T>;
+      using is_trivial_for_manager = std::is_trivially_copyable<T>;
 
       // Using when the Functor is copyable and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2096,7 +2096,7 @@ namespace management {
           std::memcpy(
             const_cast<void*>(static_cast<erasure_t*>(dst)->access()),
             const_cast<const void*>(static_cast<erasure_t*>(src)->access()),
-            sizeof(erasure_t)
+            sizeof(Functor) // Copy the whole `m_erasure` is unnecessary.
           );
           break;
         case OperatorCode::destroy: /* Do nothing */ break;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2035,12 +2035,10 @@ namespace management {
       /// @attention [basic.types.general]
       /// Only trivially copyable objects can be copied or moved by
       /// `std::memcpy`; otherwise, this would be undefined behaviour.
-      template <typename T>
-      using is_trivial_for_manager = std::is_trivially_copyable<T>;
 
       // Using when the Functor is copyable and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!is_trivial_for_manager<Functor>::value))
+        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!std::is_trivially_copyable<Functor>::value))
       /* copyable */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2062,7 +2060,7 @@ namespace management {
 
       // Using when the Functor is move only and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!is_trivial_for_manager<Functor>::value))
+        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!std::is_trivially_copyable<Functor>::value))
       /* move-only */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2084,7 +2082,7 @@ namespace management {
 
       // Used when the Functor is trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END(is_trivial_for_manager<Functor>::value)
+        EMBED_DETAIL_REQUIRES_END(std::is_trivially_copyable<Functor>::value)
       /* trivial */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,


### PR DESCRIPTION
`is_itanium_trivial_for_calls` looks better, but it will lead to UB. [basic.types.general]