### PR TITLE
Version 2.1.7

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: benchmark
         shell: bash
         run: |
-          cmake --build build --config Release --target benchmark -j100
+          cmake --build build --config Release --target benchmark --parallel
           mkdir -p runtime
           cp build/runtime-report.md runtime
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,12 +31,12 @@ jobs:
         working-directory: benchmark
         run: |
           cmake -B build -S . \
-            -DCMAKE_CXX_STANDARD=14 \
+            -DCMAKE_CXX_STANDARD=23 \
             -DCMAKE_C_COMPILER=gcc-14 \
             -DCMAKE_CXX_COMPILER=g++-14
 
-      # Run tests
-      - name: Run tests with C++
+      # Run benchmark
+      - name: Run benchmark with C++
         working-directory: benchmark
         run: |
           cmake --build build --config Release --target benchmark -j$(nproc)
@@ -51,8 +51,47 @@ jobs:
       - name: Save the benchmark result
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark-reports
+          name: benchmark-ubuntu-gcc-reports
           path: |
             benchmark/runtime/runtime-report.md
             benchmark/compiletime/benchmark_report.md
+          retention-days: 60
+
+
+  # Windows check
+  benchmark-on-windows:
+    if: github.repository_owner == 'Kim-J-Smith'
+    runs-on: windows-2025-vs2026
+
+    steps:
+      # Get the code
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # Config CMake for compilers
+      - name: Config CMake
+        working-directory: benchmark
+        shell: bash
+        run: |
+          cmake -B build -S . \
+            -G "Visual Studio 18 2026" \
+            -A x64 \
+            -DCMAKE_CXX_STANDARD=23
+
+      # Run benchmark
+      - name: Run benchmark with C++
+        working-directory: benchmark
+        shell: bash
+        run: |
+          cmake --build build --config Release --target benchmark -j100
+          mkdir -p runtime
+          cp build/runtime-report.md runtime
+
+      # Output the report
+      - name: Save the benchmark result
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-windows-vs2026-reports
+          path: |
+            benchmark/runtime/runtime-report.md
           retention-days: 60

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.1.6 LANGUAGES CXX)
+project(embedded_function VERSION 2.1.7 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.1.6-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.6">
+  <img src="https://img.shields.io/badge/Version-2.1.7-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.7">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23">
 </p>

--- a/benchmark/runtime/benchmark_assignment.cpp
+++ b/benchmark/runtime/benchmark_assignment.cpp
@@ -1,0 +1,605 @@
+#include "benchmark.hpp"
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <array>
+#include <utility>
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.CopyAssignment - Small Trivial Lambda
+// ----------------------------------------------------------------------------
+
+static void copy_assign_small_trivial_std(picobench::state& s) {
+    auto a1 = std::function<int(int)>([](int x) { return x + 1; });
+    auto a2 = std::function<int(int)>([](int x) { return x + 2; });
+    auto b = std::function<int(int)>();
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void copy_assign_small_trivial_ebd(picobench::state& s) {
+    auto a1 = ebd::fn<int(int)>([](int x) { return x + 1; });
+    auto a2 = ebd::fn<int(int)>([](int x) { return x + 2; });
+    auto b = ebd::fn<int(int)>();
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void copy_assign_small_trivial_fu2(picobench::state& s) {
+    auto a1 = fu2::function<int(int)>([](int x) { return x + 1; });
+    auto a2 = fu2::function<int(int)>([](int x) { return x + 2; });
+    auto b = fu2::function<int(int)>();
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentSmallTrivial);
+BENCHMARK_BASELINE(copy_assign_small_trivial_std);
+BENCHMARK_NOTBASE(copy_assign_small_trivial_ebd);
+BENCHMARK_NOTBASE(copy_assign_small_trivial_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.MoveAssignment - Small Trivial Lambda
+// ----------------------------------------------------------------------------
+
+static void move_assign_small_trivial_std(picobench::state& s) {
+    auto b = std::function<int(int)>();
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = std::function<int(int)>([](int x) { return x + 1; });
+        auto a2 = std::function<int(int)>([](int x) { return x + 2; });
+        b = std::move(toggle ? a1 : a2);
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void move_assign_small_trivial_ebd(picobench::state& s) {
+    auto b = ebd::fn<int(int)>();
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = ebd::fn<int(int)>([](int x) { return x + 1; });
+        auto a2 = ebd::fn<int(int)>([](int x) { return x + 2; });
+        b = std::move(toggle ? a1 : a2);
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void move_assign_small_trivial_fu2(picobench::state& s) {
+    auto b = fu2::function<int(int)>();
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = fu2::function<int(int)>([](int x) { return x + 1; });
+        auto a2 = fu2::function<int(int)>([](int x) { return x + 2; });
+        b = std::move(toggle ? a1 : a2);
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentSmallTrivial);
+BENCHMARK_BASELINE(move_assign_small_trivial_std);
+BENCHMARK_NOTBASE(move_assign_small_trivial_ebd);
+BENCHMARK_NOTBASE(move_assign_small_trivial_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.CopyAssignment - Large Capture Lambda
+// ----------------------------------------------------------------------------
+
+struct LargeCaptureData {
+    std::string str;
+    std::array<int, 1> numbers{};
+    
+    LargeCaptureData() : str("Benchmark test string for assignment performance testing") {}
+};
+
+static void copy_assign_large_capture_std(picobench::state& s) {
+    LargeCaptureData data1, data2;
+    auto a1 = std::function<size_t()>([data1]() { return data1.numbers.size() + data1.str.size(); });
+    auto a2 = std::function<size_t()>([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+    auto b = std::function<size_t()>();
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        auto* volatile ff = &b;
+        volatile size_t u = (*ff)(); (void)u;
+    }
+}
+
+// BUG
+static void copy_assign_large_capture_ebd(picobench::state& s) {
+    LargeCaptureData data1, data2;
+    auto a1 = ebd::make_fn([data1]() { return data1.numbers.size() + data1.str.size(); });
+    auto a2 = ebd::make_fn([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+    decltype(a1) b;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        auto* volatile ff = &b;
+        volatile size_t u = (*ff)(); (void)u;
+    }
+}
+
+static void copy_assign_large_capture_fu2(picobench::state& s) {
+    LargeCaptureData data1, data2;
+    auto a1 = fu2::function<size_t()>([data1]() { return data1.numbers.size() + data1.str.size(); });
+    auto a2 = fu2::function<size_t()>([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+    auto b = fu2::function<size_t()>();
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        auto* volatile ff = &b;
+        volatile size_t u = (*ff)(); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentLargeCapture);
+BENCHMARK_BASELINE(copy_assign_large_capture_std);
+BENCHMARK_NOTBASE(copy_assign_large_capture_ebd);
+BENCHMARK_NOTBASE(copy_assign_large_capture_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.MoveAssignment - Large Capture Lambda
+// ----------------------------------------------------------------------------
+
+static void move_assign_large_capture_std(picobench::state& s) {
+    auto b = std::function<size_t()>();
+    size_t total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        LargeCaptureData data1, data2;
+        auto a1 = std::function<size_t()>([data1]() { return data1.numbers.size() + data1.str.size(); });
+        auto a2 = std::function<size_t()>([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+        b = std::move(toggle ? a1 : a2);
+        total += b();
+        auto* volatile ff = &b;
+        volatile size_t u = (*ff)(); (void)u;
+        (void)total;
+    }
+}
+
+static void move_assign_large_capture_ebd(picobench::state& s) {
+    LargeCaptureData dummy_data;
+    auto dummy = ebd::make_fn([dummy_data]() { return dummy_data.numbers.size(); });
+    decltype(dummy) b;
+    size_t total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        LargeCaptureData data1, data2;
+        auto a1 = ebd::make_fn([data1]() { return data1.numbers.size() + data1.str.size(); });
+        auto a2 = ebd::make_fn([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+        b = std::move(toggle ? a1 : a2);
+        total += b();
+        auto* volatile ff = &b;
+        volatile size_t u = (*ff)(); (void)u;
+        (void)total;
+    }
+}
+
+static void move_assign_large_capture_fu2(picobench::state& s) {
+    auto b = fu2::function<size_t()>();
+    size_t total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        LargeCaptureData data1, data2;
+        auto a1 = fu2::function<size_t()>([data1]() { return data1.numbers.size() + data1.str.size(); });
+        auto a2 = fu2::function<size_t()>([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+        b = std::move(toggle ? a1 : a2);
+        total += b();
+        auto* volatile ff = &b;
+        volatile size_t u = (*ff)(); (void)u;
+        (void)total;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentLargeCapture);
+BENCHMARK_BASELINE(move_assign_large_capture_std);
+BENCHMARK_NOTBASE(move_assign_large_capture_ebd);
+BENCHMARK_NOTBASE(move_assign_large_capture_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.CopyAssignment - Stateless Lambda (Small Buffer Optimization)
+// ----------------------------------------------------------------------------
+
+static void copy_assign_stateless_std(picobench::state& s) {
+    auto a1 = std::function<int(int, int)>(std::plus<int>{});
+    auto a2 = std::function<int(int, int)>(std::minus<int>{});
+    auto b = std::function<int(int, int)>();
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        total = b(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(total, 1); (void)u;
+    }
+}
+
+static void copy_assign_stateless_ebd(picobench::state& s) {
+    auto a1 = ebd::fn<int(int, int)>(std::plus<int>{});
+    auto a2 = ebd::fn<int(int, int)>(std::minus<int>{});
+    auto b = ebd::fn<int(int, int)>();
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        total = b(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(total, 1); (void)u;
+    }
+}
+
+static void copy_assign_stateless_fu2(picobench::state& s) {
+    auto a1 = fu2::function<int(int, int)>(std::plus<int>{});
+    auto a2 = fu2::function<int(int, int)>(std::minus<int>{});
+    auto b = fu2::function<int(int, int)>();
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        total = b(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(total, 1); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentStateless);
+BENCHMARK_BASELINE(copy_assign_stateless_std);
+BENCHMARK_NOTBASE(copy_assign_stateless_ebd);
+BENCHMARK_NOTBASE(copy_assign_stateless_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.MoveAssignment - Stateless Lambda (Small Buffer Optimization)
+// ----------------------------------------------------------------------------
+
+static void move_assign_stateless_std(picobench::state& s) {
+    auto b = std::function<int(int, int)>();
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = std::function<int(int, int)>(std::plus<int>{});
+        auto a2 = std::function<int(int, int)>(std::minus<int>{});
+        b = std::move(toggle ? a1 : a2);
+        total = b(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(total, 1); (void)u;
+    }
+}
+
+static void move_assign_stateless_ebd(picobench::state& s) {
+    auto b = ebd::fn<int(int, int)>();
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = ebd::fn<int(int, int)>(std::plus<int>{});
+        auto a2 = ebd::fn<int(int, int)>(std::minus<int>{});
+        b = std::move(toggle ? a1 : a2);
+        total = b(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(total, 1); (void)u;
+    }
+}
+
+static void move_assign_stateless_fu2(picobench::state& s) {
+    auto b = fu2::function<int(int, int)>();
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = fu2::function<int(int, int)>(std::plus<int>{});
+        auto a2 = fu2::function<int(int, int)>(std::minus<int>{});
+        b = std::move(toggle ? a1 : a2);
+        total = b(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(total, 1); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentStateless);
+BENCHMARK_BASELINE(move_assign_stateless_std);
+BENCHMARK_NOTBASE(move_assign_stateless_ebd);
+BENCHMARK_NOTBASE(move_assign_stateless_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.CopyAssignment - Function Pointer
+// ----------------------------------------------------------------------------
+
+static int bench_func1(int x) { return x * 2; }
+static int bench_func2(int x) { return x * 3; }
+
+static void copy_assign_func_ptr_std(picobench::state& s) {
+    auto a1 = std::function<int(int)>(bench_func1);
+    auto a2 = std::function<int(int)>(bench_func2);
+    auto b = std::function<int(int)>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void copy_assign_func_ptr_ebd(picobench::state& s) {
+    auto a1 = ebd::fn<int(int)>(bench_func1);
+    auto a2 = ebd::fn<int(int)>(bench_func2);
+    auto b = ebd::fn<int(int)>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void copy_assign_func_ptr_fu2(picobench::state& s) {
+    auto a1 = fu2::function<int(int)>(bench_func1);
+    auto a2 = fu2::function<int(int)>(bench_func2);
+    auto b = fu2::function<int(int)>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentFuncPtr);
+BENCHMARK_BASELINE(copy_assign_func_ptr_std);
+BENCHMARK_NOTBASE(copy_assign_func_ptr_ebd);
+BENCHMARK_NOTBASE(copy_assign_func_ptr_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.MoveAssignment - Function Pointer
+// ----------------------------------------------------------------------------
+
+static void move_assign_func_ptr_std(picobench::state& s) {
+    auto b = std::function<int(int)>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = std::function<int(int)>(bench_func1);
+        auto a2 = std::function<int(int)>(bench_func2);
+        b = std::move(toggle ? a1 : a2);
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void move_assign_func_ptr_ebd(picobench::state& s) {
+    auto b = ebd::fn<int(int)>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = ebd::fn<int(int)>(bench_func1);
+        auto a2 = ebd::fn<int(int)>(bench_func2);
+        b = std::move(toggle ? a1 : a2);
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+static void move_assign_func_ptr_fu2(picobench::state& s) {
+    auto b = fu2::function<int(int)>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = fu2::function<int(int)>(bench_func1);
+        auto a2 = fu2::function<int(int)>(bench_func2);
+        b = std::move(toggle ? a1 : a2);
+        result = b(result);
+        auto* volatile ff = &b;
+        volatile int u = (*ff)(result); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentFuncPtr);
+BENCHMARK_BASELINE(move_assign_func_ptr_std);
+BENCHMARK_NOTBASE(move_assign_func_ptr_ebd);
+BENCHMARK_NOTBASE(move_assign_func_ptr_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.CopyAssignment - Between Same Type
+// ----------------------------------------------------------------------------
+
+static void copy_assign_same_type_std(picobench::state& s) {
+    auto a1 = std::function<void()>([]() {});
+    auto a2 = std::function<void()>([]() {});
+    auto b = std::function<void()>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        b();
+        dummy++;
+        auto* volatile ff = &b;
+        (*ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
+static void copy_assign_same_type_ebd(picobench::state& s) {
+    auto a1 = ebd::fn<void()>([]() {});
+    auto a2 = ebd::fn<void()>([]() {});
+    auto b = ebd::fn<void()>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        b();
+        dummy++;
+        auto* volatile ff = &b;
+        (*ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
+static void copy_assign_same_type_fu2(picobench::state& s) {
+    auto a1 = fu2::function<void()>([]() {});
+    auto a2 = fu2::function<void()>([]() {});
+    auto b = fu2::function<void()>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        b();
+        dummy++;
+        auto* volatile ff = &b;
+        (*ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentSameType);
+BENCHMARK_BASELINE(copy_assign_same_type_std);
+BENCHMARK_NOTBASE(copy_assign_same_type_ebd);
+BENCHMARK_NOTBASE(copy_assign_same_type_fu2);
+
+// ----------------------------------------------------------------------------
+// AssignmentBenchmark.MoveAssignment - Between Same Type
+// ----------------------------------------------------------------------------
+
+static void move_assign_same_type_std(picobench::state& s) {
+    auto b = std::function<void()>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = std::function<void()>([]() {});
+        auto a2 = std::function<void()>([]() {});
+        b = std::move(toggle ? a1 : a2);
+        b();
+        dummy++;
+        auto* volatile ff = &b;
+        (*ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
+static void move_assign_same_type_ebd(picobench::state& s) {
+    auto b = ebd::fn<void()>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = ebd::fn<void()>([]() {});
+        auto a2 = ebd::fn<void()>([]() {});
+        b = std::move(toggle ? a1 : a2);
+        b();
+        dummy++;
+        auto* volatile ff = &b;
+        (*ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
+static void move_assign_same_type_fu2(picobench::state& s) {
+    auto b = fu2::function<void()>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = fu2::function<void()>([]() {});
+        auto a2 = fu2::function<void()>([]() {});
+        b = std::move(toggle ? a1 : a2);
+        b();
+        dummy++;
+        auto* volatile ff = &b;
+        (*ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
+BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentSameType);
+BENCHMARK_BASELINE(move_assign_same_type_std);
+BENCHMARK_NOTBASE(move_assign_same_type_ebd);
+BENCHMARK_NOTBASE(move_assign_same_type_fu2);

--- a/benchmark/runtime/benchmark_create.cpp
+++ b/benchmark/runtime/benchmark_create.cpp
@@ -1,0 +1,96 @@
+#include "benchmark.hpp"
+
+// ----------------------------------------------------------------------------
+// CreateBenchmark.CaptureLambda
+// ----------------------------------------------------------------------------
+
+static void lambda_std(picobench::state& s) {
+    int a = 0;
+
+    for (auto _ : s) {
+        a++;
+        std::function<int()> f = [a]() -> int { return a; };
+        auto* volatile ff = &f;
+        volatile int u = (*ff)(); (void)u;
+    }
+}
+
+static void lambda_ebd(picobench::state& s) {
+    int a = 0;
+
+    for (auto _ : s) {
+        a++;
+        ebd::fn<int()> f = [a]() -> int { return a; };
+        auto* volatile ff = &f;
+        volatile int u = (*ff)(); (void)u;
+    }
+}
+
+static void lambda_fu2(picobench::state& s) {
+    int a = 0;
+
+    for (auto _ : s) {
+        a++;
+        fu2::function<int()> f = [a]() -> int { return a; };
+        auto* volatile ff = &f;
+        volatile int u = (*ff)(); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(CreateBenchmark.CaptureLambda);
+BENCHMARK_BASELINE(lambda_std);
+BENCHMARK_NOTBASE(lambda_ebd);
+BENCHMARK_NOTBASE(lambda_fu2);
+
+
+// ----------------------------------------------------------------------------
+// CreateBenchmark.NonTrivialFunctor
+// ----------------------------------------------------------------------------
+
+struct NonTrivialFunctor
+{
+    int a;
+    NonTrivialFunctor(int a) : a(a) {}
+    NonTrivialFunctor(const NonTrivialFunctor&) {}
+
+    int operator()() { return a; }
+};
+
+
+static void non_trivial_functor_std(picobench::state& s) {
+    int a = 0;
+
+    for (auto _ : s) {
+        a++;
+        std::function<int()> f = NonTrivialFunctor{a};
+        auto* volatile ff = &f;
+        volatile int u = (*ff)(); (void)u;
+    }
+}
+
+static void non_trivial_functor_ebd(picobench::state& s) {
+    int a = 0;
+
+    for (auto _ : s) {
+        a++;
+        ebd::fn<int()> f = NonTrivialFunctor{a};
+        auto* volatile ff = &f;
+        volatile int u = (*ff)(); (void)u;
+    }
+}
+
+static void non_trivial_functor_fu2(picobench::state& s) {
+    int a = 0;
+
+    for (auto _ : s) {
+        a++;
+        fu2::function<int()> f = NonTrivialFunctor{a};
+        auto* volatile ff = &f;
+        volatile int u = (*ff)(); (void)u;
+    }
+}
+
+BENCHMARK_UNIT(CreateBenchmark.NonTrivialFunctor);
+BENCHMARK_BASELINE(non_trivial_functor_std);
+BENCHMARK_NOTBASE(non_trivial_functor_ebd);
+BENCHMARK_NOTBASE(non_trivial_functor_fu2);

--- a/benchmark/runtime/benchmark_move_only_function.cpp
+++ b/benchmark/runtime/benchmark_move_only_function.cpp
@@ -112,7 +112,7 @@ static void multi_trivial_params_std(picobench::state& s) {
                                   benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
         [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
            benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
-            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; 
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; (void)unused;
         };
     benchmark_call_trivial_struct obj{};
 
@@ -126,7 +126,7 @@ static void multi_trivial_params_ebd(picobench::state& s) {
                          benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
         [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
            benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
-            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; 
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; (void)unused;
         };
     benchmark_call_trivial_struct obj{};
 
@@ -140,7 +140,7 @@ static void multi_trivial_params_fu2(picobench::state& s) {
                               benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
         [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
            benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
-            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; 
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; (void)unused;
         };
     benchmark_call_trivial_struct obj{};
 

--- a/benchmark/runtime/benchmark_move_only_function.cpp
+++ b/benchmark/runtime/benchmark_move_only_function.cpp
@@ -1,0 +1,583 @@
+#include "benchmark.hpp"
+
+#include <string>
+#include <vector>
+#include <array>
+
+// ----------------------------------------------------------------------------
+// MoveOnlyFunction Parameter Types Test Suite
+// ----------------------------------------------------------------------------
+
+#if __cpp_lib_move_only_function >= 202110L
+
+// ----------------------------------------------------------------------------
+// Test 1: Basic Scalar Types (int, double, pointers)
+// ----------------------------------------------------------------------------
+
+static void scalar_params_std(picobench::state& s) {
+    std::move_only_function<void(int, double, void*)> fn = 
+        [](int a, double b, void* c) { 
+            volatile int res = a + static_cast<int>(b);
+            (void)c; (void)res; 
+        };
+
+    for (auto _ : s) {
+        fn(42, 3.14, nullptr);
+    }
+}
+
+static void scalar_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(int, double, void*)> fn = 
+        [](int a, double b, void* c) { 
+            volatile int res = a + static_cast<int>(b);
+            (void)c; (void)res; 
+        };
+
+    for (auto _ : s) {
+        fn(42, 3.14, nullptr);
+    }
+}
+
+static void scalar_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(int, double, void*)> fn = 
+        [](int a, double b, void* c) { 
+            volatile int res = a + static_cast<int>(b);
+            (void)c; (void)res; 
+        };
+
+    for (auto _ : s) {
+        fn(42, 3.14, nullptr);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.Scalar);
+BENCHMARK_BASELINE(scalar_params_std);
+BENCHMARK_NOTBASE(scalar_params_ebd);
+BENCHMARK_NOTBASE(scalar_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 2: Small Trivial Struct (register-passable candidate)
+// ----------------------------------------------------------------------------
+
+static void small_trivial_params_std(picobench::state& s) {
+    std::move_only_function<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn = 
+        [](benchmark_trivial_struct a, benchmark_trivial_struct b) { 
+            volatile void* res = a.pod;
+            (void)b; (void)res; 
+        };
+    benchmark_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj, obj);
+    }
+}
+
+static void small_trivial_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn = 
+        [](benchmark_trivial_struct a, benchmark_trivial_struct b) { 
+            volatile void* res = a.pod;
+            (void)b; (void)res; 
+        };
+    benchmark_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj, obj);
+    }
+}
+
+static void small_trivial_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn = 
+        [](benchmark_trivial_struct a, benchmark_trivial_struct b) { 
+            volatile void* res = a.pod;
+            (void)b; (void)res; 
+        };
+    benchmark_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj, obj);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.SmallTrivial);
+BENCHMARK_BASELINE(small_trivial_params_std);
+BENCHMARK_NOTBASE(small_trivial_params_ebd);
+BENCHMARK_NOTBASE(small_trivial_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 3: Multiple Trivial Params (4 params)
+// ----------------------------------------------------------------------------
+
+static void multi_trivial_params_std(picobench::state& s) {
+    std::move_only_function<void(benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+                                  benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
+        [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
+           benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; 
+        };
+    benchmark_call_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj, obj, obj, obj);
+    }
+}
+
+static void multi_trivial_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+                         benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
+        [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
+           benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; 
+        };
+    benchmark_call_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj, obj, obj, obj);
+    }
+}
+
+static void multi_trivial_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+                              benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
+        [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
+           benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; 
+        };
+    benchmark_call_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj, obj, obj, obj);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.MultiTrivial);
+BENCHMARK_BASELINE(multi_trivial_params_std);
+BENCHMARK_NOTBASE(multi_trivial_params_ebd);
+BENCHMARK_NOTBASE(multi_trivial_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 4: Large Trivial Struct (not register-passable)
+// ----------------------------------------------------------------------------
+
+static void large_trivial_params_std(picobench::state& s) {
+    std::move_only_function<void(benchmark_huge_trivial_struct)> fn = 
+        [](benchmark_huge_trivial_struct a) { 
+            volatile char c = a.huge[0];
+            (void)c; 
+        };
+    benchmark_huge_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj);
+    }
+}
+
+static void large_trivial_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(benchmark_huge_trivial_struct)> fn = 
+        [](benchmark_huge_trivial_struct a) { 
+            volatile char c = a.huge[0];
+            (void)c; 
+        };
+    benchmark_huge_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj);
+    }
+}
+
+static void large_trivial_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(benchmark_huge_trivial_struct)> fn = 
+        [](benchmark_huge_trivial_struct a) { 
+            volatile char c = a.huge[0];
+            (void)c; 
+        };
+    benchmark_huge_trivial_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.LargeTrivial);
+BENCHMARK_BASELINE(large_trivial_params_std);
+BENCHMARK_NOTBASE(large_trivial_params_ebd);
+BENCHMARK_NOTBASE(large_trivial_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 5: std::string Parameter
+// ----------------------------------------------------------------------------
+
+static void string_params_std(picobench::state& s) {
+    std::move_only_function<void(const std::string&)> fn = 
+        [](const std::string& str) { 
+            volatile size_t len = str.size();
+            (void)len; 
+        };
+    std::string test_str = "Hello, World! This is a test string for benchmarking.";
+
+    for (auto _ : s) {
+        fn(test_str);
+    }
+}
+
+static void string_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(const std::string&)> fn = 
+        [](const std::string& str) { 
+            volatile size_t len = str.size();
+            (void)len; 
+        };
+    std::string test_str = "Hello, World! This is a test string for benchmarking.";
+
+    for (auto _ : s) {
+        fn(test_str);
+    }
+}
+
+static void string_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(const std::string&)> fn = 
+        [](const std::string& str) { 
+            volatile size_t len = str.size();
+            (void)len; 
+        };
+    std::string test_str = "Hello, World! This is a test string for benchmarking.";
+
+    for (auto _ : s) {
+        fn(test_str);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.String);
+BENCHMARK_BASELINE(string_params_std);
+BENCHMARK_NOTBASE(string_params_ebd);
+BENCHMARK_NOTBASE(string_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 6: Mixed Parameter Types (scalar + trivial + non-trivial)
+// ----------------------------------------------------------------------------
+
+static void mixed_params_std(picobench::state& s) {
+    std::move_only_function<void(int, benchmark_trivial_struct, const std::vector<int>&)> fn = 
+        [](int a, benchmark_trivial_struct b, const std::vector<int>& c) { 
+            volatile int res = a + static_cast<int>(c.size());
+            (void)b; (void)res; 
+        };
+    benchmark_trivial_struct obj{};
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+
+    for (auto _ : s) {
+        fn(42, obj, vec);
+    }
+}
+
+static void mixed_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(int, benchmark_trivial_struct, const std::vector<int>&)> fn = 
+        [](int a, benchmark_trivial_struct b, const std::vector<int>& c) { 
+            volatile int res = a + static_cast<int>(c.size());
+            (void)b; (void)res; 
+        };
+    benchmark_trivial_struct obj{};
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+
+    for (auto _ : s) {
+        fn(42, obj, vec);
+    }
+}
+
+static void mixed_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(int, benchmark_trivial_struct, const std::vector<int>&)> fn = 
+        [](int a, benchmark_trivial_struct b, const std::vector<int>& c) { 
+            volatile int res = a + static_cast<int>(c.size());
+            (void)b; (void)res; 
+        };
+    benchmark_trivial_struct obj{};
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+
+    for (auto _ : s) {
+        fn(42, obj, vec);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.Mixed);
+BENCHMARK_BASELINE(mixed_params_std);
+BENCHMARK_NOTBASE(mixed_params_ebd);
+BENCHMARK_NOTBASE(mixed_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 7: Return Value (int)
+// ----------------------------------------------------------------------------
+
+static void return_int_std(picobench::state& s) {
+    std::move_only_function<int(int, int)> fn = 
+        [](int a, int b) { return a + b; };
+
+    for (auto _ : s) {
+        volatile int res = fn(100, 200);
+        (void)res;
+    }
+}
+
+static void return_int_ebd(picobench::state& s) {
+    ebd::unique_fn<int(int, int)> fn = 
+        [](int a, int b) { return a + b; };
+
+    for (auto _ : s) {
+        volatile int res = fn(100, 200);
+        (void)res;
+    }
+}
+
+static void return_int_fu2(picobench::state& s) {
+    fu2::unique_function<int(int, int)> fn = 
+        [](int a, int b) { return a + b; };
+
+    for (auto _ : s) {
+        volatile int res = fn(100, 200);
+        (void)res;
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Return.Int);
+BENCHMARK_BASELINE(return_int_std);
+BENCHMARK_NOTBASE(return_int_ebd);
+BENCHMARK_NOTBASE(return_int_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 8: Return Struct (by value)
+// ----------------------------------------------------------------------------
+
+struct return_struct {
+    int a;
+    double b;
+    char c[16];
+};
+
+static void return_struct_std(picobench::state& s) {
+    std::move_only_function<return_struct(int, double)> fn = 
+        [](int x, double y) { 
+            return_struct r{};
+            r.a = x;
+            r.b = y;
+            return r; 
+        };
+
+    for (auto _ : s) {
+        volatile return_struct res = fn(42, 3.14);
+        (void)res;
+    }
+}
+
+static void return_struct_ebd(picobench::state& s) {
+    ebd::unique_fn<return_struct(int, double)> fn = 
+        [](int x, double y) { 
+            return_struct r{};
+            r.a = x;
+            r.b = y;
+            return r; 
+        };
+
+    for (auto _ : s) {
+        volatile return_struct res = fn(42, 3.14);
+        (void)res;
+    }
+}
+
+static void return_struct_fu2(picobench::state& s) {
+    fu2::unique_function<return_struct(int, double)> fn = 
+        [](int x, double y) { 
+            return_struct r{};
+            r.a = x;
+            r.b = y;
+            return r; 
+        };
+
+    for (auto _ : s) {
+        volatile return_struct res = fn(42, 3.14);
+        (void)res;
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Return.Struct);
+BENCHMARK_BASELINE(return_struct_std);
+BENCHMARK_NOTBASE(return_struct_ebd);
+BENCHMARK_NOTBASE(return_struct_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 9: std::array Params (fixed size)
+// ----------------------------------------------------------------------------
+
+static void array_params_std(picobench::state& s) {
+    std::move_only_function<void(std::array<int, 4>)> fn = 
+        [](std::array<int, 4> arr) { 
+            volatile int sum = arr[0] + arr[1] + arr[2] + arr[3];
+            (void)sum; 
+        };
+    std::array<int, 4> arr = {1, 2, 3, 4};
+
+    for (auto _ : s) {
+        fn(arr);
+    }
+}
+
+static void array_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(std::array<int, 4>)> fn = 
+        [](std::array<int, 4> arr) { 
+            volatile int sum = arr[0] + arr[1] + arr[2] + arr[3];
+            (void)sum; 
+        };
+    std::array<int, 4> arr = {1, 2, 3, 4};
+
+    for (auto _ : s) {
+        fn(arr);
+    }
+}
+
+static void array_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(std::array<int, 4>)> fn = 
+        [](std::array<int, 4> arr) { 
+            volatile int sum = arr[0] + arr[1] + arr[2] + arr[3];
+            (void)sum; 
+        };
+    std::array<int, 4> arr = {1, 2, 3, 4};
+
+    for (auto _ : s) {
+        fn(arr);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.Array);
+BENCHMARK_BASELINE(array_params_std);
+BENCHMARK_NOTBASE(array_params_ebd);
+BENCHMARK_NOTBASE(array_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 10: Copy Hard Struct (non-trivial)
+// ----------------------------------------------------------------------------
+
+static void copy_hard_params_std(picobench::state& s) {
+    std::move_only_function<void(benchmark_copy_hard_struct)> fn = 
+        [](benchmark_copy_hard_struct a) { 
+            volatile int dummy = 0;
+            (void)a; (void)dummy; 
+        };
+    benchmark_copy_hard_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj);
+    }
+}
+
+static void copy_hard_params_ebd(picobench::state& s) {
+    ebd::unique_fn<void(benchmark_copy_hard_struct)> fn = 
+        [](benchmark_copy_hard_struct a) { 
+            volatile int dummy = 0;
+            (void)a; (void)dummy; 
+        };
+    benchmark_copy_hard_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj);
+    }
+}
+
+static void copy_hard_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(benchmark_copy_hard_struct)> fn = 
+        [](benchmark_copy_hard_struct a) { 
+            volatile int dummy = 0;
+            (void)a; (void)dummy; 
+        };
+    benchmark_copy_hard_struct obj{};
+
+    for (auto _ : s) {
+        fn(obj);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.CopyHard);
+BENCHMARK_BASELINE(copy_hard_params_std);
+BENCHMARK_NOTBASE(copy_hard_params_ebd);
+BENCHMARK_NOTBASE(copy_hard_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 11: Noexcept Qualified Function
+// ----------------------------------------------------------------------------
+
+static void noexcept_params_std(picobench::state& s) {
+    std::move_only_function<void(int, double) noexcept> fn = 
+        [](int a, double b) noexcept { 
+            volatile int res = a + static_cast<int>(b);
+            (void)res; 
+        };
+
+    for (auto _ : s) {
+        fn(42, 3.14);
+    }
+}
+
+static void noexcept_params_ebd(picobench::state& s) {
+    ebd::basic_fn<void(int, double) noexcept, 2*sizeof(void*), false, false, false, false> fn = 
+        [](int a, double b) noexcept { 
+            volatile int res = a + static_cast<int>(b);
+            (void)res; 
+        };
+
+    for (auto _ : s) {
+        fn(42, 3.14);
+    }
+}
+
+static void noexcept_params_fu2(picobench::state& s) {
+    fu2::unique_function<void(int, double) noexcept> fn = 
+        [](int a, double b) noexcept { 
+            volatile int res = a + static_cast<int>(b);
+            (void)res; 
+        };
+
+    for (auto _ : s) {
+        fn(42, 3.14);
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.Noexcept);
+BENCHMARK_BASELINE(noexcept_params_std);
+BENCHMARK_NOTBASE(noexcept_params_ebd);
+BENCHMARK_NOTBASE(noexcept_params_fu2);
+
+// ----------------------------------------------------------------------------
+// Test 12: Const Qualified Function
+// ----------------------------------------------------------------------------
+
+static void const_params_std(picobench::state& s) {
+    std::move_only_function<int(int, int) const> fn = 
+        [](int a, int b) { return a * b; };
+
+    for (auto _ : s) {
+        volatile int res = fn(10, 20);
+        (void)res;
+    }
+}
+
+static void const_params_ebd(picobench::state& s) {
+    ebd::unique_fn<int(int, int) const> fn = 
+        [](int a, int b) { return a * b; };
+
+    for (auto _ : s) {
+        volatile int res = fn(10, 20);
+        (void)res;
+    }
+}
+
+static void const_params_fu2(picobench::state& s) {
+    fu2::unique_function<int(int, int) const> fn = 
+        [](int a, int b) { return a * b; };
+
+    for (auto _ : s) {
+        volatile int res = fn(10, 20);
+        (void)res;
+    }
+}
+
+BENCHMARK_UNIT(MoveOnlyFunction.Params.Const);
+BENCHMARK_BASELINE(const_params_std);
+BENCHMARK_NOTBASE(const_params_ebd);
+BENCHMARK_NOTBASE(const_params_fu2);
+
+#endif

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -9,7 +9,7 @@
 - Improved static assertion messages for `make_fn()` and function signatures – they now provide more actionable hints when template deduction fails (#69).
 - Relaxed internal manager constraints: `std::is_trivially_copyable` is now used instead of a more restrictive "traditional trivial" check, allowing a wider set of functors to be stored in‑place (#70).
 - Refactored the type‑erasure invoker to remove unnecessary cv‑qualifiers and `const_cast` calls, simplifying the codebase without changing public behavior (#71).
-- Cleaned up macro formatting and added `!defined(__clang__)` guards for MSVC‑specific code paths (#72).
+- Cleaned up macro formatting and added `!defined(__clang__)` guards for MSVC‑specific code paths.
 
 ## Added
 

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,19 +1,23 @@
 ## Fixed
 
-- No swap in copy assignment.
+- Fixed a double‑free bug in copy and move assignment operators for `ebd::fn`, `ebd::unique_fn`, and `ebd::safe_fn` (#75, #76).
+- Added a dedicated lifetime test suite to prevent regressions.
 
 ## Changed
 
-- Rename `is_trivial_for_call` as `is_itanium_trivial_for_calls` and `is_reg_passable` as `is_register_passable`.
-- Refactor `is_callable_from` and `is_invocable_using`.
-- Add specialization for `is_register_passable` for Windows x64.
-- Update README.md and make_fn.md.
+- Updated experimental `std::constant_wrapper` support to conform to P4206R0, which reverts the string support introduced in earlier drafts (#68).
+- Improved static assertion messages for `make_fn()` and function signatures – they now provide more actionable hints when template deduction fails (#69).
+- Relaxed internal manager constraints: `std::is_trivially_copyable` is now used instead of a more restrictive "traditional trivial" check, allowing a wider set of functors to be stored in‑place (#70).
+- Refactored the type‑erasure invoker to remove unnecessary cv‑qualifiers and `const_cast` calls, simplifying the codebase without changing public behavior (#71).
+- Cleaned up macro formatting and added `!defined(__clang__)` guards for MSVC‑specific code paths (#72).
 
 ## Added
 
-- Add static call operator test.
-- Add stateless assign test.
+- Added a comprehensive set of runtime benchmarks covering creation, copy/move assignment, and various parameter types for `ebd::fn`, `std::function`, `fu2::function`, and `std::move_only_function` (#73, #77).
+- Introduced nullability annotations (`_Nonnull`/`_Notnull_`) on the `fn_ref` constructor from function pointers to aid static analysis (#69).
+- Enabled Windows CI for the benchmark suite (#73).
 
 ## Notes
 
-- `std::constant_wrapper` support is experimental as of v2.1.6.
+- `std::constant_wrapper` support is experimental as of v2.1.7.
+- The experimental `constant_wrapper` support has been updated to align with P4206R0, removing the previously available string support. Users who were experimenting with that feature may need to adjust their code.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2032,14 +2032,13 @@ namespace management {
 
     // Using when Config::isView == false.
     struct inplace {
-      // TODO: @performance @optimize @enhancement
-      // Maybe `is_traditional_trivial` is too restrictive.
-      // `is_itanium_trivial_for_calls` can be better?
-      // or just `is_trivially_copyable` ?
+      /// @attention [basic.types.general]
+      /// Only trivially copyable objects can be copied or moved by
+      /// `std::memcpy`; otherwise, this would be undefined behaviour.
 
       // Using when the Functor is copyable and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!is_traditional_trivial<Functor>::value))
+        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!std::is_trivially_copyable<Functor>::value))
       /* copyable */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2061,7 +2060,7 @@ namespace management {
 
       // Using when the Functor is move only and not trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!is_traditional_trivial<Functor>::value))
+        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!std::is_trivially_copyable<Functor>::value))
       /* move-only */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2083,7 +2082,7 @@ namespace management {
 
       // Used when the Functor is trivial.
       EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
-        EMBED_DETAIL_REQUIRES_END(is_traditional_trivial<Functor>::value)
+        EMBED_DETAIL_REQUIRES_END(std::is_trivially_copyable<Functor>::value)
       /* trivial */ static void manage(
         OperatorCode op,
         erasure_base_t* EMBED_RESTRICT dst,
@@ -2095,7 +2094,7 @@ namespace management {
           std::memcpy(
             const_cast<void*>(static_cast<erasure_t*>(dst)->access()),
             const_cast<const void*>(static_cast<erasure_t*>(src)->access()),
-            sizeof(erasure_t)
+            sizeof(Functor) // Copy the whole `m_erasure` is unnecessary.
           );
           break;
         case OperatorCode::destroy: /* Do nothing */ break;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1561,9 +1561,9 @@ inline namespace fn_traits {
   template <typename T>
   struct is_constant_wrapper : std::false_type {};
 
-#if __cpp_lib_constant_wrapper >= 202603L
-  template <auto Cw, typename T>
-  struct is_constant_wrapper<std::constant_wrapper<Cw, T>> : std::true_type {};
+#if __cpp_lib_constant_wrapper >= 202606L
+  template <auto Val, typename T>
+  struct is_constant_wrapper<std::constant_wrapper<Val, T>> : std::true_type {};
 #endif
 
   template <typename Functor, typename FnSample, typename Sig, typename = void>
@@ -1814,7 +1814,7 @@ namespace invocation {
 #endif
 
 // Implement invocation for constant_wrapper.
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 # define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                            \
   struct view_cw {                                                                    \
     template <typename Cw>                                                            \
@@ -2235,7 +2235,7 @@ namespace command {
       m_invoker = &invoker_impl_target_t::template invoke<DecFunctor>;
     }
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
     /// @brief Initialize the m_invoker from given std::constant_wrapper.
 
@@ -2913,17 +2913,17 @@ namespace crtp_mixins {
 
 #endif
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
     /// @todo experimental
 
     // Create function reference with given `std::constant_wrapper` param.
-    template <auto CwVal, typename Fn>
+    template <auto Val, typename Fn>
       requires is_invocable_using<const Fn&>::value
         && Config::isView
-    constexpr function(std::constant_wrapper<CwVal, Fn>) noexcept
+    constexpr function(std::constant_wrapper<Val, Fn>) noexcept
     : MemberVariableBase(nullptr) {
-      using Cw = std::constant_wrapper<CwVal, Fn>;
+      using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw>();
 
       // Mandates are as follows.
@@ -2933,13 +2933,13 @@ namespace crtp_mixins {
     }
 
     // Create function reference with given `std::constant_wrapper` and object params.
-    template <auto CwVal, typename Fn, typename Up, typename Tp = remove_reference_t<Up>>
+    template <auto Val, typename Fn, typename Up, typename Tp = remove_reference_t<Up>>
       requires (!std::is_rvalue_reference_v<Up&&>)
         && is_invocable_using<const Fn&, add_cv_like_sig_t<Tp>&>::value
         && Config::isView
-    constexpr function(std::constant_wrapper<CwVal, Fn>, Up&& obj) noexcept
+    constexpr function(std::constant_wrapper<Val, Fn>, Up&& obj) noexcept
     : MemberVariableBase(nullptr) {
-      using Cw = std::constant_wrapper<CwVal, Fn>;
+      using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw, /*CallPointer*/false>(&m_erasure, std::addressof(obj));
 
       // Mandates are as follows.
@@ -2949,13 +2949,13 @@ namespace crtp_mixins {
     }
 
     // Create function reference with given `std::constant_wrapper` and pointer params.
-    template <auto CwVal, typename Fn, typename Tp, typename Tp_cv = add_cv_like_sig_t<Tp>>
+    template <auto Val, typename Fn, typename Tp, typename Tp_cv = add_cv_like_sig_t<Tp>>
       requires std::is_convertible_v<Tp*, Tp_cv*>
         && is_invocable_using<const Fn&, Tp_cv*>::value
         && Config::isView
-    constexpr function(std::constant_wrapper<CwVal, Fn>, Tp* obj) noexcept
+    constexpr function(std::constant_wrapper<Val, Fn>, Tp* obj) noexcept
     : MemberVariableBase(nullptr) {
-      using Cw = std::constant_wrapper<CwVal, Fn>;
+      using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw, /*CallPointer*/true>(&m_erasure, obj);
 
       // Mandates are as follows.
@@ -3435,7 +3435,7 @@ constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused>()) { retur
 template <template <class, std::size_t> class Unused>
 constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0>>()) { return 0; }
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 namespace detail {
 
   /// @brief `fn_ref` CTAD guides from `std::constant_wrapper`.
@@ -3459,7 +3459,7 @@ namespace detail {
   >;
 
 } // end namespace detail
-#endif // ^^^ __cpp_lib_constant_wrapper >= 202603L
+#endif // ^^^ __cpp_lib_constant_wrapper >= 202606L
 
 } // end namespace ebd
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -31,7 +31,7 @@
 #ifndef EMBED_INCLUDED_EMBED_FUNCTION_HPP_
 #define EMBED_INCLUDED_EMBED_FUNCTION_HPP_
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 # pragma warning(push)
 # pragma warning(disable: 4514 4668 4710 26495)
 #endif
@@ -214,13 +214,13 @@
 /// Using SFINAE trait `enable_if_t` to require the template arguments.
 #define EMBED_DETAIL_REQUIRES(...) ::ebd::detail::enable_if_t<__VA_ARGS__, int> = 0
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 # define EMBED_DETAIL_FORCE_EBO __declspec(empty_bases)
 #else
 # define EMBED_DETAIL_FORCE_EBO
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 # define EMBED_DETAIL_VIRTUAL_INHERITANCE __virtual_inheritance
 #else
 # define EMBED_DETAIL_VIRTUAL_INHERITANCE
@@ -281,13 +281,15 @@
 # define EMBED_DETAIL_FAIL_MESSAGE(message)
 # define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)
 #else
-# define EMBED_DETAIL_FAIL_MESSAGE(message) do { EMBED_FN_HOOK_DEBUG(\
-  __FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) " " message); } while(0)
-# define EMBED_DETAIL_ASSERT_MESSAGE(expression, message) \
-  do { if (!(expression)) { \
-    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) " " message); \
-    std::terminate(); \
-  } } while(0)
+# define EMBED_DETAIL_FAIL_MESSAGE(message)                                   \
+  do {                                                                        \
+    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) " " message);\
+  } while(0) /* Output message together with file name and line number. */
+# define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)                     \
+  do { if (!(expression)) {                                                   \
+    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) " " message);\
+    std::terminate();                                                         \
+  } } while(0) /* Output message and terminate procedure if expression is false. */
 #endif
 
 #if __cpp_lib_unreachable >= 202202L
@@ -296,7 +298,7 @@
 # define EMBED_DETAIL_UNREACHABLE() __builtin_unreachable()
 #elif defined(__GNUC__) && (__GNUC__ >= 5)
 # define EMBED_DETAIL_UNREACHABLE() __builtin_unreachable()
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !defined(__clang__)
 # define EMBED_DETAIL_UNREACHABLE() __assume(false)
 #else
 # define EMBED_DETAIL_UNREACHABLE()
@@ -3513,7 +3515,7 @@ namespace detail {
 # undef EMBED_FN_HOOK_DEBUG
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 # pragma warning(pop)
 #endif
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1868,9 +1868,9 @@ namespace invocation {
     typename Ret, typename... Args>                                               \
   struct InvokerImpl<Size, Config, Ret(Args...) C V REF NOEXCEPT> {               \
   public:                                                                         \
-    using erasure_base_t = erasure_type::ErasureBase C V;                         \
+    using erasure_base_t = erasure_type::ErasureBase;                             \
+    using erasure_t = erasure_type::Erasure<Size>;                                \
     using erasure_pass_t = erasure_type::ErasurePass C;                           \
-    using erasure_t = erasure_type::Erasure<Size> C V;                            \
     static constexpr bool is_rvalue_ref =                                         \
       std::is_rvalue_reference<int REF>::value;                                   \
     using invoker_type =                                                          \
@@ -1960,20 +1960,11 @@ namespace management {
     using manager_type = void (*) (
       OperatorCode op, erasure_base_t* dst, erasure_base_t* src);
 
-    // Get functor pointer without any qualifier.
-    template <typename Functor>
-    static Functor* get_pointer(erasure_base_t* src) noexcept {
-      auto* src_ = static_cast<erasure_t*>(src);
-      auto& fn = src_->template access<Functor>();
-      return const_cast<Functor*>(std::addressof(fn));
-    }
-
     // Use placement new to create a type-erased object.
     template <typename Functor, typename Object>
     static void create(erasure_base_t* target, Object&& obj)
     noexcept(std::is_nothrow_constructible<Functor, Object&&>::value) {
-      ::new (const_cast<void*>(static_cast<erasure_t*>(target)->access()))
-          Functor(std::forward<Object>(obj));
+      ::new (static_cast<erasure_t*>(target)->access()) Functor(std::forward<Object>(obj));
     }
 
     /// @brief Store the object pointer from function reference without placement new.
@@ -1981,9 +1972,8 @@ namespace management {
     template <typename Object>
     static EMBED_CXX20_CONSTEXPR void 
     ref_create(erasure_base_t* target, Object* obj) noexcept {
-      using pure_erasure_t = remove_cv_t<erasure_t>;
-      const_cast<pure_erasure_t*>(static_cast<erasure_t*>(target))
-          ->m_core.ref_storage.fill_ptr = const_cast<remove_cv_t<Object>*>(obj);
+      auto* pure_ptr = const_cast<remove_cv_t<Object>*>(obj);
+      static_cast<erasure_t*>(target)->m_core.ref_storage.fill_ptr = pure_ptr;
     }
 
 #if EMBED_CXX_VERSION >= 201703L
@@ -1992,8 +1982,7 @@ namespace management {
     template <typename Functor, typename... CArgs>
     static void emplace_create(erasure_base_t* target, CArgs&&... args)
     noexcept(std::is_nothrow_constructible<Functor, CArgs&&...>::value) {
-      ::new (const_cast<void*>(static_cast<erasure_t*>(target)->access()))
-          Functor(std::forward<CArgs>(args)...);
+      ::new (static_cast<erasure_t*>(target)->access()) Functor(std::forward<CArgs>(args)...);
     }
 
 #endif
@@ -2009,9 +1998,10 @@ namespace management {
     // Clone type-erased object from `src` to `dst`.
     /// @attention `clone` will never change @a src.
     template <typename Functor>
-    static void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src)
+    static void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t const* EMBED_RESTRICT src)
     noexcept(std::is_nothrow_copy_constructible<Functor>::value) {
-      const auto& src_obj = *get_pointer<Functor>(src);
+      auto* src_erasure = static_cast<erasure_t const*>(src);
+      auto& src_obj = src_erasure->template access<Functor>();
       create<Functor>(dst, src_obj);
     }
 
@@ -2019,7 +2009,8 @@ namespace management {
     template <typename Functor>
     static void move(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src)
     noexcept(std::is_nothrow_move_constructible<Functor>::value) {
-      auto& src_obj = *get_pointer<Functor>(src);
+      auto* src_erasure = static_cast<erasure_t*>(src);
+      auto& src_obj = src_erasure->template access<Functor>();
       create<Functor>(dst, std::move(src_obj));
     }
 
@@ -2092,8 +2083,8 @@ namespace management {
         case OperatorCode::clone: EMBED_FALLTHROUGH(); /* fallthrough */
         case OperatorCode::move:
           std::memcpy(
-            const_cast<void*>(static_cast<erasure_t*>(dst)->access()),
-            const_cast<const void*>(static_cast<erasure_t*>(src)->access()),
+            static_cast<erasure_t*>(dst)->access(),
+            static_cast<erasure_t const*>(src)->access(),
             sizeof(Functor) // Copy the whole `m_erasure` is unnecessary.
           );
           break;
@@ -2133,9 +2124,13 @@ namespace command {
       return m_invoker(erased, std::forward<Args>(args)...);
     }
 
-    void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src) const
+    void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t const* EMBED_RESTRICT src) const
     noexcept(Config::assertNoThrow) {
-      m_manager(management::OperatorCode::clone, dst, src);
+      // Clones the source object into the destination. The const_cast is used to
+      // bridge the internal manager's non-const interface; the manager ensures
+      // the source remains logically unmodified during clone.
+      auto* src_non_const = const_cast<erasure_base_t*>(src);
+      m_manager(management::OperatorCode::clone, dst, src_non_const);
     }
 
     void move(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src) const
@@ -2216,15 +2211,11 @@ namespace command {
       return m_invoker(erased, std::forward<Args>(args)...);
     }
 
-    void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t* EMBED_RESTRICT src)
+    void clone(erasure_base_t* EMBED_RESTRICT dst, erasure_base_t const* EMBED_RESTRICT src)
     const noexcept {
       auto* destination = static_cast<erasure_t*>(dst);
-      auto* source = static_cast<erasure_t*>(src);
-      std::memcpy(
-        const_cast<void*>(destination->access()), 
-        const_cast<const void*>(source->access()), 
-        sizeof(erasure_t)
-      );
+      auto* source = static_cast<erasure_t const*>(src);
+      std::memcpy(destination->access(), source->access(), sizeof(erasure_t));
     }
 
     void move(erasure_base_t*, erasure_base_t*) = delete;
@@ -2310,12 +2301,14 @@ namespace crtp_mixins {
                                                                             \
     Ret operator()(Args... args) C V REF NOEXCEPT {                         \
       using erasure_t = typename Self::erasure_t;                           \
-      using command_t = const typename Self::command_t;                     \
+      using command_t = typename Self::command_t;                           \
       using pass_t = typename command_t::erasure_pass_t;                    \
       remove_cv_t<pass_t> erased;                                           \
       auto* self_q = static_cast<Self C V*>(this);                          \
-      auto& cmd = const_cast<command_t&>(self_q->m_command);                \
-      erased.ptr = const_cast<erasure_t*>(&(self_q->m_erasure));            \
+      auto& cmd = const_cast<command_t const&>(self_q->m_command);          \
+    /* Pass the `m_erasure` by pointer (reference) in owning mode. */       \
+    /* Because the usage size of `m_erasure` is uncertain. */               \
+      erased.ptr = &const_cast<erasure_t&>(self_q->m_erasure);              \
       return cmd.invoke(erased, std::forward<Args>(args)...);               \
     }                                                                       \
   };                                                                        \
@@ -2330,12 +2323,14 @@ namespace crtp_mixins {
                                                                             \
     Ret operator()(Args... args) const V NOEXCEPT {                         \
       using erasure_t = typename Self::erasure_t;                           \
-      using command_t = const typename Self::command_t;                     \
+      using command_t = typename Self::command_t;                           \
       using pass_t = typename command_t::erasure_pass_t;                    \
       remove_cv_t<pass_t> erased;                                           \
       auto* self_q = static_cast<Self const V*>(this);                      \
       auto& erasure = const_cast<erasure_t&>(self_q->m_erasure);            \
-      auto& cmd = const_cast<command_t&>(self_q->m_command);                \
+      auto& cmd = const_cast<command_t const&>(self_q->m_command);          \
+    /* Pass the `m_erasure` by value in non-owning mode to avoid ODR use. */\
+    /* Because the ODR use force compilers to reserve stack memory. */      \
       erased.val = erasure.m_core.ref_storage;                              \
       return cmd.invoke(erased, std::forward<Args>(args)...);               \
     }                                                                       \
@@ -2407,24 +2402,22 @@ namespace crtp_mixins {
       // Get the real `self` and `other`.
       auto& self = static_cast<Self&>(*this);
       auto& other = static_cast<const Self&>(other_raw);
-      using erasure_t = typename Self::erasure_t;
       using command_t = typename Self::command_t;
 
       // Copy from `other` to `self`.
-      other.m_command.clone(&self.m_erasure, const_cast<erasure_t*>(&other.m_erasure));
+      other.m_command.clone(&self.m_erasure, &other.m_erasure);
       std::memcpy(&self.m_command, &other.m_command, sizeof(command_t));
     }
 
     copy_impl& operator=(const copy_impl& other_raw) noexcept(Config::assertNoThrow) {
       auto& self = static_cast<Self&>(*this);
       auto& other = static_cast<const Self&>(other_raw);
-      using erasure_t = typename Self::erasure_t;
       using command_t = typename Self::command_t;
 
       if (this != std::addressof(other_raw)) {
         self.m_command.destroy(&self.m_erasure);
 
-        other.m_command.clone(&self.m_erasure, const_cast<erasure_t*>(&other.m_erasure));
+        other.m_command.clone(&self.m_erasure, &other.m_erasure);
         std::memcpy(&self.m_command, &other.m_command, sizeof(command_t));
       }
       return *this;
@@ -2788,13 +2781,10 @@ namespace crtp_mixins {
       && function<OtherSize, OtherCfg, OtherSig>::internal_is_copyable
     ) function(const function<OtherSize, OtherCfg, OtherSig>& other)
     noexcept(is_cfg_noexcept<Config>::value && is_cfg_noexcept<OtherCfg>::value) {
-      using other_fn_t = function<OtherSize, OtherCfg, OtherSig>;
-      using other_erasure_t = typename other_fn_t::erasure_t;
-
       // Suppress GCC warning: "-Wmaybe-uninitialized".
       std::memset(&m_erasure, 0, sizeof(void*));
 
-      other.m_command.clone(&m_erasure, const_cast<other_erasure_t*>(&other.m_erasure));
+      other.m_command.clone(&m_erasure, &other.m_erasure);
       std::memcpy(&m_command, &other.m_command, sizeof(command_t));
     }
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2359,8 +2359,8 @@ namespace crtp_mixins {
   // Implement the move constructor and move assignment.
   template <typename Config, typename Self>
   struct move_impl {
-    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(move_impl);
-    EMBED_DETAIL_COPY_FUNCTION(move_impl, default);
+    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(move_impl)
+    EMBED_DETAIL_COPY_FUNCTION(move_impl, default)
 
     move_impl(move_impl&& other_raw) noexcept(Config::assertNoThrow) {
       // Get the real `self` and `other`.
@@ -2397,8 +2397,8 @@ namespace crtp_mixins {
   // Implement the copy constructor and copy assignment.
   template <typename Config, typename Self>
   struct copy_impl {
-    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(copy_impl);
-    EMBED_DETAIL_MOVE_FUNCTION(copy_impl, default);
+    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(copy_impl)
+    EMBED_DETAIL_MOVE_FUNCTION(copy_impl, default)
 
     copy_impl(const copy_impl& other_raw) noexcept(Config::assertNoThrow) {
       // Get the real `self` and `other`.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2217,7 +2217,7 @@ namespace command {
     const noexcept {
       auto* destination = static_cast<erasure_t*>(dst);
       auto* source = static_cast<erasure_t const*>(src);
-      std::memcpy(destination->access(), source->access(), sizeof(erasure_t));
+      std::memcpy(destination->access(), source->access(), default_buffer_size::ref_buf);
     }
 
     void move(erasure_base_t*, erasure_base_t*) = delete;
@@ -2332,7 +2332,7 @@ namespace crtp_mixins {
       auto& erasure = const_cast<erasure_t&>(self_q->m_erasure);            \
       auto& cmd = const_cast<command_t const&>(self_q->m_command);          \
     /* Pass the `m_erasure` by value in non-owning mode to avoid ODR use. */\
-    /* Because the ODR use force compilers to reserve stack memory. */      \
+    /* Because the ODR use forces compilers to reserve stack memory. */     \
       erased.val = erasure.m_core.ref_storage;                              \
       return cmd.invoke(erased, std::forward<Args>(args)...);               \
     }                                                                       \
@@ -2501,13 +2501,13 @@ namespace crtp_mixins {
     assignment_self_clear(const assignment_self_clear&) = default;
     assignment_self_clear(assignment_self_clear&&)      = default;
 
-    assignment_self_clear&
+    assignment_self_clear& // Destroy the callable object in `m_erasure` before copy assignment.
     operator=(const assignment_self_clear& other_raw) noexcept(Config::assertNoThrow) {
       auto& self = static_cast<Self&>(*this);
       if (this != std::addressof(other_raw)) { self.m_command.destroy(&self.m_erasure); }
       return *this;
     }
-    assignment_self_clear&
+    assignment_self_clear& // Destroy the callable object in `m_erasure` before move assignment.
     operator=(assignment_self_clear&& other_raw) noexcept(Config::assertNoThrow) {
       auto& self = static_cast<Self&>(*this);
       if (this != std::addressof(other_raw)) { self.m_command.destroy(&self.m_erasure); }
@@ -2698,6 +2698,9 @@ namespace crtp_mixins {
     template <bool, std::size_t, typename, typename, typename>
     friend struct crtp_mixins::core_components_impl;
 
+    // Assert the `Config` is config_package.
+    static_assert(is_config_package<Config>::value, EMBED_DETAIL_REPORT_IE("Config is invalid."));
+
     // Assert the `Signature` is well-formed.
     static_assert(unwrap_signature<Signature>::isSignature, 
       "The `Signature` of the function wrapper is invalid:\n\n"
@@ -2810,6 +2813,7 @@ namespace crtp_mixins {
 
     // Use `placement new` to create new functor during construction. (Copy)
     // From `function<Buffer_small, ...>` to `function<Buffer_big, ...>`.
+    // Used in both OWNING mode and NON-OWNING mode.
     EMBED_DETAIL_TEMPLATE_BEGIN(
       std::size_t OtherSize, typename OtherCfg, typename OtherSig)
     EMBED_DETAIL_REQUIRES_END(

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3,7 +3,7 @@
  * 
  * @date        2026-2-7
  * 
- * @version     2.1.6
+ * @version     2.1.7
  * 
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -70,6 +70,14 @@
 # endif
 #endif
 
+#ifndef EMBED_HAS_FEATURE
+# if defined(__has_feature)
+#  define EMBED_HAS_FEATURE(x) __has_feature(x)
+# else
+#  define EMBED_HAS_FEATURE(x) 0
+# endif
+#endif
+
 #ifndef EMBED_CXX_ENABLE_EXCEPTION
 # if defined(__cpp_exceptions)
 #  define EMBED_CXX_ENABLE_EXCEPTION (__cpp_exceptions != 0)
@@ -204,8 +212,7 @@
 
 /// @brief Similar to `requires` in C++20.
 /// Using SFINAE trait `enable_if_t` to require the template arguments.
-#define EMBED_DETAIL_REQUIRES(...) \
-  ::ebd::detail::enable_if_t<(__VA_ARGS__), int> = 0
+#define EMBED_DETAIL_REQUIRES(...) ::ebd::detail::enable_if_t<__VA_ARGS__, int> = 0
 
 #if defined(_MSC_VER)
 # define EMBED_DETAIL_FORCE_EBO __declspec(empty_bases)
@@ -299,6 +306,18 @@
 #define EMBED_DETAIL_REPORT_IE(error) \
   "An internal library error has occurred: " error " This is unexpected.\n" \
   "PLEASE report this bug at <https://github.com/Kim-J-Smith/Embedded-Function/issues>."
+
+#if EMBED_HAS_FEATURE(nullability) && defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wnullability-completeness"
+# pragma clang diagnostic ignored "-Wnullability-extension"
+# define EMBED_DETAIL_NOT_NULL(T) T _Nonnull
+#elif defined(_MSC_VER) && defined(_PREFAST_)
+# include <sal.h>
+# define EMBED_DETAIL_NOT_NULL(T) _Notnull_ T
+#else
+# define EMBED_DETAIL_NOT_NULL(T) T
+#endif
 
 namespace ebd EMBED_ABI_VISIBILITY(default) {
 namespace detail {
@@ -1096,17 +1115,16 @@ inline namespace fn_traits {
       is_callable_from_pkg<Signature, dec_func, ret, args_pack>::value;
   };
 
-  // Check the align and size of functor.
-  template <typename Functor, typename Config, std::size_t BufSize, typename Erasure,
-    typename DecFunctor = decay_t<Functor>>
-  struct align_size_is_ok {
-    static constexpr bool is_ok = sizeof(DecFunctor) <= sizeof(Erasure)
-      && alignof(DecFunctor) <= alignof(Erasure)
-      && (sizeof(DecFunctor) % alignof(DecFunctor) == 0);
+  template <typename Fn, typename Cfg, typename Erasure, typename DecFn = decay_t<Fn>>
+  struct buffer_size_is_enough : bool_constant<
+    !is_stored_origin<DecFn, Cfg::isView>::value || sizeof(DecFn) <= sizeof(Erasure)
+  > {};
 
-    static constexpr bool value = 
-      !is_stored_origin<DecFunctor, Config::isView>::value || is_ok;
-  };
+  template <typename Fn, typename Cfg, typename Erasure, typename DecFn = decay_t<Fn>>
+  struct buffer_alignment_is_enough : bool_constant<
+    !is_stored_origin<DecFn, Cfg::isView>::value
+    || (alignof(DecFn) <= alignof(Erasure) && (sizeof(DecFn) % alignof(DecFn) == 0))
+  > {};
 
   // Get aligned size. Rounds up to the nearest word.
   template <std::size_t MinAlign = sizeof(void (*) ())>
@@ -1224,15 +1242,15 @@ inline namespace fn_traits {
     Functor, void_t<decltype(&Functor::operator())>>
   : public std::true_type {};
 
-  // Check static callable functor.
+  // Check statically callable functor. ([func.wrap.func.con]/16.2 Static operator())
 #if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
   template <typename Fn, typename... Args>
-  struct is_static_callable_functor : bool_constant<
+  struct is_statically_callable : bool_constant<
     requires (Args&&... args) { Fn::operator()(std::forward<Args>(args)...); }
   > {};
 #else
   template <typename Fn, typename... Args>
-  struct is_static_callable_functor : std::false_type {};
+  struct is_statically_callable : std::false_type {};
 #endif
 
   // Trait to add qualifiers (const, volatile, &, &&, noexcept) to a function
@@ -1306,7 +1324,7 @@ inline namespace fn_traits {
 
   // noexcept(false)
   template <typename Fn, typename Ret, typename... Args>
-    requires is_static_callable_functor<Fn, Args...>::value
+    requires is_statically_callable<Fn, Args...>::value
   struct get_unique_signature_impl<Fn, Ret(*)(Args...)> {
     using type = Ret(Args...) const;
     using sig_with_noexcept = Ret(Args...) const;
@@ -1314,7 +1332,7 @@ inline namespace fn_traits {
 
   // noexcept(true)
   template <typename Fn, typename Ret, typename... Args>
-    requires is_static_callable_functor<Fn, Args...>::value
+    requires is_statically_callable<Fn, Args...>::value
   struct get_unique_signature_impl<Fn, Ret(*)(Args...) noexcept> {
     using type = Ret(Args...) const;
     using sig_with_noexcept = Ret(Args...) const noexcept;
@@ -1505,7 +1523,7 @@ inline namespace fn_traits {
             typename Functor, typename Object, typename ErasureT>
   struct asserts_for_function : public std::true_type {
 
-    static_assert(align_size_is_ok<Functor, Config, BufferSize, ErasureT>::value,
+    static_assert(buffer_size_is_enough<Functor, Config, ErasureT>::value,
       "The `BufferSize` is smaller than the callable object. Please use bigger "
       "`BufferSize` and try again:\n\n"
       "        FnWrapper<Signature, Bigger-BufferSize> f = CallableObject;\n"
@@ -1514,6 +1532,9 @@ inline namespace fn_traits {
       "             should be greater than `sizeof(CallableObject)`\n\n"
       "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, etc."
     );
+
+    static_assert(buffer_alignment_is_enough<Functor, Config, ErasureT>::value,
+      "The alignment of the callable object is too big to be wrapped into ebd::fn.");
 
     static_assert(assert_throwing_is_ok<Functor, Object, Config>::value,
       "The 'Functor' may throw exceptions during construction and destruction,"
@@ -1679,7 +1700,7 @@ inline namespace fn_traits {
   // Check whether the functor is stateless.
   template <bool IsView, typename Fn, typename... Args>
   struct is_stateless : bool_constant<
-    is_static_callable_functor<Fn, Args...>::value
+    is_statically_callable<Fn, Args...>::value
     || is_std_op_wrapper<Fn>::value
     || (is_empty_trivial<Fn>::value && !IsView)
     // ^^^ empty trivial functor may use `this` in operator(). This is
@@ -1692,11 +1713,16 @@ inline namespace fn_traits {
     static_assert(always_false<Unused>::value,
       "`make_fn()` CANNOT infer the template arguments of `ebd::basic_fn` from the given "
       "arguments.\nYou can specify the signature and try again:\n\n"
+      "        auto f = ebd::make_fn<Signature[, BufferSize]>();\n"
+      "                              ^^^^^^^^^\n"
+      "        auto f = ebd::make_fn<Signature[, BufferSize]>(nullptr);\n"
+      "                              ^^^^^^^^^\n"
       "        auto f = ebd::make_fn<Signature>(CallableObject);\n"
       "                              ^^^^^^^^^\n"
       "        auto f = ebd::make_fn<FnWrapper, Signature>(CallableObject);\n"
       "                                         ^^^^^^^^^\n\n"
       "The `Signature` is like `void()`, `float(int,int) const`;\n"
+      "The `BufferSize` is the size (in bytes) of the internal storage;\n"
       "The `FnWrapper` is an alias of `ebd::basic_fn` and has `template <class, std::size_t>` "
       "as a template argument list, such as `ebd::fn_ref`, `ebd::safe_fn`, etc. If omitted, "
       "the `FnWrapper` will be inferred to be `ebd::fn` if the `CallableObject` is copyable, "
@@ -1741,10 +1767,9 @@ namespace erasure_type {
 
   template <std::size_t Size>
   union EMBED_DETAIL_ALIAS ErasureCore {
-    static_assert(Size > 0, "erasure size must greater than 0");
     // An array of `unsigned char` can be used to hold other objects.
     // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0137r1.html>.
-    unsigned char pod[Size];
+    unsigned char pod[get_aligned_size(Size)];
     ErasureRefStorage ref_storage; // alignas(ref_storage)
   };
 
@@ -1759,8 +1784,7 @@ namespace erasure_type {
   // See <https://eel.is/c++draft/basic.life#7>.
   template <std::size_t Size>
   struct EMBED_DETAIL_ALIAS Erasure : public ErasureBase {
-    alignas(default_buffer_size::align_value)
-    ErasureCore<Size> m_core;
+    alignas(default_buffer_size::align_value) ErasureCore<Size> m_core;
 
     // Access the pointer of erasureCore that qualified with nothing or const.
     void* access() noexcept { return &m_core.pod[0]; }
@@ -1875,20 +1899,19 @@ namespace invocation {
                                                                                   \
     /* Using when Config::isView == true. */                                      \
     struct view {                                                                 \
-      /* Using when Functor::is_stored_origin == true. */                         \
-      template <typename Functor>                                                 \
-      static enable_if_t<is_stored_origin<Functor, true>::value, Ret>             \
-      invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
+      /* Using when the `Functor` is function pointer. */                         \
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)                               \
+        EMBED_DETAIL_REQUIRES_END(is_stored_origin<Functor, true>::value)         \
+      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
         auto* fn = reinterpret_cast<Functor>(base.val.fill_func_ptr);             \
-        using Fn = remove_reference_t<decltype(fn)>&;                             \
-        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
+        return invoke_r<Ret>(fn, std::forward<Args>(args)...);                    \
       }                                                                           \
                                                                                   \
-      /* Using when Functor::is_stored_origin == false. */                        \
-      template <typename Functor>                                                 \
-      static enable_if_t<!is_stored_origin<Functor, true>::value, Ret>            \
-      invoke(erasure_pass_t base, smart_forward_t<Args>... args) {                \
-        auto& fn = *(static_cast<Functor C V*>(base.val.fill_ptr));               \
+      /* Using when the `Functor` is NOT function pointer. */                     \
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)                               \
+        EMBED_DETAIL_REQUIRES_END((!is_stored_origin<Functor, true>::value))      \
+      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
+        auto& fn = *static_cast<Functor C V*>(base.val.fill_ptr);                 \
         using Fn = remove_reference_t<decltype(fn)>&;                             \
         return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
       }                                                                           \
@@ -2009,12 +2032,17 @@ namespace management {
 
     // Using when Config::isView == false.
     struct inplace {
+      // TODO: @performance @optimize @enhancement
+      // Maybe `is_traditional_trivial` is too restrictive.
+      // `is_itanium_trivial_for_calls` can be better?
+      // or just `is_trivially_copyable` ?
+
       // Using when the Functor is copyable and not trivial.
-      template <typename Functor, bool IsCopyable>
-      static enable_if_t<IsCopyable && !is_traditional_trivial<Functor>::value>
-      /* copyable */ manage(
-        OperatorCode op, 
-        erasure_base_t* EMBED_RESTRICT dst, 
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
+        EMBED_DETAIL_REQUIRES_END(IsCopyable && (!is_traditional_trivial<Functor>::value))
+      /* copyable */ static void manage(
+        OperatorCode op,
+        erasure_base_t* EMBED_RESTRICT dst,
         erasure_base_t* EMBED_RESTRICT src
       ) {
         switch (op) {
@@ -2032,11 +2060,11 @@ namespace management {
       }
 
       // Using when the Functor is move only and not trivial.
-      template <typename Functor, bool IsCopyable>
-      static enable_if_t<!IsCopyable && !is_traditional_trivial<Functor>::value>
-      /* move-only */ manage(
-        OperatorCode op, 
-        erasure_base_t* EMBED_RESTRICT dst, 
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
+        EMBED_DETAIL_REQUIRES_END((!IsCopyable) && (!is_traditional_trivial<Functor>::value))
+      /* move-only */ static void manage(
+        OperatorCode op,
+        erasure_base_t* EMBED_RESTRICT dst,
         erasure_base_t* EMBED_RESTRICT src
       ) {
         switch (op) {
@@ -2054,10 +2082,11 @@ namespace management {
       }
 
       // Used when the Functor is trivial.
-      template <typename Functor, bool IsCopyable>
-      static enable_if_t<is_traditional_trivial<Functor>::value> manage(
-        OperatorCode op, 
-        erasure_base_t* EMBED_RESTRICT dst, 
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor, bool IsCopyable)
+        EMBED_DETAIL_REQUIRES_END(is_traditional_trivial<Functor>::value)
+      /* trivial */ static void manage(
+        OperatorCode op,
+        erasure_base_t* EMBED_RESTRICT dst,
         erasure_base_t* EMBED_RESTRICT src
       ) {
         switch (op) {
@@ -2146,7 +2175,7 @@ namespace command {
     EMBED_CXX20_CONSTEXPR enable_if_t<is_stateless</*IsView*/false, DecFunctor, Args...>::value>
     init(erasure_base_t*, Functor&&) noexcept {
       using invoker_impl_target_t = conditional_t<
-        is_static_callable_functor<DecFunctor, Args...>::value,
+        is_statically_callable<DecFunctor, Args...>::value,
         typename invoker_impl_t::static_call,
         typename invoker_impl_t::empty_trivial_class
       >;
@@ -2228,7 +2257,7 @@ namespace command {
     enable_if_t<!IsStoredOrigin && is_stateless</*IsView*/true, DecFunctor, Args...>::value>
     init(erasure_base_t*, Functor&&) noexcept {
       using invoker_impl_target_t = conditional_t<
-        is_static_callable_functor<DecFunctor, Args...>::value,
+        is_statically_callable<DecFunctor, Args...>::value,
         typename invoker_impl_t::static_call,
         typename invoker_impl_t::empty_trivial_class
       >;
@@ -2630,10 +2659,8 @@ namespace crtp_mixins {
 
     template <typename, typename>
     friend struct crtp_mixins::copy_impl;
-
     template <typename, typename>
     friend struct crtp_mixins::move_impl;
-
     template <typename, typename>
     friend struct crtp_mixins::destructor_impl;
 
@@ -2643,46 +2670,35 @@ namespace crtp_mixins {
     template <bool, std::size_t, typename, typename, typename>
     friend struct crtp_mixins::core_components_impl;
 
-    /// @brief ASSERT the given template arguments are valid.
-
-    /// @tparam BufferSize
-    static_assert(BufferSize >= sizeof(void*), 
-      "The 'BufferSize' that you pass in is too small."
-      " Try to use a BufferSize that is greater than or equal to sizeof(void*).");
-    
-    /// @tparam Config
-    static_assert(is_config_package<Config>::value, 
-      "The second argument must be 'config_package'."
-      " Try to use config_package<...> as the second argument.");
-
-    /// @tparam Signature
+    // Assert the `Signature` is well-formed.
     static_assert(unwrap_signature<Signature>::isSignature, 
-      "The 'Signature' argument of ebd::function must be a function type,"
-      " such as void(), void(int) const or int(char*, float).");
+      "The `Signature` of the function wrapper is invalid:\n\n"
+      "        FnWrapper<Signature, BufferSize> f = CallableObject;\n"
+      "                  ^^^^^^^^^\n"
+      "                      |\n"
+      " should be like `void()`, `int(int) const`, etc\n\n"
+      "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, `ebd::fn_ref`, etc."
+    );
 
-    /// Check the "noexcept" is same.
+    // Assert the noexcept-qualifier in `Signature` matchs the `Config`.
     static_assert(!(Config::isThrowing && unwrap_signature<Signature>::isNoexcept),
-      "This 'noexcept' qualifier is in conflict with the 'IsThrowing'"
-      " configuration option. (Use 'ebd::safe_fn' or 'ebd::fn_ref')");
+      "This `noexcept`-qualifier is in conflict with the `IsThrowing` configuration "
+      "option in `Config`. (Use 'ebd::safe_fn' or 'ebd::fn_ref')");
 
-    using MemberVariableBase = crtp_mixins::member_variable_impl<
-      BufferSize, Config, Signature>;
+    using Base_MemberVariable = crtp_mixins::member_variable_impl<BufferSize, Config, Signature>;
 
-    using CoreComponents = crtp_mixins::core_components_impl<
-      Config::isView, BufferSize, Config, Signature, function>;
+    using Base_CoreComponents =
+      crtp_mixins::core_components_impl<Config::isView, BufferSize, Config, Signature, function>;
 
-    using erasure_t = typename MemberVariableBase::erasure_t;
+    using erasure_t = typename Base_MemberVariable::erasure_t;
 
-    using command_t = typename MemberVariableBase::command_t;
+    using command_t = typename Base_MemberVariable::command_t;
 
     // The `m_erasure` contains the type-erased object.
-    using MemberVariableBase::m_erasure;
+    using Base_MemberVariable::m_erasure;
 
     // The `m_command` is responsible for managing and invoking the `m_erasure`.
-    using MemberVariableBase::m_command;
-
-    // The buffer size.
-    static constexpr std::size_t buffer_size = BufferSize;
+    using Base_MemberVariable::m_command;
 
     // `true` if self is copyable.
     static constexpr bool internal_is_copyable = Config::isCopyable || Config::isView;
@@ -2705,7 +2721,7 @@ namespace crtp_mixins {
 
     /// @brief Get the buffer size.
     EMBED_NODISCARD EMBED_INLINE static constexpr std::size_t
-    get_buffer_size() noexcept { return buffer_size; }
+    get_buffer_size() noexcept { return BufferSize; }
 
     /// @brief Return `true` if the function is copyable.
     EMBED_NODISCARD EMBED_INLINE static constexpr bool
@@ -2737,32 +2753,32 @@ namespace crtp_mixins {
 # pragma GCC diagnostic pop
 #endif
 
-    /// @brief All following methods that begin with `CoreComponents` are implemented in 
+    /// @brief All following methods that begin with `Base_CoreComponents` are implemented in 
     /// the base class @e `crtp_mixins::core_components_impl`.
 
-    using CoreComponents::is_empty;
+    using Base_CoreComponents::is_empty;
 
-    using CoreComponents::operator bool;
+    using Base_CoreComponents::operator bool;
 
-    using CoreComponents::clear;
+    using Base_CoreComponents::clear;
 
-    using CoreComponents::swap;
+    using Base_CoreComponents::swap;
 
-    using CoreComponents::operator=;
+    using Base_CoreComponents::operator=;
 
     // Create an empty function wrapper.
     function() noexcept
 #if __cpp_concepts >= 202002L
-      requires requires { CoreComponents(nullptr); }
+      requires requires { Base_CoreComponents(nullptr); }
 #endif
-    : CoreComponents(nullptr) {}
+    : Base_CoreComponents(nullptr) {}
 
     // Create an empty function wrapper.
     function(std::nullptr_t) noexcept
 #if __cpp_concepts >= 202002L
-      requires requires { CoreComponents(nullptr); }
+      requires requires { Base_CoreComponents(nullptr); }
 #endif
-    : CoreComponents(nullptr) {}
+    : Base_CoreComponents(nullptr) {}
 
     // Use `placement new` to create new functor during construction. (Copy)
     // From `function<Buffer_small, ...>` to `function<Buffer_big, ...>`.
@@ -2834,7 +2850,7 @@ namespace crtp_mixins {
       std::is_function<Func>::value
       && is_invocable_using<Func>::value
       && Config::isView
-    ) function(Func* function_ptr) noexcept {
+    ) function(EMBED_DETAIL_NOT_NULL(Func*) function_ptr) noexcept {
 
       static_assert(asserts_for_function<
           BufferSize, Config, Signature, Func*, Func*&&, erasure_t>::value,
@@ -2860,7 +2876,7 @@ namespace crtp_mixins {
       && is_invocable_using<add_cv_like_sig_t<Tp>&>::value
       && Config::isView
     ) EMBED_CXX20_CONSTEXPR function(Functor&& functor) noexcept
-    : MemberVariableBase(nullptr) {
+    : Base_MemberVariable(nullptr) {
 
       static_assert(asserts_for_function<
           BufferSize, Config, Signature, Functor, Functor&&, erasure_t>::value,
@@ -2922,7 +2938,7 @@ namespace crtp_mixins {
       requires is_invocable_using<const Fn&>::value
         && Config::isView
     constexpr function(std::constant_wrapper<Val, Fn>) noexcept
-    : MemberVariableBase(nullptr) {
+    : Base_MemberVariable(nullptr) {
       using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw>();
 
@@ -2938,7 +2954,7 @@ namespace crtp_mixins {
         && is_invocable_using<const Fn&, add_cv_like_sig_t<Tp>&>::value
         && Config::isView
     constexpr function(std::constant_wrapper<Val, Fn>, Up&& obj) noexcept
-    : MemberVariableBase(nullptr) {
+    : Base_MemberVariable(nullptr) {
       using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw, /*CallPointer*/false>(&m_erasure, std::addressof(obj));
 
@@ -2954,7 +2970,7 @@ namespace crtp_mixins {
         && is_invocable_using<const Fn&, Tp_cv*>::value
         && Config::isView
     constexpr function(std::constant_wrapper<Val, Fn>, Tp* obj) noexcept
-    : MemberVariableBase(nullptr) {
+    : Base_MemberVariable(nullptr) {
       using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw, /*CallPointer*/true>(&m_erasure, obj);
 
@@ -2973,33 +2989,33 @@ namespace crtp_mixins {
   };
 
   // `true` if the wrapper has no target, `false` otherwise. (noexcept)
-  template <std::size_t Buf, typename Cfg, typename Sig,
-    EMBED_DETAIL_REQUIRES(Cfg::isView == false)
-  > EMBED_INLINE EMBED_CXX14_CONSTEXPR bool 
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+    EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
+  EMBED_INLINE EMBED_CXX14_CONSTEXPR bool
   operator==(const function<Buf, Cfg, Sig>& fn, std::nullptr_t) noexcept {
     return fn.is_empty();
   }
 
   // `true` if the wrapper has no target, `false` otherwise. (noexcept)
-  template <std::size_t Buf, typename Cfg, typename Sig,
-    EMBED_DETAIL_REQUIRES(Cfg::isView == false)
-  > EMBED_INLINE EMBED_CXX14_CONSTEXPR bool 
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+    EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
+  EMBED_INLINE EMBED_CXX14_CONSTEXPR bool
   operator==(std::nullptr_t, const function<Buf, Cfg, Sig>& fn) noexcept {
     return fn.is_empty();
   }
 
   // `true` if the wrapper does have target, `false` otherwise. (noexcept)
-  template <std::size_t Buf, typename Cfg, typename Sig,
-    EMBED_DETAIL_REQUIRES(Cfg::isView == false)
-  > EMBED_INLINE EMBED_CXX14_CONSTEXPR bool 
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+    EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
+  EMBED_INLINE EMBED_CXX14_CONSTEXPR bool
   operator!=(const function<Buf, Cfg, Sig>& fn, std::nullptr_t) noexcept {
     return !fn.is_empty();
   }
 
   // `true` if the wrapper does have target, `false` otherwise. (noexcept)
-  template <std::size_t Buf, typename Cfg, typename Sig,
-    EMBED_DETAIL_REQUIRES(Cfg::isView == false)
-  > EMBED_INLINE EMBED_CXX14_CONSTEXPR bool 
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+    EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
+  EMBED_INLINE EMBED_CXX14_CONSTEXPR bool
   operator!=(std::nullptr_t, const function<Buf, Cfg, Sig>& fn) noexcept {
     return !fn.is_empty();
   }
@@ -3482,12 +3498,17 @@ namespace detail {
 #undef EMBED_DETAIL_UNREACHABLE
 #undef EMBED_DETAIL_ASSERT_MESSAGE
 #undef EMBED_DETAIL_REPORT_IE
+#if EMBED_HAS_FEATURE(nullability) && defined(__clang__)
+# pragma clang diagnostic pop
+#endif // ^^^ Pop the pushed warning for EMBED_DETAIL_NOT_NULL
+#undef EMBED_DETAIL_NOT_NULL
 #if defined(EMBED_FN_CONFIG_UNDEF_MACROS)
 // #undef most of the EMBED_* macros if EMBED_FN_CONFIG_UNDEF_MACROS is defined.
 // EMBED_CXX_VERSION and EMBED_CXX_ENABLE_EXCEPTION are reserved.
 # undef EMBED_HAS_BUILTIN
 # undef EMBED_HAS_ATTRIBUTE
 # undef EMBED_HAS_CXX_ATTRIBUTE
+# undef EMBED_HAS_FEATURE
 # undef EMBED_ABI_VISIBILITY
 # undef EMBED_CXX14_CONSTEXPR
 # undef EMBED_CXX20_CONSTEXPR

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2382,7 +2382,7 @@ namespace crtp_mixins {
       using command_t = typename Self::command_t;
 
       if (this != std::addressof(other_raw)) {
-        self.m_command.destroy(&self.m_erasure);
+        // Self-clear already done in `crtp_mixins::assignment_self_clear`.
 
         other.m_command.move(&self.m_erasure, &other.m_erasure);
         std::memcpy(&self.m_command, &other.m_command, sizeof(command_t));
@@ -2417,7 +2417,7 @@ namespace crtp_mixins {
       using command_t = typename Self::command_t;
 
       if (this != std::addressof(other_raw)) {
-        self.m_command.destroy(&self.m_erasure);
+        // Self-clear already done in `crtp_mixins::assignment_self_clear`.
 
         other.m_command.clone(&self.m_erasure, &other.m_erasure);
         std::memcpy(&self.m_command, &other.m_command, sizeof(command_t));
@@ -2489,12 +2489,44 @@ namespace crtp_mixins {
     }
   };
 
+  // The self-clear must happen before the default copy/move assignment in
+  // `member_variable_impl`; otherwise the assignment would overwrite
+  // `self.m_command` first, and the subsequent clear would destroy the
+  // newly assigned state.
+  // See <https://github.com/Kim-J-Smith/Embedded-Function/issues/75>.
+  template <typename Self, typename Config, bool IsView /*= false*/>
+  struct assignment_self_clear {
+    assignment_self_clear()                             = default;
+    ~assignment_self_clear()                            = default;
+    assignment_self_clear(const assignment_self_clear&) = default;
+    assignment_self_clear(assignment_self_clear&&)      = default;
+
+    assignment_self_clear&
+    operator=(const assignment_self_clear& other_raw) noexcept(Config::assertNoThrow) {
+      auto& self = static_cast<Self&>(*this);
+      if (this != std::addressof(other_raw)) { self.m_command.destroy(&self.m_erasure); }
+      return *this;
+    }
+    assignment_self_clear&
+    operator=(assignment_self_clear&& other_raw) noexcept(Config::assertNoThrow) {
+      auto& self = static_cast<Self&>(*this);
+      if (this != std::addressof(other_raw)) { self.m_command.destroy(&self.m_erasure); }
+      return *this;
+    }
+  };
+
+  template <typename Self, typename Config>
+  struct assignment_self_clear<Self, Config, /*IsView =*/ true>
+  { EMBED_DETAIL_ALL_DEFAULT(assignment_self_clear) };
+
   // Implement the member variables. Transplant the member variables
   // to the base class to achieve greater flexibility.
   /// @attention This class must be placed first in the inheritance list; otherwise, there
   /// will be an out-of-order error when it comes to move constructors and move assignments.
   template <std::size_t BufferSize, typename Config, typename Signature>
-  struct member_variable_impl {
+  struct member_variable_impl : public assignment_self_clear<
+    /* Self = */ function<BufferSize, Config, Signature>, Config, Config::isView
+  > {
     EMBED_DETAIL_ALL_DEFAULT(member_variable_impl)
 
     // Zero initialize the `m_erasure` and `m_command`.
@@ -2657,6 +2689,8 @@ namespace crtp_mixins {
     friend struct crtp_mixins::move_impl;
     template <typename, typename>
     friend struct crtp_mixins::destructor_impl;
+    template <typename, typename, bool>
+    friend struct crtp_mixins::assignment_self_clear;
 
     template <typename, typename, bool, typename>
     friend struct crtp_mixins::operator_dereference_impl;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,6 +110,7 @@ if(MSVC)
     /wd5045
     /wd6326
     /analyze
+    /WX
   )
   target_link_options(
     ${PROJECT_NAME} PRIVATE
@@ -133,6 +134,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     -O0
     -fmax-errors=50
     -fno-exceptions
+    -Werror
   )
   target_compile_options(
     gtest_lib PRIVATE
@@ -150,6 +152,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     -fno-permissive
     -fno-exceptions
     -O0
+    -Werror
   )
   target_compile_options(
     gtest_lib PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,8 @@ if(MSVC)
     /wd4514
     /wd4626
     /wd5045
+    /wd6326
+    /analyze
   )
   target_link_options(
     ${PROJECT_NAME} PRIVATE
@@ -187,6 +189,11 @@ foreach(macros_ ${TEST_USE_MACROS})
   endif()
 endforeach()
 
+if(MSVC)
+  set(FAIL_TEST_INCLUDE_PATH_CMD "${FAIL_TEST_INCLUDE_PATH_CMD} /analyze /WX")
+else()
+  set(FAIL_TEST_INCLUDE_PATH_CMD "${FAIL_TEST_INCLUDE_PATH_CMD} -Werror")
+endif()
 
 message(STATUS "===---------------------- FAIL TEST BEGIN ----------------------===")
 message(STATUS "Flags: ${FAIL_TEST_CMAKE_FLAGS}")

--- a/test/conformance/fn_ref/__constant_wrapper.hpp
+++ b/test/conformance/fn_ref/__constant_wrapper.hpp
@@ -15,6 +15,7 @@
 
 #include <utility>
 #include <functional>
+#include <type_traits>
 
 #if defined(_MSC_VER)
 // C++23 is not full supported if _MSC_VER < 1950.
@@ -25,48 +26,17 @@
 
 #if __cplusplus >= 202302L && !defined(__cpp_lib_constant_wrapper) && MSVC_IS_OK
 
-#define __cpp_lib_constant_wrapper 202603L
+#define __cpp_lib_constant_wrapper 202606L
 
 namespace std {
 
-template <class _Tp>
-struct __cw_fixed_value {
-  using __type  = _Tp;
-   constexpr __cw_fixed_value(__type __v) noexcept : __data(__v) {}
-  _Tp __data;
-};
-
-template <class _Tp, size_t _Extent>
-struct __cw_fixed_value<_Tp[_Extent]> {
-  using __type  = _Tp[_Extent];
-  _Tp __data[_Extent];
-
-   constexpr __cw_fixed_value(_Tp (&__arr)[_Extent]) noexcept
-      : __cw_fixed_value(__arr, make_index_sequence<_Extent>{}) {}
-
-private:
-  template <size_t... _Idxs>
-   constexpr __cw_fixed_value(_Tp (&__arr)[_Extent], index_sequence<_Idxs...>) noexcept
-      : __data{__arr[_Idxs]...} {}
-};
-
-template <class _Tp, size_t _Extent>
-__cw_fixed_value(_Tp (&)[_Extent]) -> __cw_fixed_value<_Tp[_Extent]>;
-
-template <__cw_fixed_value _Xp,
-#  ifdef __GNUC__
-          // gcc bug:  https://gcc.gnu.org/PR117392
-          class = typename decltype(__cw_fixed_value(_Xp))::__type
-#  else
-          class = typename decltype(_Xp)::__type
-#  endif
-          >
+template <auto _Xp, class = std::remove_cvref_t<decltype(_Xp)>>
 struct constant_wrapper;
 
 template <class _Tp>
 concept __constexpr_param = requires { typename constant_wrapper<_Tp::value>; };
 
-template <__cw_fixed_value _Xp>
+template <auto _Xp>
 constexpr auto cw = constant_wrapper<_Xp>{};
 
 struct __cw_operators {
@@ -290,11 +260,11 @@ concept __constexpr_indexable = (__constexpr_param<remove_cvref_t<_Args>> && ...
   typename constant_wrapper<_Obj[remove_cvref_t<_Args>::value...]>;
 };
 
-template <__cw_fixed_value _Xp, class>
+template <auto _Xp, class>
 struct constant_wrapper : __cw_operators {
-  static constexpr const auto& value = _Xp.__data;
+  static constexpr decltype(auto) value = (_Xp);
   using type                         = constant_wrapper;
-  using value_type                   = decltype(_Xp)::__type;
+  using value_type                   = decltype(_Xp);
 
   template <__constexpr_param _Rp>
   [[nodiscard]]  constexpr auto operator=(_Rp) const noexcept

--- a/test/conformance/fn_ref/assign.delete.pass.cpp
+++ b/test/conformance/fn_ref/assign.delete.pass.cpp
@@ -44,7 +44,7 @@ STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void()>, ebd::fn_ref<void() const>
 STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void()>, void (*)()>::value);
 STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void()>, void (*)(int)>::value);
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
   STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void()>, std::constant_wrapper<+[] {}>>);
   STATIC_ASSERT_(std::is_constructible_v<ebd::fn_ref<void()>, std::constant_wrapper<[] {}>>);
   STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void()>, std::constant_wrapper<[] {}>>);
@@ -62,7 +62,7 @@ STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const>, ebd::fn_ref<void() 
 STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const>, void (*)()>::value);
 STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, void (*)(int)>::value);
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
   STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void() const>, std::constant_wrapper<[] { return 42; }>>);
   STATIC_ASSERT_(!std::is_assignable_v<ebd::fn_ref<void() const>, std::constant_wrapper<[](int) { return 42; }>>);
 #endif
@@ -77,7 +77,7 @@ STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, void (*)(int)>::va
   STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() noexcept>, void (*)() noexcept>::value);
   STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() noexcept>, void (*)(int) noexcept>::value);
 
-# if __cpp_lib_constant_wrapper >= 202603L
+# if __cpp_lib_constant_wrapper >= 202606L
     STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void() noexcept>, std::constant_wrapper<[] noexcept {} >>);
     STATIC_ASSERT_(!std::is_assignable_v<ebd::fn_ref<void() noexcept>, std::constant_wrapper<[](int) noexcept {}>>);
 # endif
@@ -91,7 +91,7 @@ STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const>, void (*)(int)>::va
   STATIC_ASSERT_(std::is_assignable<ebd::fn_ref<void() const noexcept>, void (*)() noexcept>::value);
   STATIC_ASSERT_(!std::is_assignable<ebd::fn_ref<void() const noexcept>, void (*)(int) noexcept>::value);
 
-# if __cpp_lib_constant_wrapper >= 202603L
+# if __cpp_lib_constant_wrapper >= 202606L
 
     STATIC_ASSERT_(std::is_assignable_v<ebd::fn_ref<void() const noexcept>, std::constant_wrapper<[] noexcept {}>>);
     STATIC_ASSERT_(
@@ -104,7 +104,7 @@ static int forty_two() { return 42; }
 TEST(Conformance_fn_ref, assign_delete_pass) {
   static_cast<void>(&forty_two);
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
   {
     ebd::fn_ref<int()> f(std::cw<[] { return 41; }>);
     f = ebd::fn_ref<int()>(std::cw<[] { return 42; }>);

--- a/test/conformance/fn_ref/clang.bug.pass.cpp
+++ b/test/conformance/fn_ref/clang.bug.pass.cpp
@@ -30,7 +30,7 @@ TEST(Conformance_fn_ref, clang_bug_pass) {
 
   static_cast<void>(&this_name_should_not_be_changed);
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
 # if defined(__clang__) && !defined(EBD_TEST_TRY_BUG__Clang_SameNameStaticFunction)
   ebd::fn_ref<double(int,double)> f = std::cw<+[](int x, double y) { return x + y; }>;

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -128,7 +128,7 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     static_cast<void>(&get_ref); // unused
   }
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
   {
     auto rx = get_ref();

--- a/test/conformance/fn_ref/constant_wrapper.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper.pass.cpp
@@ -27,7 +27,7 @@
 
 #include "test_function.hpp"
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
 #define ASSERT_(...) ASSERT_EQ((__VA_ARGS__) == true, true)
 #ifndef TEST_IS_CONSTANT_EVALUATED
@@ -195,4 +195,4 @@ TEST(Conformance_fn_ref, constant_wrapper_pass) {
 
 }
 
-#endif // __cpp_lib_constant_wrapper >= 202603L
+#endif // __cpp_lib_constant_wrapper >= 202606L

--- a/test/conformance/fn_ref/constant_wrapper_ptr.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper_ptr.pass.cpp
@@ -28,7 +28,7 @@
 
 #include "test_function.hpp"
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
 #define ASSERT_(...) ASSERT_EQ((__VA_ARGS__) == true, true)
 #ifndef TEST_IS_CONSTANT_EVALUATED
@@ -387,4 +387,4 @@ TEST(Conformance_fn_ref, constant_wrapper_ptr_pass) {
 #endif // ^^^ __cpp_deduction_guides >= 201907L
 }
 
-#endif // __cpp_lib_constant_wrapper >= 202603L
+#endif // __cpp_lib_constant_wrapper >= 202606L

--- a/test/conformance/fn_ref/constant_wrapper_ref.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper_ref.pass.cpp
@@ -28,7 +28,7 @@
 
 #include "test_function.hpp"
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
 #define ASSERT_(...) ASSERT_EQ((__VA_ARGS__) == true, true)
 #ifndef TEST_IS_CONSTANT_EVALUATED
@@ -423,4 +423,4 @@ TEST(Conformance_fn_ref, constant_wrapper_ref_pass) {
 
 }
 
-#endif // __cpp_lib_constant_wrapper >= 202603L
+#endif // __cpp_lib_constant_wrapper >= 202606L

--- a/test/conformance/fn_ref/copy.pass.cpp
+++ b/test/conformance/fn_ref/copy.pass.cpp
@@ -64,7 +64,7 @@ TEST(Conformance_fn_ref, copy_pass) {
   static_cast<void>(&this_name_should_not_be_changed);
   static_cast<void>(&needs_conversion_2);
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
   {
     ebd::fn_ref<void()> f(std::cw<[] {}>);
     auto f2 = f;

--- a/test/conformance/fn_ref/copy_assign.pass.cpp
+++ b/test/conformance/fn_ref/copy_assign.pass.cpp
@@ -66,7 +66,7 @@ TEST(Conformance_fn_ref, copy_assign_pass) {
   static_cast<void>(&needs_conversion_1);
   static_cast<void>(&zero_1);
 
-#if 1 && __cpp_lib_constant_wrapper >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202606L
   {
     ebd::fn_ref<void()> f(std::cw<[] {}>);
     ebd::fn_ref<void()> f2(std::cw<[] {}>);

--- a/test/conformance/fn_ref/fail/non_nullptr_init.fail.cpp
+++ b/test/conformance/fn_ref/fail/non_nullptr_init.fail.cpp
@@ -1,0 +1,14 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+#if defined(__GNUC__) && !defined(__clang__)
+  static_assert(false, "");
+#else
+  // ebd::fn_ref shouldn't be created from nullptr.
+  ebd::fn_ref<int()> f = static_cast<int(*)()>(nullptr); // FAIL
+  (void)f;
+#endif
+}

--- a/test/conformance/fn_ref/move.pass.cpp
+++ b/test/conformance/fn_ref/move.pass.cpp
@@ -59,7 +59,7 @@ static int needs_conversion_5(Int x, Int y, Int z) noexcept { return x.i + y.i +
 TEST(Conformance_fn_ref, move_pass) {
   static_cast<void>(&f2);
   static_cast<void>(&needs_conversion_5);
-#if 1 && __cpp_lib_constant_wrapper >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202606L
   {
     ebd::fn_ref<void()> f(std::cw<[] {}>);
     auto f2 = std::move(f);

--- a/test/conformance/fn_ref/move_assign.pass.cpp
+++ b/test/conformance/fn_ref/move_assign.pass.cpp
@@ -66,7 +66,7 @@ TEST(Conformance_fn_ref, move_assign_pass) {
   SUCCEED();
 }
 
-#if __cpp_lib_constant_wrapper >= 202603L
+#if __cpp_lib_constant_wrapper >= 202606L
 
 TEST(Conformance_fn_ref, move_assign_pass_0) {
   ebd::fn_ref<void()> f(std::cw<[] {}>);

--- a/test/conformance/fn_ref/ref.pass.cpp
+++ b/test/conformance/fn_ref/ref.pass.cpp
@@ -207,7 +207,7 @@ int fn() { return 5; }
 #if __cpp_noexcept_function_type >= 201510L && __cpp_constexpr >= 201603L
   constexpr auto fn_noexcept = []() noexcept { return 6; };
 
-#if 1 && __cpp_lib_constant_wrapper >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202606L
   const auto one = []() noexcept { return 1; };
   const auto two = []() noexcept { return 2; };
 # endif
@@ -359,7 +359,7 @@ TEST(Conformance_fn_ref, ref_pass) {
     }
   }
 #endif
-#if 1 && __cpp_lib_constant_wrapper >= 202603L
+#if 1 && __cpp_lib_constant_wrapper >= 202606L
   {
     // P3961R1 Less double indirection in function_ref
     // double unwrapping

--- a/test/test_Lifetime.cpp
+++ b/test/test_Lifetime.cpp
@@ -1,0 +1,95 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "gtest/gtest.h"
+#include "test_function.hpp"
+
+static int free_count = 0;
+
+struct no_double_free_checker {
+    int m_var = 123;
+    ~no_double_free_checker() noexcept { free_count++; }
+};
+
+// https://github.com/Kim-J-Smith/Embedded-Function/issues/75
+TEST(LifetimeTest, no_double_free_in_assignment) {
+    // fn
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::fn<int()> f2;
+        f2 = f1; // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::fn<int()> f2;
+        f2 = std::move(f1); // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    // unique_fn
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::unique_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::unique_fn<int()> f2;
+        f2 = std::move(f1); // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    // safe_fn
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::safe_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::safe_fn<int()> f2;
+        f2 = f1; // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::safe_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::safe_fn<int()> f2;
+        f2 = std::move(f1); // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    // fn -> unique_fn
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::unique_fn<int()> f2;
+        f2 = f1; // 1 + 1 = 2
+    }
+    ASSERT_EQ(free_count, 5);
+
+    // small buffer -> big buffer
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        auto f1 = ebd::make_fn([checker]() { return checker.m_var; }); // 2
+        ebd::fn<int(), 10 * sizeof(void*)> f2;
+        f2 = f1; // 1 + 1 = 2
+    }
+    ASSERT_EQ(free_count, 5);
+
+    // small buffer -> big buffer & fn -> unique_fn
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        auto f1 = ebd::make_fn([checker]() { return checker.m_var; }); // 2
+        ebd::unique_fn<int(), 10 * sizeof(void*)> f2;
+        f2 = f1; // 1 + 1 = 2
+    }
+    ASSERT_EQ(free_count, 5);
+}
+
+


### PR DESCRIPTION
## Fixed

- Fixed a double‑free bug in copy and move assignment operators for `ebd::fn`, `ebd::unique_fn`, and `ebd::safe_fn` (#75, #76).
- Added a dedicated lifetime test suite to prevent regressions.

## Changed

- Updated experimental `std::constant_wrapper` support to conform to P4206R0, which reverts the string support introduced in earlier drafts (#68).
- Improved static assertion messages for `make_fn()` and function signatures – they now provide more actionable hints when template deduction fails (#69).
- Relaxed internal manager constraints: `std::is_trivially_copyable` is now used instead of a more restrictive "traditional trivial" check, allowing a wider set of functors to be stored in‑place (#70).
- Refactored the type‑erasure invoker to remove unnecessary cv‑qualifiers and `const_cast` calls, simplifying the codebase without changing public behavior (#71).
- Cleaned up macro formatting and added `!defined(__clang__)` guards for MSVC‑specific code paths (#72).

## Added

- Added a comprehensive set of runtime benchmarks covering creation, copy/move assignment, and various parameter types for `ebd::fn`, `std::function`, `fu2::function`, and `std::move_only_function` (#73, #77).
- Introduced nullability annotations (`_Nonnull`/`_Notnull_`) on the `fn_ref` constructor from function pointers to aid static analysis (#69).
- Enabled Windows CI for the benchmark suite (#73).

## Notes

- `std::constant_wrapper` support is experimental as of v2.1.7.
- The experimental `constant_wrapper` support has been updated to align with P4206R0, removing the previously available string support. Users who were experimenting with that feature may need to adjust their code.