### PR TITLE
Version 2.1.9

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,9 +3,17 @@ name: "Benchmark"
 on:
   push:
     branches: [ main, version-* ]
+    paths:
+      - 'include/**'
+      - 'benchmark/**'
+      - '.github/workflows/benchmark.yml'
   pull_request:
     branches: [ main, version-* ]
     types: [ opened, synchronize, reopened ]
+    paths:
+      - 'include/**'
+      - 'benchmark/**'
+      - '.github/workflows/benchmark.yml'
 
 jobs:
   # Ubuntu check

--- a/.github/workflows/example-pass.yml
+++ b/.github/workflows/example-pass.yml
@@ -1,0 +1,40 @@
+name: "Example Build"
+
+on:
+  pull_request:
+    branches: [ main, version-* ]
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - 'example/**'
+      - 'include/**'
+      - '.github/workflows/example-pass.yml'
+
+jobs:
+  build-examples:
+    if: github.repository_owner == 'Kim-J-Smith'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install compilers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends g++ clang
+
+      - name: Build with g++ (C++11)
+        run: |
+          g++ -std=c++11 -I include -o /dev/null example/basic_usage.cpp
+          g++ -std=c++11 -I include -o /dev/null example/callback_abstraction.cpp
+          g++ -std=c++11 -I include -o /dev/null example/make_fn_deduction.cpp
+          g++ -std=c++11 -I include -o /dev/null example/member_binding.cpp
+          g++ -std=c++11 -I include -o /dev/null example/thread_pool.cpp
+
+      - name: Build with clang++ (C++11)
+        run: |
+          clang++ -std=c++11 -I include -o /dev/null example/basic_usage.cpp
+          clang++ -std=c++11 -I include -o /dev/null example/callback_abstraction.cpp
+          clang++ -std=c++11 -I include -o /dev/null example/make_fn_deduction.cpp
+          clang++ -std=c++11 -I include -o /dev/null example/member_binding.cpp
+          clang++ -std=c++11 -I include -o /dev/null example/thread_pool.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,17 @@
 *CMakeFiles*
 
 .clang-tidy
+.clangd
 
 *.idea*
 *.cache*
+
+/build/
+CMakeCache.txt
+Makefile
+*.pdb
+.DS_Store
+Thumbs.db
+*.log
+*.swp
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.1.8 LANGUAGES CXX)
+project(embedded_function VERSION 2.1.9 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.1.8-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.8">
+  <img src="https://img.shields.io/badge/Version-2.1.9-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.9">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23">
 </p>
@@ -9,8 +9,6 @@
 <p align="center">
   <a href="https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/test.yml">
     <img src="https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/test.yml/badge.svg">
-  </a>
-  <a>
     <img src="https://img.shields.io/badge/GCC_C++11~23-support-B46F1B?style=flat&logo=gnu" alt="gcc-C++11~23 - support">
     <img src="https://img.shields.io/badge/Clang_C++11~23-support-045891?style=flat&logo=llvm" alt="clang-C++11~23 - support">
     <img src="https://img.shields.io/badge/MSVC_C++14~23-support-5C2D91?style=flat" alt="msvc-C++14~23 - support">
@@ -122,7 +120,7 @@ auto main() -> int {
     - Allow the application of qualifiers, such as `const`, `volatile`, `&` and `&&`, to the function signature.
     - Ensure that the qualifier of the underlying object is consistent or more restrictive than that of the function signature.
 
-  - Learn and refer to the optimization experience of `std::function` in [libstdc++](https://gcc.gnu.org/cgit/gcc/commit/?id=d38d26be33aba5d4c12429478375a47c474124d2), [libc++](https://reviews.llvm.org/D55045) and [Microsoft C++ Standard Library](https://github.com/microsoft/STL/issues/969).
+  - Learn and refer to the optimization experience of `std::function` in libc++, libstdc++, MSVC STL.
 
   - Provide a view or reference to the callable object, referring to the [`std::function_ref` P0792](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0792r14.html).
 
@@ -346,8 +344,6 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 > See [here](https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/benchmark.yml) for more benchmark results. Follow [`benchmark/README.md`](./benchmark/README.md) to run the benchmark in your platform.
 
 ## 🧭 Future learning & evolution reference
-
-- [`llvm::function_ref`](https://reviews.llvm.org/D106784?id=361604).
 
 - [C++26-`std::function_ref`-P0792](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0792r14.html).
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ auto main() -> int {
 }
 ```
 
+> More examples are available in the [`example/`](./example/) directory.
+
 ## 🔧 Wrapper definition syntax
 
 ```cpp

--- a/docs/api/basic_fn.md
+++ b/docs/api/basic_fn.md
@@ -69,7 +69,7 @@ view(42);
 ## Notes
 
 - Prefer using the predefined aliases (`ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, `ebd::fn_view`) unless you need a combination not covered by them.
-- The buffer size is automatically aligned to the nearest word size.
+- The buffer size is automatically aligned to the nearest alignment boundary.
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
 
 ## See Also

--- a/docs/api/detail/function.md
+++ b/docs/api/detail/function.md
@@ -277,6 +277,6 @@ int result = add(10, 20); // result = 30
 ## Notes
 
 - The `ebd::detail::function` class is not intended for direct use. Instead, use the predefined aliases such as `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, and `ebd::fn_view`.
-- The buffer size is automatically aligned to the nearest word size.
+- The buffer size is automatically aligned to the nearest alignment boundary.
 - The function wrapper supports all callable objects, including free functions, lambdas, functors, static member functions, and member functions.
 - When `Config::isView` is `true`, the wrapper acts as a non-owning view, similar to `std::function_ref`.

--- a/docs/api/fn.md
+++ b/docs/api/fn.md
@@ -68,7 +68,7 @@ fn(100);
 ## Notes
 
 - `ebd::fn` is copyable and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest word size.
+- The buffer size is automatically aligned to the nearest alignment boundary.
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
 - When called in an empty state, `ebd::fn` will throw `std::bad_function_call` (if exceptions are enabled).
 

--- a/docs/api/safe_fn.md
+++ b/docs/api/safe_fn.md
@@ -68,7 +68,7 @@ fn(100);
 ## Notes
 
 - `ebd::safe_fn` is copyable and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest word size.
+- The buffer size is automatically aligned to the nearest alignment boundary.
 - The callable object must be noexcept in all operations (construction, destruction, copy, move).
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
 - When called in an empty state, `ebd::safe_fn` will call `std::terminate()` instead of throwing an exception.

--- a/docs/api/unique_fn.md
+++ b/docs/api/unique_fn.md
@@ -74,7 +74,7 @@ fn(100);
 ## Notes
 
 - `ebd::unique_fn` is move-only and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest word size.
+- The buffer size is automatically aligned to the nearest alignment boundary.
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
 - When called in an empty state, `ebd::unique_fn` will throw `std::bad_function_call` (if exceptions are enabled).
 

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,15 +1,15 @@
-## 🔧 Fixed Bugs
-- Fixed a bug where `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` could not wrap callable objects that were aligned to `alignof(std::max_align_t)` on some platforms.
+**🔧 Fixed Bugs**
+- Fixed a bug where `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` could not wrap callable objects that were aligned to `alignof(std::max_align_t)` on some platforms. (#96)
 
-## ⚠️ Breaking Changes
-- The alignment of `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` has been changed to `alignof(std::max_align_t)`.
+**⚠️ Breaking Changes**
+- The alignment of `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` has been changed to `alignof(std::max_align_t)`. (#96)
 
-## ✨ New Features
-- Added some code examples in `example/`.
+**✨ New Features**
+- Added some code examples in `example/`. (#95)
 
-## 🛠️ Optimizations and Improvements
-- Optimized debug information to provide better diagnostics.
+**🛠️ Optimizations and Improvements**
+- Optimized debug information to provide better diagnostics. (#97)
 
-## 📌 Notes
+**📌 Notes**
 - **The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` will be removed in v2.2.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.
 - As of v2.1.9, the usage of `std::constant_wrapper` and `std::meta::is_complete_type` remains **experimental**. These features have been officially adopted in the C++26 standard (`ISO/IEC 14882:2026`) and will become fully stable starting from **v2.2.0**.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,14 +1,14 @@
 ## 🔧 Fixed Bugs
-- Fixed a bug where `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` could not wrap callable objects that was aligned to `alignof(std::max_align_t)` on some platforms.
+- Fixed a bug where `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` could not wrap callable objects that were aligned to `alignof(std::max_align_t)` on some platforms.
 
 ## ⚠️ Breaking Changes
-- `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` are now aligned to `alignof(std::max_align_t)`.
+- The alignment of `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` has been changed to `alignof(std::max_align_t)`.
 
 ## ✨ New Features
 - Added some code examples in `example/`.
 
 ## 🛠️ Optimizations and Improvements
-- None.
+- Optimized debug information to provide better diagnostics.
 
 ## 📌 Notes
 - **The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` will be removed in v2.2.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,11 +1,11 @@
 ## 🔧 Fixed Bugs
-- None.
+- Fixed a bug where `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` could not wrap callable objects that was aligned to `alignof(std::max_align_t)` on some platforms.
 
 ## ⚠️ Breaking Changes
-- None.
+- `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` are now aligned to `alignof(std::max_align_t)`.
 
 ## ✨ New Features
-- None.
+- Added some code examples in `example/`.
 
 ## 🛠️ Optimizations and Improvements
 - None.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -5,12 +5,11 @@
 - None.
 
 ## ✨ New Features
-- Added a static assertion for the completeness of parameter types in the function wrappers. This helps to determine the cause of the error. (#80 #83)
+- None.
 
 ## 🛠️ Optimizations and Improvements
-- Replaced the internal `switch-case` branch dispatch with a `VTable` mechanism for better lifetime management and reduced function‑call overhead, resulting in improved performance. (#74 #84)
-- Renamed all `HOW-TO-*` documentation files to `README.md` to provide better navigation on GitHub. (#86)
+- None.
 
 ## 📌 Notes
-- **The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` will be removed in v2.0.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.
-- As of v2.1.8, the usage of `std::constant_wrapper` and `std::meta::is_complete_type` remains **experimental**. These features have been officially adopted in the C++26 standard (`ISO/IEC 14882:2026`) and will become fully stable starting from **v2.2.0**.
+- **The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` will be removed in v2.2.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.
+- As of v2.1.9, the usage of `std::constant_wrapper` and `std::meta::is_complete_type` remains **experimental**. These features have been officially adopted in the C++26 standard (`ISO/IEC 14882:2026`) and will become fully stable starting from **v2.2.0**.

--- a/example/basic_usage.cpp
+++ b/example/basic_usage.cpp
@@ -1,0 +1,72 @@
+/// basic_usage.cpp — four wrapper types: fn, unique_fn, safe_fn, fn_ref
+#include <iostream>
+#include <memory>
+#include <embed/embed_function.hpp>
+
+static int add(int a, int b) { return a + b; }
+
+struct Printer {
+    void operator()(const char* msg) const noexcept {
+        std::cout << "Printer: " << msg << '\n';
+    }
+};
+
+struct MoveOnly {
+    std::unique_ptr<int> val;
+    explicit MoveOnly(int v) : val(new int(v)) {}
+    MoveOnly(MoveOnly&&) = default;
+    MoveOnly& operator=(MoveOnly&&) = default;
+    int operator()(int x) const { return *val + x; }
+};
+
+/*
+=== Typical output:
+fn  add: 7
+fn  mul: 12
+fn2 mul: 30
+ufn  : 101
+ufn2 : 102
+Printer: Hello safe_fn!
+ref  : 70
+empty_fn is empty
+===
+*/
+
+int main() {
+    // ebd::fn — copyable, owning
+    ebd::fn<int(int, int)> fn1;
+    fn1 = &add;
+    std::cout << "fn  add: " << fn1(3, 4) << '\n';
+
+    fn1 = [](int a, int b) { return a * b; };
+    std::cout << "fn  mul: " << fn1(3, 4) << '\n';
+
+    ebd::fn<int(int, int)> fn2 = fn1;  // copy
+    std::cout << "fn2 mul: " << fn2(5, 6) << '\n';
+
+    // ebd::unique_fn — move-only, owning
+    ebd::unique_fn<int(int)> ufn;
+    ufn = MoveOnly(100);
+    std::cout << "ufn  : " << ufn(1) << '\n';
+
+    ebd::unique_fn<int(int)> ufn2 = std::move(ufn);  // move
+    std::cout << "ufn2 : " << ufn2(2) << '\n';
+
+    // ebd::safe_fn — copyable, requires noexcept callable
+    ebd::safe_fn<void(const char*)> sfn;
+    sfn = Printer{};
+    sfn("Hello safe_fn!");
+
+    // ebd::fn_ref — non-owning view (zero overhead)
+    int factor = 10;
+    auto lambda = [&factor](int x) { return x * factor; };
+    ebd::fn_ref<int(int)> ref = lambda;
+    std::cout << "ref  : " << ref(7) << '\n';
+
+    // Empty state check
+    ebd::fn<void()> empty_fn;
+    std::cout << "empty_fn is "
+              << (empty_fn ? "not empty" : "empty") << '\n';
+
+    return 0;
+}

--- a/example/callback_abstraction.cpp
+++ b/example/callback_abstraction.cpp
@@ -1,0 +1,74 @@
+/// callback_abstraction.cpp — fn_ref as zero-overhead callback param, fn as stored callback
+#include <iostream>
+#include <vector>
+#include <embed/embed_function.hpp>
+
+// fn_ref passed entirely in registers — enables direct tail-call to the target
+template <typename T>
+void for_each(const std::vector<T>& vec, ebd::fn_ref<void(const T&)> callback) {
+    for (typename std::vector<T>::size_type i = 0; i < vec.size(); ++i) {
+        callback(vec[i]);
+    }
+}
+
+// fn as stored callback holder (copyable, heap-free)
+struct Button {
+    ebd::fn<void()> onClick;
+
+    void click() {
+        if (onClick) { onClick(); }
+    }
+};
+
+static void print_int(int x) {
+    std::cout << '[' << x << "] ";
+}
+
+struct PrintStr {
+    const char* prefix;
+    void operator()(int x) const {
+        std::cout << prefix << x << ' ';
+    }
+};
+
+/*
+=== Typical output:
+free func: [0] [10] [20] [30] [40]
+sum via lambda: 100
+functor: *0 *10 *20 *30 *40
+Button clicked!
+Total so far: 100
+===
+*/
+
+int main() {
+    std::vector<int> nums;
+    nums.reserve(5);
+    for (int i = 0; i < 5; ++i) { nums.push_back(i * 10); }
+
+    // Free function pointer via fn_ref
+    std::cout << "free func: ";
+    for_each(nums, ebd::fn_ref<void(const int&)>(&print_int));
+    std::cout << '\n';
+
+    // Lambda with capture via fn_ref
+    int total = 0;
+    for_each(nums, ebd::fn_ref<void(const int&)>(
+        [&total](const int& v) { total += v; }));
+    std::cout << "sum via lambda: " << total << '\n';
+
+    // Functor via fn_ref
+    std::cout << "functor: ";
+    for_each(nums, ebd::fn_ref<void(const int&)>(PrintStr{"*"}));
+    std::cout << '\n';
+
+    // fn as stored callback
+    Button btn;
+    btn.onClick = [] { std::cout << "Button clicked!\n"; };
+    btn.click();
+
+    btn.onClick = [&total] { std::cout << "Total so far: " << total << '\n'; };
+    btn.click();
+
+    return 0;
+}

--- a/example/make_fn_deduction.cpp
+++ b/example/make_fn_deduction.cpp
@@ -1,0 +1,77 @@
+/// make_fn_deduction.cpp — auto-deduced signature, member function wrapping, operator* fallback
+#include <iostream>
+#include <embed/embed_function.hpp>
+
+static void greet(const char* name) {
+    std::cout << "Hello, " << name << "!\n";
+}
+
+struct Counter {
+    int count;
+    explicit Counter(int c = 0) : count(c) {}
+
+    int get() const { return count; }
+    void set(int c) { count = c; }
+    void inc() { ++count; }
+};
+
+struct Doubler {
+    int operator()(int x) const { return x * 2; }
+};
+
+/*
+=== Typical output:
+Hello, make_fn from free function!
+Hello, raw function pointer!
+lambda sum: 30
+Doubler(21) = 42
+getter(c) = 0
+after inc: 1
+after set: 99
+filled later
+unique_fn!
+===
+*/
+
+int main() {
+    // Deduce from free function pointer
+    auto fn1 = ebd::make_fn(&greet);
+    fn1("make_fn from free function");
+
+    // operator* recovers the raw function pointer
+    void(*raw_ptr)(const char*) = *fn1;
+    raw_ptr("raw function pointer");
+
+    // Deduce from lambda (signature + buffer size auto-inferred)
+    auto fn2 = ebd::make_fn([](int a, int b) { return a + b; });
+    std::cout << "lambda sum: " << fn2(10, 20) << '\n';
+
+    // Deduce from functor
+    auto fn3 = ebd::make_fn(Doubler{});
+    std::cout << "Doubler(21) = " << fn3(21) << '\n';
+
+    // Wrap member functions
+    Counter c(0);
+
+    auto getter = ebd::make_fn(&Counter::get);
+    std::cout << "getter(c) = " << getter(c) << '\n';
+
+    auto increment = ebd::make_fn(&Counter::inc);
+    increment(c);
+    std::cout << "after inc: " << getter(c) << '\n';
+
+    auto setter = ebd::make_fn(&Counter::set);
+    setter(c, 99);
+    std::cout << "after set: " << getter(c) << '\n';
+
+    // Explicit signature (e.g., for overload disambiguation)
+    auto empty_fn = ebd::make_fn<void()>();
+    empty_fn = [] { std::cout << "filled later\n"; };
+    empty_fn();
+
+    // Explicit wrapper type
+    auto ufn = ebd::make_fn<ebd::unique_fn>([]() { std::cout << "unique_fn!\n"; });
+    ufn();
+
+    return 0;
+}

--- a/example/member_binding.cpp
+++ b/example/member_binding.cpp
@@ -1,0 +1,77 @@
+/// member_binding.cpp — member function wrapping, object binding, wrapper conversions
+#include <iostream>
+#include <string>
+#include <embed/embed_function.hpp>
+
+struct Dog {
+    std::string name;
+    explicit Dog(const char* n) : name(n) {}
+
+    void speak() const {
+        std::cout << name << " barks: Woof!\n";
+    }
+    void rename(const char* n) {
+        name = n;
+    }
+};
+
+struct Cat {
+    std::string name;
+    explicit Cat(const char* n) : name(n) {}
+
+    void speak() const {
+        std::cout << name << " meows: Meow~\n";
+    }
+};
+
+// fn_ref as parameter — accepts fn, unique_fn, fn_ref, etc.
+void process(ebd::fn_ref<void() const> action) {
+    action();
+}
+
+/*
+=== Typical output:
+Buddy barks: Woof!
+Whiskers meows: Meow~
+Buddy barks: Woof!
+Whiskers meows: Meow~
+Buddy barks: Woof!
+Buddy barks: Woof!
+Rex barks: Woof!
+===
+*/
+
+int main() {
+    Dog dog("Buddy");
+    Cat cat("Whiskers");
+
+    // Way 1: wrap member function pointer directly (object passed as 1st arg)
+    ebd::fn<void(const Dog&) const> dog_memfn = ebd::make_fn(&Dog::speak);
+    ebd::fn<void(const Cat&) const> cat_memfn = ebd::make_fn(&Cat::speak);
+
+    dog_memfn(dog);
+    cat_memfn(cat);
+
+    // Way 2: bind object via lambda -> zero-arg callable
+    ebd::fn<void() const> dog_lambda = [&dog] { dog.speak(); };
+    ebd::fn<void() const> cat_lambda = [&cat] { cat.speak(); };
+
+    process(dog_lambda);
+    process(cat_lambda);
+
+    // Wrapper conversions: unique_fn -> fn_ref
+    ebd::unique_fn<void() const> utemp = [&dog] { dog.speak(); };
+    ebd::fn_ref<void() const> ref_from_unique = utemp;
+    process(ref_from_unique);
+
+    // fn -> fn (copy)
+    ebd::fn<void() const> fn_copy = dog_lambda;
+    process(fn_copy);
+
+    // Non-const member function with extra argument
+    ebd::fn<void(Dog&, const char*)> rename = ebd::make_fn(&Dog::rename);
+    rename(dog, "Rex");
+    process(dog_lambda);  // name changed
+
+    return 0;
+}

--- a/example/thread_pool.cpp
+++ b/example/thread_pool.cpp
@@ -1,0 +1,96 @@
+/// thread_pool.cpp — simple thread pool using ebd::unique_fn for move-only task storage
+#include <iostream>
+#include <thread>
+#include <mutex>
+#include <future>
+#include <vector>
+#include <queue>
+#include <condition_variable>
+#include <functional>
+#include <type_traits>
+#include <embed/embed_function.hpp>
+
+class ThreadPool {
+private:
+    using Task_t = decltype(ebd::make_fn<void()>(std::packaged_task<void()>{}));
+
+    std::vector<std::thread> m_wokers;
+    std::queue<Task_t> m_tasks;
+    std::mutex m_mutex;
+    std::condition_variable m_cond_var;
+    bool m_stop_flag;
+
+#if EMBED_CXX_VERSION >= 201703L
+    template <class F, class... Ts> using Result_t = std::invoke_result_t<F, Ts...>;
+#else
+    template <class F, class... Ts> using Result_t = typename ebd::detail::invoke_result<F, Ts...>::type;
+#endif
+
+    void thread_work() {
+        while (true) {
+            Task_t task;
+            {
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_cond_var.wait(lock, [this] { return m_stop_flag || !m_tasks.empty(); });
+                if (m_stop_flag && m_tasks.empty()) { return; }
+                task = std::move(m_tasks.front());
+                m_tasks.pop();
+            }
+            task();
+        }
+    }
+public:
+    explicit ThreadPool(std::size_t thread_number = std::thread::hardware_concurrency()) {
+        if (thread_number == 0) { thread_number = 1; }
+        m_wokers.reserve(thread_number);
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_stop_flag = false;
+            for (std::size_t i = 0; i < thread_number; i++) {
+                m_wokers.emplace_back(&ThreadPool::thread_work, this);
+            }
+        }
+    }
+
+    ~ThreadPool() {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_stop_flag = true;
+        }
+        m_cond_var.notify_all();
+        for (auto& w : m_wokers) { w.join(); }
+    }
+
+    template <typename Callable, typename... Args>
+    std::future<Result_t<Callable, Args...>> submit(Callable&& callable_obj, Args&&... args) {
+        // ebd::unique_fn wraps move-only packaged_task - no std::shared_ptr needed
+        auto new_task = std::packaged_task<Result_t<Callable, Args...>()>(
+            std::bind(std::forward<Callable>(callable_obj), std::forward<Args>(args)...));
+        auto result = new_task.get_future();
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_tasks.emplace(std::move(new_task));
+        }
+        m_cond_var.notify_one();
+        return result;
+    }
+};
+
+/*
+=== Typical output:
+Hello! I'm task 1;
+Task 4 return: Hello! I'm task 2;
+Hello! I'm task 3;
+Hello! I'm task 4;
+42
+===
+*/
+
+int main() {
+    ThreadPool tp;
+    tp.submit([]{ std::cout << "Hello! I'm task 1;\n"; });
+    tp.submit([]{ std::cout << "Hello! I'm task 2;\n"; });
+    tp.submit([]{ std::cout << "Hello! I'm task 3;\n"; });
+    auto res = tp.submit([]{ std::cout << "Hello! I'm task 4;\n"; return 42; });
+    std::cout << "Task 4 return: " << res.get() << '\n';
+}

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1003,13 +1003,44 @@ inline namespace fn_traits {
   template <typename T, bool IsView = true>
   using get_stored_type_t = typename get_stored_type<T, IsView>::type;
 
-  // Implement the `fn_can_convert`.
+  // [func.wrap.move.ctor]/1
+  template <typename Signature, typename Fn, typename Ret, typename ArgsPackage>
+  struct is_callable_from_pkg;
+
+  template <typename Signature, typename Fn, typename Ret, typename... Args>
+  struct is_callable_from_pkg<Signature, Fn, Ret, args_package<Args...>> {
+    using unwrap_sig  = unwrap_signature<Signature>;
+    using f_cv        = typename unwrap_sig::template add_cv_like<Fn>;
+    using f_cvref     = typename unwrap_sig::template add_cvref_like<Fn>;
+    using f_inv_quals = conditional_t<unwrap_sig::hasRRef, f_cv&&, f_cv&>;
+
+    static constexpr bool value = unwrap_sig::isNoexcept
+      ? is_nothrow_invocable_r<Ret, f_cvref, Args...>::value
+        && is_nothrow_invocable_r<Ret, f_inv_quals, Args...>::value
+      : is_invocable_r<Ret, f_cvref, Args...>::value
+        && is_invocable_r<Ret, f_inv_quals, Args...>::value;
+  };
+
+  // Check the functor is callable with given arguments.
+  // [func.wrap.move.ctor]/1
+  template <typename Functor, typename Signature>
+  struct is_callable_from_impl {
+    using unwrap_sig = unwrap_signature<Signature>;
+    using ret       = typename unwrap_sig::ret;
+    using args_pack = typename unwrap_sig::args;
+    using dec_func  = decay_t<Functor>;
+
+    static constexpr bool value =
+      is_callable_from_pkg<Signature, dec_func, ret, args_pack>::value;
+  };
+
+  // Implement `is_convertible_from_specialization`.
   template <typename To, typename From>
-  struct fn_can_convert_impl : public std::false_type {};
+  struct is_convertible_from_specialization_impl : public std::false_type {};
 
   template <std::size_t BufTo, typename CfgTo, typename SigTo,
     std::size_t BufFrom, typename CfgFrom, typename SigFrom>
-  struct fn_can_convert_impl<
+  struct is_convertible_from_specialization_impl<
     function<BufTo, CfgTo, SigTo>, function<BufFrom, CfgFrom, SigFrom>
   > {
     // Get the unwrap trait.
@@ -1042,23 +1073,18 @@ inline namespace fn_traits {
       || (CfgTo::isView && CfgFrom::isView && unwrap_to::isNoexcept < unwrap_from::isNoexcept);
 
     static constexpr bool qualifier_ok =
-      (unwrap_to::hasConst <= unwrap_from::hasConst)
-      /// TODO: `volatile` -> non-`volatile` seems valid. Test and assembly analysis are needed.
-      && (unwrap_to::hasVolatile == unwrap_from::hasVolatile)
-      && (unwrap_to::hasRRef == unwrap_from::hasRRef)
-      && (unwrap_to::hasLRef == unwrap_from::hasLRef)
-      && noexcept_qualifier_ok;
+      // The `const` and `noexcept` checks in the Non-owning context have certain peculiarities.
+      noexcept_qualifier_ok && unwrap_to::hasConst <= unwrap_from::hasConst
+      && is_callable_from_impl<function<BufFrom, CfgFrom, SigFrom>, SigTo>::value;
 
     static constexpr bool value =
       buf_ok && cfg_ok && sig_ret_ok && sig_args_ok && qualifier_ok;
   };
 
-  // Check ebd::detail::function are similar or not.
+  // If the `From` type can be converted to the `To` type, then the value is `true`.
   template <typename To, typename From>
-  struct fn_can_convert : public bool_constant<
-    fn_can_convert_impl<
-      remove_reference_t<To>, remove_reference_t<From>
-    >::value
+  struct is_convertible_from_specialization : public bool_constant<
+    is_convertible_from_specialization_impl<remove_reference_t<To>, remove_reference_t<From>>::value
   >::type {};
 
   // Check whether Functor can be constructed as decay_t<Functor>
@@ -1087,37 +1113,6 @@ inline namespace fn_traits {
   template <typename Fn, typename... Args>
   struct invoke_result_package<Fn, args_package<Args...>>
   : public invoke_result<Fn, Args...> {};
-
-  // [func.wrap.move.ctor]/1
-  template <typename Signature, typename Fn, typename Ret, typename ArgsPackage>
-  struct is_callable_from_pkg;
-
-  template <typename Signature, typename Fn, typename Ret, typename... Args>
-  struct is_callable_from_pkg<Signature, Fn, Ret, args_package<Args...>> {
-    using unwrap_sig  = unwrap_signature<Signature>;
-    using f_cv        = typename unwrap_sig::template add_cv_like<Fn>;
-    using f_cvref     = typename unwrap_sig::template add_cvref_like<Fn>;
-    using f_inv_quals = conditional_t<unwrap_sig::hasRRef, f_cv&&, f_cv&>;
-
-    static constexpr bool value = unwrap_sig::isNoexcept
-      ? is_nothrow_invocable_r<Ret, f_cvref, Args...>::value
-        && is_nothrow_invocable_r<Ret, f_inv_quals, Args...>::value
-      : is_invocable_r<Ret, f_cvref, Args...>::value
-        && is_invocable_r<Ret, f_inv_quals, Args...>::value;
-  };
-
-  // Check the functor is callable with given arguments.
-  // [func.wrap.move.ctor]/1
-  template <typename Functor, typename Signature>
-  struct is_callable_from_impl {
-    using unwrap_sig = unwrap_signature<Signature>;
-    using ret       = typename unwrap_sig::ret;
-    using args_pack = typename unwrap_sig::args;
-    using dec_func  = decay_t<Functor>;
-
-    static constexpr bool value =
-      is_callable_from_pkg<Signature, dec_func, ret, args_pack>::value;
-  };
 
   template <typename Fn, typename Cfg, typename Erasure, typename DecFn = decay_t<Fn>>
   struct buffer_size_is_enough : bool_constant<
@@ -2666,10 +2661,10 @@ namespace crtp_mixins {
     core_components_impl& operator=(std::nullptr_t) = delete; // no empty state in view mode
     EMBED_DETAIL_TEMPLATE_BEGIN(typename T)
     EMBED_DETAIL_REQUIRES_END(
-      (!fn_can_convert<Self, T>::value)
+      (!is_convertible_from_specialization<Self, T>::value)
       && (!std::is_pointer<T>::value)
       && (!is_constant_wrapper<T>::value)
-    ) core_components_impl& operator=(T)              = delete;
+    ) core_components_impl& operator=(T)            = delete;
 
     // Swap the contents of two function objects. (View mode)
     void swap(core_components_impl& fn_raw) noexcept {
@@ -2807,7 +2802,7 @@ namespace crtp_mixins {
     EMBED_DETAIL_TEMPLATE_BEGIN(
       std::size_t OtherSize, typename OtherCfg, typename OtherSig)
     EMBED_DETAIL_REQUIRES_END(
-      fn_can_convert<function, function<OtherSize, OtherCfg, OtherSig>>::value
+      is_convertible_from_specialization<function, function<OtherSize, OtherCfg, OtherSig>>::value
       && function<OtherSize, OtherCfg, OtherSig>::internal_is_copyable
     ) function(const function<OtherSize, OtherCfg, OtherSig>& other)
     noexcept(is_cfg_noexcept<Config>::value && is_cfg_noexcept<OtherCfg>::value) {
@@ -2823,7 +2818,7 @@ namespace crtp_mixins {
     EMBED_DETAIL_TEMPLATE_BEGIN(
       std::size_t OtherSize, typename OtherCfg, typename OtherSig)
     EMBED_DETAIL_REQUIRES_END(
-      fn_can_convert<function, function<OtherSize, OtherCfg, OtherSig>>::value
+      is_convertible_from_specialization<function, function<OtherSize, OtherCfg, OtherSig>>::value
       && (!Config::isView)
     ) function(function<OtherSize, OtherCfg, OtherSig>&& other)
     noexcept(is_cfg_noexcept<Config>::value && is_cfg_noexcept<OtherCfg>::value) {
@@ -2842,7 +2837,7 @@ namespace crtp_mixins {
     /// @note Used for function wrapper only. (OWNING)
     EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)
     EMBED_DETAIL_REQUIRES_END(
-      (!fn_can_convert<function, Functor>::value)
+      (!is_convertible_from_specialization<function, Functor>::value)
       && (!is_self<Functor, function>::value)
       && (!is_in_place_type<decay_t<Functor>>::value)
       && is_callable_from<Functor>::value
@@ -2885,7 +2880,7 @@ namespace crtp_mixins {
       typename Tp = remove_reference_t<Functor>)
     EMBED_DETAIL_REQUIRES_END(
       (!is_self<Functor, function>::value)
-      && (!fn_can_convert<function, Functor>::value)
+      && (!is_convertible_from_specialization<function, Functor>::value)
       && (!std::is_member_pointer<Tp>::value)
       && is_invocable_using<add_cv_like_sig_t<Tp>&>::value
       && Config::isView

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -172,7 +172,6 @@
 # include <functional>  // std::bad_function_call
 # include <exception>   // std::terminate
 # include <type_traits> // std::enable_if, ...
-# include <tuple>       // std::tuple
 # include <initializer_list>
 # if __cpp_impl_reflection >= 202506L && __has_include(<meta>)
 #  include <meta>       // std::meta::is_complete_type(C++26)
@@ -626,17 +625,21 @@ inline namespace cxx_traits {
       ((*std::declval<Arg>()).*std::declval<Memfunc>()) (std::declval<Args>()...));
   };
 
+  // Uses empty class as the package of arguments.
+  template <typename... Args>
+  struct args_package {};
+
   template <typename Func, typename ArgsTuple, typename = void>
   struct call_is_nothrow_helper : std::false_type {};
 
   template <typename Func, typename... Args>
-  struct call_is_nothrow_helper<Func, std::tuple<Args...>,
+  struct call_is_nothrow_helper<Func, args_package<Args...>,
     void_t<typename invoke_result<Func, Args...>::tag>>
   : call_is_nothrow_impl<typename invoke_result<Func, Args...>::tag, Func, Args...>
   {};
 
   template <typename Func, typename... Args>
-  using call_is_nothrow = call_is_nothrow_helper<Func, std::tuple<Args...>>;
+  using call_is_nothrow = call_is_nothrow_helper<Func, args_package<Args...>>;
 
   // See <https://en.cppreference.com/w/cpp/types/reference_converts_from_temporary.html>.
   template <typename To, typename From>
@@ -875,10 +878,6 @@ inline namespace fn_traits {
   struct is_config_package<
     config_package<IsCopyable, IsView, IsThrowing, AssertObjectNoThrow>>
   : public std::true_type {};
-
-  // Uses empty class as the package of arguments.
-  template <typename... Args>
-  struct args_package {};
 
   // Unwrap the function signature.
   template <typename T>
@@ -1603,7 +1602,7 @@ inline namespace fn_traits {
     typename PureSig = typename unwrap_signature<Sig>::pure_sig>
   struct is_invocable_using_impl;
   template <typename Sig, typename... TArgs, typename Ret, typename... Args>
-  struct is_invocable_using_impl<Sig, std::tuple<TArgs...>, Ret(Args...)>
+  struct is_invocable_using_impl<Sig, args_package<TArgs...>, Ret(Args...)>
   : conditional_t<
       unwrap_signature<Sig>::isNoexcept,
       is_nothrow_invocable_r<Ret, TArgs..., Args...>,
@@ -2759,7 +2758,7 @@ namespace crtp_mixins {
 
     // [func.wrap.ref.ctor]/1 is-invocable-using
     template <typename... T>
-    using is_invocable_using = is_invocable_using_impl<Signature, std::tuple<T...>>;
+    using is_invocable_using = is_invocable_using_impl<Signature, args_package<T...>>;
 
     template <typename T>
     using add_cv_like_sig_t = typename unwrap_signature<Signature>::template add_cv_like<T>;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3,7 +3,7 @@
  *
  * @date        2026-2-7
  *
- * @version     2.1.8
+ * @version     2.1.9
  *
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1034,13 +1034,8 @@ inline namespace fn_traits {
 
     // In view mode, the requires is special.
     // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3961r1.html>.
-    static constexpr bool noexcept_qualifier_ok =
-      (unwrap_to::isNoexcept == unwrap_from::isNoexcept)
-      || (
-        CfgTo::isView == true
-        && CfgFrom::isView == true
-        && unwrap_to::isNoexcept < unwrap_from::isNoexcept
-      );
+    static constexpr bool noexcept_qualifier_ok = unwrap_to::isNoexcept == unwrap_from::isNoexcept
+      || (CfgTo::isView && CfgFrom::isView && unwrap_to::isNoexcept < unwrap_from::isNoexcept);
 
     static constexpr bool qualifier_ok =
       (unwrap_to::hasConst <= unwrap_from::hasConst)
@@ -1075,7 +1070,7 @@ inline namespace fn_traits {
   struct is_nothrow_construct_from_functor<
     Functor, Class, void_t<decltype( Class(std::declval<Functor>()) )>>
   : public bool_constant<
-    noexcept(::new (static_cast<void*>(0)) Class(std::declval<Functor>()))
+    noexcept(::new (static_cast<void*>(nullptr)) Class(std::declval<Functor>()))
   > {};
 
   // Get invoke result with arguments package.
@@ -2776,31 +2771,14 @@ namespace crtp_mixins {
     EMBED_NODISCARD EMBED_INLINE static constexpr bool
     is_copyable() noexcept { return internal_is_copyable; }
 
-#if defined(__GNUC__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wuninitialized"
-#endif
     /// @brief All following methods that end with `= default` are implemented in
-    /// the base class @e `crtp_mixins::lifetime_operations_impl`.
-
-    // The destructor of the function wrapper, is trivial if `Config::isView == true`.
-    ~function()                                   = default;
-    // The copy constructor of the function wrapper, `=delete` if `(Config::isView ||
-    // Config::isCopyable) == true`, and is trivial if `Config::isView == true`.
-    function(const function& other)               = default;
-    // The move constructor of the function wrapper, is trivial if
-    // `(Config::isView || Config::isCopyable) == true`.
-    function(function&& other)                    = default;
-    // The copy assignment of the function wrapper, `=delete` if `(Config::isView ||
-    // Config::isCopyable) == true`, and is trivial if `Config::isView == true`.
-    function& operator=(const function& other)    = default;
-    // The move assignment of the function wrapper, is trivial if
-    // `(Config::isView || Config::isCopyable) == true`.
-    function& operator=(function&& other)         = default;
-
-#if defined(__GNUC__)
-# pragma GCC diagnostic pop
-#endif
+    /// the base class @e `crtp_mixins::lifetime_operations_impl`. They are trivial
+    /// if `Config::isView` equals `true`.
+    ~function()                                 = default;
+    function(const function& other)             = default;
+    function(function&& other)                  = default;
+    function& operator=(const function& other)  = default;
+    function& operator=(function&& other)       = default;
 
     /// Implemented in the base class @e `crtp_mixins::core_components_impl`.
     using Base_CoreComponents::operator=;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -79,6 +79,14 @@
 # endif
 #endif
 
+#ifndef EMBED_HAS_INCLUDE
+# if defined(__has_include)
+#  define EMBED_HAS_INCLUDE(x) __has_include(x)
+# else
+#  define EMBED_HAS_INCLUDE(x) 0
+# endif
+#endif
+
 #ifndef EMBED_CXX_ENABLE_EXCEPTION
 # if defined(__cpp_exceptions)
 #  define EMBED_CXX_ENABLE_EXCEPTION (__cpp_exceptions != 0)
@@ -174,8 +182,7 @@
 # include <exception>   // std::terminate
 # include <type_traits> // std::enable_if, ...
 # include <initializer_list>
-// TODO: __has_include() triggers warning in MSVC
-# if __cpp_impl_reflection >= 202506L && __has_include(<meta>)
+# if __cpp_impl_reflection >= 202506L && EMBED_HAS_INCLUDE(<meta>)
 #  include <meta>       // std::meta::is_complete_type(C++26)
 # endif
 #else
@@ -1913,73 +1920,73 @@ namespace invocation {
   template <std::size_t Size, typename Config, typename Signature>
   struct InvokerImpl;
 
-#define EMBED_DETAIL_INVOKER_IMPL_DEFINE(C, V, REF, NOEXCEPT)                     \
-  template <std::size_t Size, typename Config, typename Ret, typename... Args>    \
-  struct InvokerImpl<Size, Config, Ret(Args...) C V REF NOEXCEPT> {               \
-  public:                                                                         \
-    using erasure_base_t = erasure_type::ErasureBase;                             \
-    using erasure_t = erasure_type::Erasure<Config::isView, Size>;                \
-    using erasure_pass_t = erasure_type::ErasurePass C;                           \
-    static constexpr bool is_rvalue_ref =                                         \
-      std::is_rvalue_reference<int REF>::value;                                   \
-    using invoker_type =                                                          \
-      Ret (*) (erasure_pass_t erased, smart_forward_t<Args>... args);             \
-                                                                                  \
-    /* Using when M_erasure is empty. */                                          \
-    struct empty {                                                                \
-      static Ret invoke(erasure_pass_t, smart_forward_t<Args>...) {               \
-        throw_or_terminate<Config::isThrowing>();                                 \
-        /* Unreachable: throw_or_terminate() is [[noreturn]] */                   \
-      }                                                                           \
-    };                                                                            \
-                                                                                  \
-    /* Using when Config::isView == false. */                                     \
-    struct inplace {                                                              \
-      template <typename Functor>                                                 \
-      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
-        auto* erased = static_cast<erasure_t C V*>(base.ptr);                     \
-        auto& fn = erased->template access<Functor>();                            \
-        using Fn = conditional_t<is_rvalue_ref,                                   \
-          remove_reference_t<decltype(fn)>&&,                                     \
-          remove_reference_t<decltype(fn)>&>;                                     \
-        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
-      }                                                                           \
-    };                                                                            \
-                                                                                  \
-    /* Using when Config::isView == true. */                                      \
-    struct view {                                                                 \
-      /* Using when the `Functor` is function pointer. */                         \
-      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)                               \
-        EMBED_DETAIL_REQUIRES_END(is_stored_origin<Functor, true>::value)         \
-      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
-        auto* fn = reinterpret_cast<Functor>(base.val.fill_func_ptr);             \
-        return invoke_r<Ret>(fn, std::forward<Args>(args)...);                    \
-      }                                                                           \
-                                                                                  \
-      /* Using when the `Functor` is NOT function pointer. */                     \
-      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)                               \
-        EMBED_DETAIL_REQUIRES_END((!is_stored_origin<Functor, true>::value))      \
-      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) {     \
-        auto& fn = *static_cast<Functor C V*>(base.val.fill_ptr);                 \
-        using Fn = remove_reference_t<decltype(fn)>&;                             \
-        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
-      }                                                                           \
-    };                                                                            \
-                                                                                  \
-    /* Used for stateless(empty) Functor (like std::less). */                     \
-    struct empty_trivial_class {                                                  \
-      template <typename EmptyFn>                                                 \
-      static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) {          \
-        C V EmptyFn fn{};  /* Empty and trivial class. It is stateless */         \
-        using Fn = conditional_t<is_rvalue_ref,                                   \
-          remove_reference_t<decltype(fn)>&&,                                     \
-          remove_reference_t<decltype(fn)>&>;                                     \
-        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);   \
-      }                                                                           \
-    };                                                                            \
-                                                                                  \
-    EMBED_DETAIL_STATIC_CALL_INVOKER_IMPL(C, V, REF, NOEXCEPT)                    \
-    EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                             \
+#define EMBED_DETAIL_INVOKER_IMPL_DEFINE(C, V, REF, NOEXCEPT)                         \
+  template <std::size_t Size, typename Config, typename Ret, typename... Args>        \
+  struct InvokerImpl<Size, Config, Ret(Args...) C V REF NOEXCEPT> {                   \
+  public:                                                                             \
+    using erasure_base_t = erasure_type::ErasureBase;                                 \
+    using erasure_t = erasure_type::Erasure<Config::isView, Size>;                    \
+    using erasure_pass_t = erasure_type::ErasurePass C;                               \
+    static constexpr bool is_rvalue_ref =                                             \
+      std::is_rvalue_reference<int REF>::value;                                       \
+    using invoker_type =                                                              \
+      Ret (*) (erasure_pass_t erased, smart_forward_t<Args>... args) NOEXCEPT;        \
+                                                                                      \
+    /* Using when M_erasure is empty. */                                              \
+    struct empty {                                                                    \
+      static Ret invoke(erasure_pass_t, smart_forward_t<Args>...) NOEXCEPT {          \
+        throw_or_terminate<Config::isThrowing>();                                     \
+        /* Unreachable: throw_or_terminate() is [[noreturn]] */                       \
+      }                                                                               \
+    };                                                                                \
+                                                                                      \
+    /* Using when Config::isView == false. */                                         \
+    struct inplace {                                                                  \
+      template <typename Functor>                                                     \
+      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) NOEXCEPT {\
+        auto* erased = static_cast<erasure_t C V*>(base.ptr);                         \
+        auto& fn = erased->template access<Functor>();                                \
+        using Fn = conditional_t<is_rvalue_ref,                                       \
+          remove_reference_t<decltype(fn)>&&,                                         \
+          remove_reference_t<decltype(fn)>&>;                                         \
+        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);       \
+      }                                                                               \
+    };                                                                                \
+                                                                                      \
+    /* Using when Config::isView == true. */                                          \
+    struct view {                                                                     \
+      /* Using when the `Functor` is function pointer. */                             \
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)                                   \
+        EMBED_DETAIL_REQUIRES_END(is_stored_origin<Functor, true>::value)             \
+      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) NOEXCEPT {\
+        auto* fn = reinterpret_cast<Functor>(base.val.fill_func_ptr);                 \
+        return invoke_r<Ret>(fn, std::forward<Args>(args)...);                        \
+      }                                                                               \
+                                                                                      \
+      /* Using when the `Functor` is NOT function pointer. */                         \
+      EMBED_DETAIL_TEMPLATE_BEGIN(typename Functor)                                   \
+        EMBED_DETAIL_REQUIRES_END((!is_stored_origin<Functor, true>::value))          \
+      static Ret invoke(erasure_pass_t base, smart_forward_t<Args>... args) NOEXCEPT {\
+        auto& fn = *static_cast<Functor C V*>(base.val.fill_ptr);                     \
+        using Fn = remove_reference_t<decltype(fn)>&;                                 \
+        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);       \
+      }                                                                               \
+    };                                                                                \
+                                                                                      \
+    /* Used for stateless(empty) Functor (like std::less). */                         \
+    struct empty_trivial_class {                                                      \
+      template <typename EmptyFn>                                                     \
+      static Ret invoke(erasure_pass_t, smart_forward_t<Args>... args) NOEXCEPT {     \
+        C V EmptyFn fn{};  /* Empty and trivial class. It is stateless */             \
+        using Fn = conditional_t<is_rvalue_ref,                                       \
+          remove_reference_t<decltype(fn)>&&,                                         \
+          remove_reference_t<decltype(fn)>&>;                                         \
+        return invoke_r<Ret>(static_cast<Fn>(fn), std::forward<Args>(args)...);       \
+      }                                                                               \
+    };                                                                                \
+                                                                                      \
+    EMBED_DETAIL_STATIC_CALL_INVOKER_IMPL(C, V, REF, NOEXCEPT)                        \
+    EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)                                 \
   };
 
   EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_INVOKER_IMPL_DEFINE)
@@ -3520,6 +3527,7 @@ namespace detail {
 # undef EMBED_HAS_ATTRIBUTE
 # undef EMBED_HAS_CXX_ATTRIBUTE
 # undef EMBED_HAS_FEATURE
+# undef EMBED_HAS_INCLUDE
 # undef EMBED_ABI_VISIBILITY
 # undef EMBED_CXX14_CONSTEXPR
 # undef EMBED_CXX20_CONSTEXPR

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -173,6 +173,7 @@
 # include <exception>   // std::terminate
 # include <type_traits> // std::enable_if, ...
 # include <initializer_list>
+// TODO: __has_include() triggers warning in MSVC
 # if __cpp_impl_reflection >= 202506L && __has_include(<meta>)
 #  include <meta>       // std::meta::is_complete_type(C++26)
 # endif
@@ -259,15 +260,6 @@
 
 #define EMBED_DETAIL_TEXT(text) EMBED_DETAIL_TEXT_IMPL(text)
 #define EMBED_DETAIL_TEXT_IMPL(text) #text
-
-#if __cpp_lib_launder >= 201606L
-# define EMBED_DETAIL_LAUNDER(x) ( ::std::launder(x) )
-#elif EMBED_HAS_BUILTIN(__builtin_launder)
-# define EMBED_DETAIL_LAUNDER(x) ( ::ebd::detail::launder(x) )
-# define EMBED_DETAIL__NEED_LAUNDER
-#else
-# define EMBED_DETAIL_LAUNDER(x) ( x )
-#endif
 
 #if EMBED_HAS_ATTRIBUTE(may_alias)
 # define EMBED_DETAIL_ALIAS __attribute__((may_alias))
@@ -798,14 +790,26 @@ inline namespace cxx_traits {
       std::forward<Args>(args)...);
   }
 
-#ifdef EMBED_DETAIL__NEED_LAUNDER
-
   // [ptr.launder]
-  template <typename T> EMBED_NODISCARD EMBED_INLINE constexpr
-  T* launder(T* ptr) noexcept { return __builtin_launder(ptr); }
-
-#undef EMBED_DETAIL__NEED_LAUNDER
+  template <typename T>
+  EMBED_NODISCARD EMBED_INLINE T* launder(T* ptr) noexcept {
+#if __cpp_lib_launder >= 201606L
+    return std::launder(ptr);
+#elif EMBED_HAS_BUILTIN(__builtin_launder) || __GNUC__ >= 5
+    // `__builtin_launder` in MSVC is only accessible since C++17.
+    return __builtin_launder(ptr);
+#elif defined(__GNUC__) || defined(__clang__)
+    __asm__("": "+r"(ptr)); // Cannot use `__asm__` in `noexcept` function.
+    return ptr;
+#else
+# if defined(_MSC_VER) && !defined(__clang__)
+#  pragma message("WARNING: `launder` is not implemented for this environment.")
+# else
+#  warning "`launder` is not implemented for this environment."
+# endif
+    return ptr;
 #endif
+  }
 
   template <typename T>
   struct is_unbounded_array : std::false_type {};
@@ -1837,19 +1841,19 @@ namespace erasure_type {
 
     template <typename T>
     T& access() noexcept
-    { return *EMBED_DETAIL_LAUNDER(static_cast<T*>(access())); }
+    { return *::ebd::detail::launder(static_cast<T*>(access())); }
 
     template <typename T>
     const T& access() const noexcept
-    { return *EMBED_DETAIL_LAUNDER(static_cast<const T*>(access())); }
+    { return *::ebd::detail::launder(static_cast<const T*>(access())); }
 
     template <typename T>
     volatile T& access() volatile noexcept
-    { return *EMBED_DETAIL_LAUNDER(static_cast<volatile T*>(access())); }
+    { return *::ebd::detail::launder(static_cast<volatile T*>(access())); }
 
     template <typename T>
     const volatile T& access() const volatile noexcept
-    { return *EMBED_DETAIL_LAUNDER(static_cast<const volatile T*>(access())); }
+    { return *::ebd::detail::launder(static_cast<const volatile T*>(access())); }
   };
 
   // ABI for passing either pointer or value.
@@ -3495,7 +3499,6 @@ namespace detail {
 #undef EMBED_DETAIL_REQUIRES_END
 #undef EMBED_DETAIL_TEXT
 #undef EMBED_DETAIL_TEXT_IMPL
-#undef EMBED_DETAIL_LAUNDER
 #undef EMBED_DETAIL_ALIAS
 #undef EMBED_DETAIL_FAIL_MESSAGE
 #undef EMBED_DETAIL_UNREACHABLE

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1145,7 +1145,13 @@ inline namespace fn_traits {
     static constexpr std::size_t value = sizeof(void (UndefinedClass::*) ());
 #endif
 
-    static constexpr std::size_t align_value = alignof(void (UndefinedClass::*) ());
+    // The alignment for owning wrappers (ebd::fn, ebd::unique_fn, ebd::safe_fn).
+    // Using alignof(std::max_align_t) ensures that objects with the maximum
+    // fundamental alignment can be stored in the internal buffer.
+    static constexpr std::size_t align_value = alignof(std::max_align_t);
+
+    // The alignment for non-owning wrapper (ebd::fn_ref).
+    static constexpr std::size_t view_align_value = alignof(void (*) ());
   };
 
   // Get aligned size. Rounds up to the nearest MinAlign size.
@@ -1809,7 +1815,7 @@ namespace erasure_type {
   union EMBED_DETAIL_ALIAS ErasureCore {
     // An array of `unsigned char` can be used to hold other objects.
     // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0137r1.html>.
-    unsigned char pod[get_aligned_size(Size)];
+    unsigned char pod[get_aligned_size<alignof(void*)>(Size)];
     ErasureRefStorage ref_storage; // alignas(ref_storage)
   };
 
@@ -1822,32 +1828,35 @@ namespace erasure_type {
   // placement new. After that, using `access` to obtain the address or reference
   // (rather than the content) is also in accordance with the C++ standard.
   // See <https://eel.is/c++draft/basic.life#7>.
-  template <std::size_t Size>
+  template <bool IsView, std::size_t Size>
   struct EMBED_DETAIL_ALIAS Erasure : public ErasureBase {
-    alignas(default_buffer_size::align_value) ErasureCore<Size> m_core;
+    alignas(IsView
+            ? default_buffer_size::view_align_value
+            : default_buffer_size::align_value)
+    ErasureCore<Size> m_core;
 
     // Access the pointer of erasureCore that qualified with nothing or const.
-    void* access() noexcept { return &m_core.pod[0]; }
-    const void* access() const noexcept { return &m_core.pod[0]; }
+    EMBED_NODISCARD void* access() noexcept { return &m_core.pod[0]; }
+    EMBED_NODISCARD const void* access() const noexcept { return &m_core.pod[0]; }
 
     // Access the pointer of erasureCore that qualified with volatile or const volatile.
-    volatile void* access() volatile noexcept { return &m_core.pod[0]; }
-    const volatile void* access() const volatile noexcept { return &m_core.pod[0]; }
+    EMBED_NODISCARD volatile void* access() volatile noexcept { return &m_core.pod[0]; }
+    EMBED_NODISCARD const volatile void* access() const volatile noexcept { return &m_core.pod[0]; }
 
     template <typename T>
-    T& access() noexcept
+    EMBED_NODISCARD T& access() noexcept
     { return *::ebd::detail::launder(static_cast<T*>(access())); }
 
     template <typename T>
-    const T& access() const noexcept
+    EMBED_NODISCARD const T& access() const noexcept
     { return *::ebd::detail::launder(static_cast<const T*>(access())); }
 
     template <typename T>
-    volatile T& access() volatile noexcept
+    EMBED_NODISCARD volatile T& access() volatile noexcept
     { return *::ebd::detail::launder(static_cast<volatile T*>(access())); }
 
     template <typename T>
-    const volatile T& access() const volatile noexcept
+    EMBED_NODISCARD const volatile T& access() const volatile noexcept
     { return *::ebd::detail::launder(static_cast<const volatile T*>(access())); }
   };
 
@@ -1904,12 +1913,11 @@ namespace invocation {
   struct InvokerImpl;
 
 #define EMBED_DETAIL_INVOKER_IMPL_DEFINE(C, V, REF, NOEXCEPT)                     \
-  template <std::size_t Size, typename Config,                                    \
-    typename Ret, typename... Args>                                               \
+  template <std::size_t Size, typename Config, typename Ret, typename... Args>    \
   struct InvokerImpl<Size, Config, Ret(Args...) C V REF NOEXCEPT> {               \
   public:                                                                         \
     using erasure_base_t = erasure_type::ErasureBase;                             \
-    using erasure_t = erasure_type::Erasure<Size>;                                \
+    using erasure_t = erasure_type::Erasure<Config::isView, Size>;                \
     using erasure_pass_t = erasure_type::ErasurePass C;                           \
     static constexpr bool is_rvalue_ref =                                         \
       std::is_rvalue_reference<int REF>::value;                                   \
@@ -2549,7 +2557,7 @@ namespace crtp_mixins {
     constexpr member_variable_impl(std::nullptr_t) noexcept
     : m_erasure(erasure_t{}), m_command(command_t{}) {}
 
-    using erasure_t = erasure_type::Erasure<BufferSize>;
+    using erasure_t = erasure_type::Erasure<Config::isView, BufferSize>;
     using command_t = command::CommandTable<
       Config::isView, BufferSize, Config, Signature,
       typename unwrap_signature<Signature>::args>;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -27,6 +27,7 @@
 
 /// @b EMBED_FN_HOOK_DEBUG(message)
 /// If this macro is defined, it will be called to print debug message in debug mode.
+/// @example `fputs(message, stderr)`
 
 #ifndef EMBED_INCLUDED_EMBED_FUNCTION_HPP_
 #define EMBED_INCLUDED_EMBED_FUNCTION_HPP_
@@ -271,14 +272,14 @@
 # define EMBED_DETAIL_FAIL_MESSAGE(message)
 # define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)
 #else
-# define EMBED_DETAIL_FAIL_MESSAGE(message)                                   \
-  do {                                                                        \
-    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) " " message);\
+# define EMBED_DETAIL_FAIL_MESSAGE(message)                                             \
+  do {                                                                                  \
+    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) ":\n\t" message "\n"); \
   } while(0) /* Output message together with file name and line number. */
-# define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)                     \
-  do { if (!(expression)) {                                                   \
-    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) " " message);\
-    std::terminate();                                                         \
+# define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)                               \
+  do { if (!(expression)) {                                                             \
+    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) ":\n\t" message "\n"); \
+    std::terminate();                                                                   \
   } } while(0) /* Output message and terminate procedure if expression is false. */
 #endif
 

--- a/test/conformance/fn/fail/assign_const.fail.cpp
+++ b/test/conformance/fn/fail/assign_const.fail.cpp
@@ -1,0 +1,12 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+  ebd::fn<int(int, int)> f_non_const = ebd_test_free_func_iii_add;
+  ebd::fn<int(int, int) const> f_const = ebd_test_free_func_iii_add;
+
+  // fn<Sig> -> fn<Sig const> is invalid.
+  f_const = f_non_const; // FAIL
+}

--- a/test/conformance/fn/fail/assign_lref.fail.cpp
+++ b/test/conformance/fn/fail/assign_lref.fail.cpp
@@ -1,0 +1,12 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+  ebd::fn<int(int, int)> f_non_lref = ebd_test_free_func_iii_add;
+  ebd::fn<int(int, int) &> f_lref = ebd_test_free_func_iii_add;
+
+  // fn<Sig &> -> fn<Sig> is invalid.
+  f_non_lref = f_lref; // FAIL
+}

--- a/test/conformance/fn/fail/assign_rref.fail.cpp
+++ b/test/conformance/fn/fail/assign_rref.fail.cpp
@@ -1,0 +1,12 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+  ebd::fn<int(int, int)> f_non_rref = ebd_test_free_func_iii_add;
+  ebd::fn<int(int, int) &&> f_rref = ebd_test_free_func_iii_add;
+
+  // fn<Sig &&> -> fn<Sig> is invalid.
+  f_non_rref = f_rref; // FAIL
+}

--- a/test/conformance/fn/fail/assign_volatile.fail.cpp
+++ b/test/conformance/fn/fail/assign_volatile.fail.cpp
@@ -1,0 +1,12 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+  ebd::fn<int(int, int)> f_non_volatile = ebd_test_free_func_iii_add;
+  ebd::fn<int(int, int) volatile> f_volatile = ebd_test_free_func_iii_add;
+
+  // fn<Sig> -> fn<Sig volatile> is invalid.
+  f_volatile = f_non_volatile; // FAIL
+}

--- a/test/conformance/fn_ref/fail/const_assign.fail.cpp
+++ b/test/conformance/fn_ref/fail/const_assign.fail.cpp
@@ -4,9 +4,9 @@
 #include "test_function.hpp"
 
 int main() {
-  ebd::fn_ref<int(int, int)> f1 = ebd_test_free_func_iii_add;
-  ebd::fn_ref<int(int, int) const> f2 = ebd_test_free_func_iii_add;
+  ebd::fn_ref<int(int, int)> f_non_const = ebd_test_free_func_iii_add;
+  ebd::fn_ref<int(int, int) const> f_const = ebd_test_free_func_iii_add;
 
-  // const -> non-const is not allowed.
-  f2 = f1; // FAIL
+  // fn_ref<Sig> -> fn_ref<Sig const> is invalid.
+  f_const = f_non_const; // FAIL
 }

--- a/test/conformance/fn_ref/fail/volatile_assign.fail.cpp
+++ b/test/conformance/fn_ref/fail/volatile_assign.fail.cpp
@@ -1,0 +1,12 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+  ebd::fn_ref<int(int, int)> f_non_volatile = ebd_test_free_func_iii_add;
+  ebd::fn_ref<int(int, int) volatile> f_volatile = ebd_test_free_func_iii_add;
+
+  // fn_ref<Sig> -> fn_ref<Sig volatile> is invalid.
+  f_volatile = f_non_volatile; // FAIL
+}

--- a/test/conformance/safe_fn/fail/assign_noexcept.1.fail.cpp
+++ b/test/conformance/safe_fn/fail/assign_noexcept.1.fail.cpp
@@ -1,0 +1,15 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+#if __cpp_noexcept_function_type >= 201510L && EMBED_CXX_VERSION >= 201703L
+  ebd::safe_fn<int() noexcept> f_noexcept = ebd_test_free_func_noexcept;
+  ebd::safe_fn<int() noexcept(false)> f_maythrow = ebd_test_free_func_maythrow;
+
+  f_noexcept = f_maythrow; // FAIL
+#else
+  static_assert(false, "FAIL"); // FAIL
+#endif
+}

--- a/test/conformance/safe_fn/fail/assign_noexcept.2.fail.cpp
+++ b/test/conformance/safe_fn/fail/assign_noexcept.2.fail.cpp
@@ -1,0 +1,15 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "test_function.hpp"
+
+int main() {
+#if __cpp_noexcept_function_type >= 201510L && EMBED_CXX_VERSION >= 201703L
+  ebd::safe_fn<int() noexcept> f_noexcept = ebd_test_free_func_noexcept;
+  ebd::safe_fn<int() noexcept(false)> f_maythrow = ebd_test_free_func_maythrow;
+
+  f_maythrow = f_noexcept; // FAIL (size)
+#else
+  static_assert(false, "FAIL"); // FAIL
+#endif
+}

--- a/test/test_AssignAndConvert.cpp
+++ b/test/test_AssignAndConvert.cpp
@@ -124,3 +124,85 @@ TEST(AssignAndConvert, StatelessAssign) {
         ASSERT_EQ(f2(2, 1), false);
     }
 }
+
+// AssignAndConvert[6]
+TEST(AssignAndConvert, VolatileToNonVolatile) {
+    {
+        ebd::fn<void()> f_non_volatile;
+        ebd::fn<void() volatile> f_volatile;
+
+        f_non_volatile = f_volatile; // OK
+        // f_volatile = f_non_volatile; // Error
+    }
+    {
+        ebd::unique_fn<void()> f_non_volatile;
+        ebd::unique_fn<void() volatile> f_volatile;
+
+        f_non_volatile = std::move(f_volatile); // OK
+        // f_volatile = f_non_volatile; // Error
+    }
+    {
+        ebd::safe_fn<void()> f_non_volatile;
+        ebd::safe_fn<void() volatile> f_volatile;
+
+        f_non_volatile = f_volatile; // OK
+        // f_volatile = f_non_volatile; // Error
+    }
+    {
+        ebd::fn_ref<void()> f_non_volatile = +[]{};
+        ebd::fn_ref<void() volatile> f_volatile = +[]{};
+
+        f_non_volatile = f_volatile; // OK
+        // f_volatile = f_non_volatile; // Error
+    }
+}
+
+// AssignAndConvert[7]
+TEST(AssignAndConvert, NonRefToLeftValueRef) {
+    {
+        ebd::fn<void()> f_non_ref;
+        ebd::fn<void() &> f_ref;
+
+        f_ref = f_non_ref; // OK
+        // f_non_ref = f_ref; // Error
+    }
+    {
+        ebd::unique_fn<void()> f_non_ref;
+        ebd::unique_fn<void() &> f_ref;
+
+        f_ref = std::move(f_non_ref); // OK
+        // f_non_ref = f_ref; // Error
+    }
+    {
+        ebd::safe_fn<void()> f_non_ref;
+        ebd::safe_fn<void() &> f_ref;
+
+        f_ref = f_non_ref; // OK
+        // f_non_ref = f_ref; // Error
+    }
+}
+
+// AssignAndConvert[8]
+TEST(AssignAndConvert, NonRefToRightValueRef) {
+    {
+        ebd::fn<void()> f_non_ref;
+        ebd::fn<void() &&> f_ref;
+
+        f_ref = f_non_ref; // OK
+        // f_non_ref = f_ref; // Error
+    }
+    {
+        ebd::unique_fn<void()> f_non_ref;
+        ebd::unique_fn<void() &&> f_ref;
+
+        f_ref = std::move(f_non_ref); // OK
+        // f_non_ref = f_ref; // Error
+    }
+    {
+        ebd::safe_fn<void()> f_non_ref;
+        ebd::safe_fn<void() &&> f_ref;
+
+        f_ref = f_non_ref; // OK
+        // f_non_ref = f_ref; // Error
+    }
+}

--- a/test/test_BasicAttributes.cpp
+++ b/test/test_BasicAttributes.cpp
@@ -18,10 +18,10 @@ TEST(BasicAttributes, SizeAndAlign) {
     ASSERT_EQ(sf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
     ASSERT_EQ(fv_t::get_buffer_size() == ebd::detail::default_buffer_size::view_buf, true);
 
-    ASSERT_EQ(alignof(f_t) >= alignof(void*), true);
-    ASSERT_EQ(alignof(uf_t) >= alignof(void*), true);
-    ASSERT_EQ(alignof(sf_t) >= alignof(void*), true);
-    ASSERT_EQ(alignof(fv_t) >= alignof(void*), true);
+    ASSERT_EQ(alignof(f_t) == ebd::detail::default_buffer_size::align_value, true);
+    ASSERT_EQ(alignof(uf_t) == ebd::detail::default_buffer_size::align_value, true);
+    ASSERT_EQ(alignof(sf_t) == ebd::detail::default_buffer_size::align_value, true);
+    ASSERT_EQ(alignof(fv_t) == alignof(void(*)()), true);
 
     ASSERT_EQ(sizeof(f_t) - f_t::get_buffer_size(), 2 * sizeof(void*));
     ASSERT_EQ(sizeof(uf_t) - uf_t::get_buffer_size(), 2 * sizeof(void*));
@@ -100,19 +100,19 @@ TEST(BasicAttributes, DefaultConfig) {
     static_assert(
         std::is_same<
             ebd::fn<void(), 0>, 
-            ebd::basic_fn<void(), sizeof(void(*)()), true, false, true, false>
+            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, true, false>
         >::value, 
         "The default config of ebd::fn has been changed!");
     static_assert(
         std::is_same<
             ebd::unique_fn<void(), 0>, 
-            ebd::basic_fn<void(), sizeof(void(*)()), false, false, true, false>
+            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), false, false, true, false>
         >::value, 
         "The default config of ebd::unique_fn has been changed!");
     static_assert(
         std::is_same<
             ebd::safe_fn<void(), 0>, 
-            ebd::basic_fn<void(), sizeof(void(*)()), true, false, false, true>
+            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, false, true>
         >::value, 
         "The default config of ebd::safe_fn has been changed!");
     static_assert(

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -706,3 +706,24 @@ TEST(InitFunction, from_copyable_function) {
     ASSERT_EQ(f3.is_empty(), true);
 }
 #endif
+
+// InitFunction[38]
+TEST(InitFunction, from_large_alignment) {
+    {
+        ebd::fn<int() const> f = ebd_test_large_alignment{};
+        ASSERT_EQ(f(), 42);
+    }
+    {
+        ebd::unique_fn<int() const> f = ebd_test_large_alignment{};
+        ASSERT_EQ(f(), 42);
+    }
+    {
+        ebd::safe_fn<int() const> f = ebd_test_large_alignment{};
+        ASSERT_EQ(f(), 42);
+    }
+    {
+        ebd_test_large_alignment obj{};
+        ebd::fn_ref<int() const> f = obj;
+        ASSERT_EQ(f(), 42);
+    }
+}

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -225,3 +225,8 @@ struct ebd_test_static_call_operator {
 #endif
 
 inline int ebd_test_safe_tmp_fn(ebd::fn_ref<int()> f) { return f(); }
+
+struct ebd_test_large_alignment {
+    alignas(std::max_align_t) int m_var;
+    int operator()() const { return 42; }
+};


### PR DESCRIPTION
**🔧 Fixed Bugs**
- Fixed a bug where `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` could not wrap callable objects that were aligned to `alignof(std::max_align_t)` on some platforms. (#96)

**⚠️ Breaking Changes**
- The alignment of `ebd::fn`, `ebd::unique_fn` and `ebd::safe_fn` has been changed to `alignof(std::max_align_t)`. (#96)

**✨ New Features**
- Added some code examples in `example/`. (#95)

**🛠️ Optimizations and Improvements**
- Optimized debug information to provide better diagnostics. (#97)

**📌 Notes**
- **The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` will be removed in v2.2.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.
- As of v2.1.9, the usage of `std::constant_wrapper` and `std::meta::is_complete_type` remains **experimental**. These features have been officially adopted in the C++26 standard (`ISO/IEC 14882:2026`) and will become fully stable starting from **v2.2.0**.