### PR TITLE
Eliminate the noise in diagnostic.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1491,6 +1491,9 @@ inline namespace fn_traits {
   /// @todo experimental
   template <typename T, bool Val = std::meta::is_complete_type(^^T)>
   consteval bool is_complete_here_impl(int) noexcept { return Val; }
+#elif defined(__clang__) && EMBED_HAS_BUILTIN(__is_complete_type)
+  template <typename T, bool Val = __is_complete_type(T)>
+  constexpr bool is_complete_here_impl(int) noexcept { return Val; }
 #else
   template <typename T, typename = void>
   constexpr bool is_complete_here_impl(...) noexcept {
@@ -1502,10 +1505,8 @@ inline namespace fn_traits {
 #endif
 
   // Use template parameter `IsCompleteHere` to avoid violating ODR.
-  template <typename T, bool IsCompleteHere = is_complete_here_impl<T>(0)>
-  constexpr bool is_complete_or_unbounded_here() noexcept {
-    return IsCompleteHere || std::is_void<T>::value || is_unbounded_array<T>::value;
-  }
+  template <typename T, bool Val = is_complete_here_impl<T>(0)>
+  constexpr bool is_complete_here() noexcept { return Val; }
 
   // MSVC 19.21 and earlier have a bug when using `sizeof(T) <= sizeof(void*)`
   // in `conditional_t`. To work around this issue and facilitate targeted
@@ -1529,8 +1530,9 @@ inline namespace fn_traits {
   };
 
   // Avoid triggering repeated error messages caused by incompleteness.
+  // According to [temp.point]/7, this specialization should only be used in error situations.
   template <typename T> // use `enable_if_t` as MSVC workaround
-  struct is_register_passable<T, enable_if_t<!is_complete_or_unbounded_here<T>()>>
+  struct is_register_passable<T, enable_if_t<!is_complete_here<T>()>>
   : std::false_type {};
 
   // Used to choose either perfect forwarding or pass-by-value.
@@ -1799,10 +1801,8 @@ inline namespace fn_traits {
 
   template <template <class...> class T, typename... Args,
     // Use template parameter `Val` to avoid violating ODR.
-    bool Val = logical_and<is_complete_or_unbounded_here<Args>()...>::value>
-  constexpr bool each_param_is_complete_or_unbounded_here(T<Args...>) noexcept {
-    return Val;
-  }
+    bool Val = logical_and<is_complete_here<Args>()...>::value>
+  constexpr bool each_param_is_complete_here(T<Args...>) noexcept { return Val; }
 
 } // end namespace fn_traits
 
@@ -2604,7 +2604,7 @@ namespace crtp_mixins {
 
     // Assert each parameter type is a complete class.
     static_assert(
-      each_param_is_complete_or_unbounded_here(typename unwrap_signature<Signature>::args{}),
+      each_param_is_complete_here(typename unwrap_signature<Signature>::args{}),
       "each parameter type must be a complete class");
 
     // Assert the noexcept-qualifier in `Signature` matchs the `Config`.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2584,13 +2584,13 @@ namespace crtp_mixins {
     // Zero initialize the `m_erasure` and `m_command`.
     constexpr member_variable_impl(std::nullptr_t) noexcept
     : m_erasure(erasure_t{}), m_command(command_t{}) {}
-  protected:
-    using erasure_t = erasure_type::Erasure<BufferSize>;
 
+    using erasure_t = erasure_type::Erasure<BufferSize>;
     using command_t = command::CommandTable<
       Config::isView, BufferSize, Config, Signature,
       typename unwrap_signature<Signature>::args>;
 
+  protected:
     // Assert the `Config` is config_package.
     static_assert(is_config_package<Config>::value, EMBED_DETAIL_REPORT_IE("Config is invalid."));
 
@@ -2720,7 +2720,7 @@ namespace crtp_mixins {
   /// @tparam Signature - The signature of the wrapper, e.g., @e `Ret(Args...)`.
   template <std::size_t BufferSize, typename Config, typename Signature>
   class EMBED_DETAIL_FORCE_EBO function final
-    : public crtp_mixins::member_variable_impl<
+    : protected crtp_mixins::member_variable_impl<
         /* Buf = */ BufferSize, /* Cfg = */ Config, /* Sig = */ Signature
       >,
       public crtp_mixins::operator_call_impl<
@@ -2832,17 +2832,7 @@ namespace crtp_mixins {
 # pragma GCC diagnostic pop
 #endif
 
-    /// @brief All following methods that begin with `Base_CoreComponents` are implemented in
-    /// the base class @e `crtp_mixins::core_components_impl`.
-
-    using Base_CoreComponents::is_empty;
-
-    using Base_CoreComponents::operator bool;
-
-    using Base_CoreComponents::clear;
-
-    using Base_CoreComponents::swap;
-
+    /// Implemented in the base class @e `crtp_mixins::core_components_impl`.
     using Base_CoreComponents::operator=;
 
     // Create an empty function wrapper.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1488,12 +1488,14 @@ inline namespace fn_traits {
   using get_member_fn_type_t = typename get_member_fn_type<Signature>::type;
 
 #if __cpp_lib_reflection >= 202506L
-  /// @todo experimental
+  /// @todo experimental `std::meta::is_complete_type`
+  // Use template parameter `Val` to avoid violating ODR.
   template <typename T, bool Val = std::meta::is_complete_type(^^T)>
-  consteval bool is_complete_here_impl(int) noexcept { return Val; }
+  consteval bool is_complete_here() noexcept { return Val; }
 #elif defined(__clang__) && EMBED_HAS_BUILTIN(__is_complete_type)
+  // Use template parameter `Val` to avoid violating ODR.
   template <typename T, bool Val = __is_complete_type(T)>
-  constexpr bool is_complete_here_impl(int) noexcept { return Val; }
+  constexpr bool is_complete_here() noexcept { return Val; }
 #else
   template <typename T, typename = void>
   constexpr bool is_complete_here_impl(...) noexcept {
@@ -1502,11 +1504,11 @@ inline namespace fn_traits {
 
   template <typename T, typename = enable_if_t<sizeof(T) && std::is_object<T>::value>>
   constexpr bool is_complete_here_impl(int) noexcept { return true; }
-#endif
 
-  // Use template parameter `IsCompleteHere` to avoid violating ODR.
+  // Use template parameter `Val` to avoid violating ODR.
   template <typename T, bool Val = is_complete_here_impl<T>(0)>
   constexpr bool is_complete_here() noexcept { return Val; }
+#endif
 
   // MSVC 19.21 and earlier have a bug when using `sizeof(T) <= sizeof(void*)`
   // in `conditional_t`. To work around this issue and facilitate targeted

--- a/test/test_BasicAttributes.cpp
+++ b/test/test_BasicAttributes.cpp
@@ -122,3 +122,36 @@ TEST(BasicAttributes, DefaultConfig) {
         >::value, 
         "The default config of ebd::fn_ref has been changed!");
 }
+
+// BasicAttributes[5]
+// The `void` and `int[]` are not really incomplete type.
+TEST(BasicAttributes, SeemsIncomplete) {
+    {
+        ebd::fn<int(void)> f1 = [] { return 42; };
+        ebd::fn<int(int[])> f2 = [](int[]) { return 43; };
+
+        ASSERT_EQ(f1(), 42);
+        ASSERT_EQ(f2(nullptr), 43);
+    }
+    {
+        ebd::unique_fn<int(void)> f1 = [] { return 42; };
+        ebd::unique_fn<int(int[])> f2 = [](int[]) { return 43; };
+
+        ASSERT_EQ(f1(), 42);
+        ASSERT_EQ(f2(nullptr), 43);
+    }
+    {
+        ebd::safe_fn<int(void)> f1 = [] { return 42; };
+        ebd::safe_fn<int(int[])> f2 = [](int[]) { return 43; };
+
+        ASSERT_EQ(f1(), 42);
+        ASSERT_EQ(f2(nullptr), 43);
+    }
+    {
+        ebd::fn_ref<int(void)> f1 = +[] { return 42; };
+        ebd::fn_ref<int(int[])> f2 = +[](int[]) { return 43; };
+
+        ASSERT_EQ(f1(), 42);
+        ASSERT_EQ(f2(nullptr), 43);
+    }
+}


### PR DESCRIPTION
1. use `is_complete_here` instead of `is_complete_or_unbounded_here`.

2. make the `erasure_t` and `command_t` public in `member_variable_impl` to eliminate the noise `error: 'erasure_t' is a protected member of 'ebd::detail::crtp_mixins::member_variable_impl<...>'` and `error: 'command_t' is a protected member of 'ebd::detail::crtp_mixins::member_variable_impl<...>'`.

3. remove unused `using Base_CoreComponents::xxx;` to eliminate the noise `error: using declaration refers into 'Base_CoreComponents', which is not a base class of 'function<...>'`.