### PR TITLE
Version 2.2.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,7 @@ on:
       - 'include/**'
       - 'benchmark/**'
       - '.github/workflows/benchmark.yml'
+  workflow_dispatch:
 
 jobs:
   # Ubuntu check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main, version-* ]
     types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
 
 jobs:
   # GCC 13

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.1.11 LANGUAGES CXX)
+project(embedded_function VERSION 2.2.0 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To make sure the process of accepting patches goes smoothly for everyone (especi
 
 3. Do your modifications on that branch. Except for special cases, your contribution should include proper unit tests and documentation.
 
-4. Make sure your modifications did not break anything by building and running the [tests](./test/HOW-TO-TEST.md).
+4. Make sure your modifications did not break anything by building and running the [tests](./test/README.md).
 
 5. Commit your changes. Your commit message should start with a one line short description of the modifications, with the details and explanations of your modifications following in subsequent paragraphs or bullet points.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing to *Embedded-Function*!
 
 To make sure the process of accepting patches goes smoothly for everyone (especially for the maintainer), you should try to follow these few simple guidelines when you contribute:
 
-0. Before contributing, please open an issue to discuss significant changes.
+0. Before contributing, please open an [issue](https://github.com/Kim-J-Smith/Embedded-Function/issues) to discuss significant changes.
 
 1. Fork the repository.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 *Embedded Function* is a **lightweight** and **no-heap-allocation** function wrapper collection implemented based on the C++11 standard, optimized([see below](#-performance-optimization)) for resource-constrained or high-performance environments.
 
-The library is [freestanding](https://en.cppreference.com/w/cpp/freestanding), making it feasible for embedded development or kernel design of an operating system.
+The library is [freestanding](https://cppreference.com/w/cpp/freestanding), making it feasible for embedded development or kernel design of an operating system.
 
 In a [single header file](./include/embed/embed_function.hpp), **five** function wrappers are provided as follows (the customizable [`ebd::basic_fn`](./docs/api/basic_fn.md) is the fifth):
 
@@ -171,7 +171,7 @@ auto main() -> int {
 In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided, which can automatically deduce the signature and buffer size of the callable object and create a `ebd::fn`, `ebd::unique_fn` or `ebd::fn_ref` object. (Return `ebd::unique_fn` only when the callable object is of the move-only type. Return `ebd::fn_ref` only when the callable object is `std::cw`.)
 
 > __NOTE__: 
-> The [Concepts](https://en.cppreference.com/w/cpp/language/constraints.html) language feature is available for use provided that the compiler is configured to support the C++20 standard. On platforms that do not support C++20, `enable_if` will be used instead.
+> The [Concepts](https://cppreference.com/w/cpp/language/constraints.html) language feature is available for use provided that the compiler is configured to support the C++20 standard. On platforms that do not support C++20, `enable_if` will be used instead.
 
 ### Usage
 
@@ -392,7 +392,7 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 ## 📚 Similar implementations
 
-- [std::function](http://en.cppreference.com/w/cpp/utility/functional/function)
+- [std::function](https://cppreference.com/w/cpp/utility/functional/function)
 
 - [Naios/function2](https://github.com/Naios/function2)
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ auto main() -> int {
 | [`ebd::fn`](./docs/api/fn.md)    |  Yes  |   No  | No (`std::terminate()`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Copyable callable wrapper |
 | [`ebd::unique_fn`](./docs/api/unique_fn.md)    |  No  |   No  | No (`std::terminate()`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Move-only callable wrapper |
 | [`ebd::classic_fn`](./docs/api/classic_fn.md)    |  Yes  |   No  | Yes (`std::bad_function_call`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Classic wrapper (like `std::function`) |
-| [`ebd::fn_ref`](./docs/api/fn_ref.md)    |  Yes  |   Yes  | No (*NO EMPTY STATE*) | No | Fixed | Lightweight non-owning  reference(view) of callables |
+| [`ebd::fn_ref`](./docs/api/fn_ref.md)    |  Yes  |   Yes  | No (**NO EMPTY STATE**) | No | Fixed | Lightweight non-owning  reference(view) of callables |
 | [`ebd::basic_fn`](./docs/api/basic_fn.md) | - | - | - | - | - | Customized by the user |
 
 ### Key takeaways
@@ -175,9 +175,10 @@ In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided
 
 ### Usage
 
-- `[]` means optional.
+- **`[]` means optional**.
 - `Signature`: The signature of the callable object. (such as `void(int)`)
 - `BufferSize`: The buffer size of the callable object. (such as `2*sizeof(void*)`)
+- `FnWrapper`: One of `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn` and `ebd::fn_ref`.
 
 ```cpp
 // Create empty ebd::fn with specified signature and buffer size.
@@ -208,8 +209,10 @@ auto f = ebd::make_fn<ebd::fn_ref[, Signature]>(Callable_Object);
 
 ```cpp
 // In place build functor within buffer. Functor should be unambiguously callable (non-overload).
-auto f = ebd::make_fn(std::in_place_type<Functor>, CArgs...); // Since C++17
-auto f = ebd::make_fn(std::in_place_type<Functor>, {/*std::initializer_list*/}, CArgs...); // Since C++17
+// Since C++17.
+auto f = ebd::make_fn[<FnWrapper[, Signature]>](std::in_place_type<Functor>, CArgs...);
+auto f = ebd::make_fn[<FnWrapper[, Signature]>](
+  std::in_place_type<Functor>, {/*std::initializer_list*/}, CArgs...);
 ```
 
 ## 🔗 Back to function pointer

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ auto main() -> int {
 
 ### Brief introduction
 
-In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided, which can automatically deduce the signature and buffer size of the callable object and create a `ebd::fn` or `ebd::unique_fn` object. (Return `ebd::unique_fn` only when the callable object is of the move-only type.)
+In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided, which can automatically deduce the signature and buffer size of the callable object and create a `ebd::fn`, `ebd::unique_fn` or `ebd::fn_ref` object. (Return `ebd::unique_fn` only when the callable object is of the move-only type. Return `ebd::fn_ref` only when the callable object is `std::cw`.)
 
 > __NOTE__: 
 > The [Concepts](https://en.cppreference.com/w/cpp/language/constraints.html) language feature is available for use provided that the compiler is configured to support the C++20 standard. On platforms that do not support C++20, `enable_if` will be used instead.
@@ -213,6 +213,14 @@ auto f = ebd::make_fn<ebd::fn_ref[, Signature]>(Callable_Object);
 auto f = ebd::make_fn[<FnWrapper[, Signature]>](std::in_place_type<Functor>, CArgs...);
 auto f = ebd::make_fn[<FnWrapper[, Signature]>](
   std::in_place_type<Functor>, {/*std::initializer_list*/}, CArgs...);
+```
+
+```cpp
+// Create ebd::fn_ref from std::constant_wrapper. 
+// Since C++26
+auto f = ebd::make_fn(std::cw<&free_function>);
+auto f = ebd::make_fn(std::cw<&Class::member_function>, obj);
+auto f = ebd::make_fn(std::cw<&Class::member_function>, &obj);
 ```
 
 ## 🔗 Back to function pointer

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.1.11-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.11">
+  <img src="https://img.shields.io/badge/Version-2.2.0-yellow?style=for-the-badge&logo=github" alt="Version - 2.2.0">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23/26-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23/26">
 </p>
@@ -283,6 +283,34 @@ auto main() -> int {
     fn1(); fn2(); fn3(); fn4(); fn5();
 }
 ```
+
+## 🛠️ Debug diagnostics hook
+
+`EMBED_FN_HOOK_DEBUG(message)` is a user-defined macro hook for capturing diagnostic output in debug builds. Define it **before** including the header:
+
+```cpp
+#include <cstdio>
+#define EMBED_FN_HOOK_DEBUG(message) fputs(message, stderr)
+#include "embed/embed_function.hpp"
+```
+
+The library invokes the hook with a pre-formatted message that contains the source location:
+
+```
+<file>:<line>:
+	<message>
+```
+
+The hook is called when:
+
+- An empty wrapper is invoked (e.g., `ebd::fn` / `ebd::unique_fn` holding no target) with message: `"Empty function has been called!"`.
+- An internal assertion fails (e.g., constructing `ebd::fn_ref` from a `nullptr` function or object pointer). For assertions, the message also appends the failed expression, e.g., `[(function_ptr != nullptr) == false]`, and `std::terminate()` is called afterwards.
+
+Notes:
+
+- All diagnostics are **compiled out entirely** in optimized builds (when `__OPTIMIZE__` or `NDEBUG` is defined), which means zero runtime overhead.
+- If the hook is not defined, the library substitutes a no-op. The checks still run in debug builds, and failed internal assertions still call `std::terminate()` regardless of the hook.
+- When `EMBED_FN_CONFIG_UNDEF_MACROS` is defined, `EMBED_FN_HOOK_DEBUG` is undefined at the end of the header.
 
 ## ✅ Compatibility
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 <p align="center">
   <a href="https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/test.yml">
     <img src="https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/test.yml/badge.svg">
-    <img src="https://img.shields.io/badge/GCC_C++11~23-support-B46F1B?style=flat&logo=gnu" alt="gcc-C++11~23 - support">
-    <img src="https://img.shields.io/badge/Clang_C++11~23-support-045891?style=flat&logo=llvm" alt="clang-C++11~23 - support">
-    <img src="https://img.shields.io/badge/MSVC_C++14~23-support-5C2D91?style=flat" alt="msvc-C++14~23 - support">
+    <img src="https://img.shields.io/badge/GCC_5.1~16.1-support-B46F1B?style=flat&logo=gnu" alt="gcc-5.1~16.1 - support">
+    <img src="https://img.shields.io/badge/Clang_3.7~22.1-support-045891?style=flat&logo=llvm" alt="clang-3.7~22.1 - support">
+    <img src="https://img.shields.io/badge/MSVC_19.10~19.51-support-5C2D91?style=flat" alt="msvc-19.10~19.51 - support">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Version-2.1.11-yellow?style=for-the-badge&logo=github" alt="Version - 2.1.11">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
-  <img src="https://img.shields.io/badge/C++-11/14/17/20/23-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23">
+  <img src="https://img.shields.io/badge/C++-11/14/17/20/23/26-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23/26">
 </p>
 
 <p align="center">
@@ -32,7 +32,7 @@ template <class Signature, size_t BufferSize = /*DefaultSize*/>
 template <class Signature, size_t BufferSize = /*DefaultSize*/>
   class unique_fn; // Wrapper for movable, especially move-only callable objects.
 template <class Signature, size_t BufferSize = /*DefaultSize*/>
-  class safe_fn; // Wrapper for copyable callable objects which assert no-throw in Ctor and Dtor.
+  class classic_fn; // Wrapper for copyable callable objects (throws on empty, like std::function).
 template <class Signature, size_t Unused = 0>
   class fn_ref; // View (non-owning wrapper) for callable objects.
 }
@@ -89,7 +89,7 @@ auto main() -> int {
 // Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
 ```
 
-- *`Function wrapper`*: One of `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn` and `ebd::fn_ref`.
+- *`Function wrapper`*: One of `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn` and `ebd::fn_ref`.
 
 - *`Return type`*: A type that can be implicitly converted from the direct return type of *`Callable object`*.
 
@@ -126,7 +126,7 @@ auto main() -> int {
 
   - Provide a view or reference to the callable object, referring to the [`std::function_ref` P0792](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0792r14.html).
 
-  - Following the above design goals, `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn` and `ebd::fn_ref` were designed for developers to use.
+  - Following the above design goals, `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn` and `ebd::fn_ref` were designed for developers to use.
 
 ## ✨ Core function wrappers
 
@@ -134,19 +134,19 @@ auto main() -> int {
 
 | Wrapper Type | Copyable | View (Non-owning) | Throws on Empty Call | Assert No-Throw (Ctor/Dtor) | Buffer Size | Primary Use Case |
 | :----------- | :---: | :---: | :---: | :---: | :---: | :---: |
-| [`ebd::fn`](./docs/api/fn.md)    |  Yes  |   No  | Yes (`std::bad_function_call`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Copyable callable wrapper |
-| [`ebd::unique_fn`](./docs/api/unique_fn.md)    |  No  |   No  | Yes (`std::bad_function_call`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Move-only callable wrapper |
-| [`ebd::safe_fn`](./docs/api/safe_fn.md)    |  Yes  |   No  | No (`std::terminate()`) | Yes | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Exception-safe copyable callable wrapper |
+| [`ebd::fn`](./docs/api/fn.md)    |  Yes  |   No  | No (`std::terminate()`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Copyable callable wrapper |
+| [`ebd::unique_fn`](./docs/api/unique_fn.md)    |  No  |   No  | No (`std::terminate()`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Move-only callable wrapper |
+| [`ebd::classic_fn`](./docs/api/classic_fn.md)    |  Yes  |   No  | Yes (`std::bad_function_call`) | No | Configurable (aligned, default: `sizeof(void(Class::*)())`) | Classic wrapper (like `std::function`) |
 | [`ebd::fn_ref`](./docs/api/fn_ref.md)    |  Yes  |   Yes  | No (*NO EMPTY STATE*) | No | Fixed | Lightweight non-owning  reference(view) of callables |
 | [`ebd::basic_fn`](./docs/api/basic_fn.md) | - | - | - | - | - | Customized by the user |
 
 ### Key takeaways
 
-1. **Ownership & Copy**: `fn`/`safe_fn` own callables (copyable), `unique_fn` owns but is move-only, `fn_ref` is non-owning (view).
+1. **Ownership & Copy**: `fn`/`classic_fn` own callables (copyable), `unique_fn` owns but is move-only, `fn_ref` is non-owning (view).
 
-2. **Exception Behavior**: Only `fn`/`unique_fn` throw on empty calls; `safe_fn`/`fn_ref` terminate (no exceptions).
+2. **Exception Behavior**: `fn`/`unique_fn` terminate on empty calls (no exceptions); `classic_fn` throws `std::bad_function_call` (like `std::function`).
 
-3. **Buffer Configuration**: `fn`/`unique_fn`/`safe_fn` support configurable buffer sizes (aligned), while `fn_ref` uses a fixed buffer (unused template param).
+3. **Buffer Configuration**: `fn`/`unique_fn`/`classic_fn` support configurable buffer sizes (aligned), while `fn_ref` uses a fixed buffer (unused template param).
 
 4. **Triviality**: `fn_ref` is trivially copyable (same as `std::function_ref`).
 
@@ -157,11 +157,11 @@ auto main() -> int {
 - `Yes-R`: Convertible and non-owning wrapping.
 - `No`: Inconvertible
 
-| From \ To | `ebd::fn` | `ebd::unique_fn` | `ebd::safe_fn` | `ebd::fn_ref` |
+| From \ To | `ebd::fn` | `ebd::unique_fn` | `ebd::classic_fn` | `ebd::fn_ref` |
 | :---: | :---: | :---: | :---: | :---: |
-| `ebd::fn` | Yes-D | Yes-D | No | Yes-R |
+| `ebd::fn` | Yes-D | Yes-D | Yes-I | Yes-R |
 | `ebd::unique_fn` | No | Yes-D | No | Yes-R |
-| `ebd::safe_fn` | Yes-I | Yes-I | Yes-D | Yes-R |
+| `ebd::classic_fn` | Yes-I | Yes-I | Yes-D | Yes-R |
 | `ebd::fn_ref` | Yes-I | Yes-I | Yes-I | Yes-D |
 
 ## 🧩 Automatic deduction
@@ -202,7 +202,7 @@ auto f = ebd::make_fn<Signature>(Ambiguous_Callable_Object);
 // The Callable_Object should be unambiguously callable (non-overload) if `Signature` is omitted.
 auto f = ebd::make_fn<ebd::fn[, Signature]>(Callable_Object);
 auto f = ebd::make_fn<ebd::unique_fn[, Signature]>(Callable_Object);
-auto f = ebd::make_fn<ebd::safe_fn[, Signature]>(Callable_Object);
+auto f = ebd::make_fn<ebd::classic_fn[, Signature]>(Callable_Object);
 auto f = ebd::make_fn<ebd::fn_ref[, Signature]>(Callable_Object);
 ```
 
@@ -216,7 +216,7 @@ auto f = ebd::make_fn(std::in_place_type<Functor>, {/*std::initializer_list*/}, 
 
 ### Brief introduction
 
-In embedded MCU development, it is often necessary to pass a C-style free function pointer as an argument, as existing libraries are typically written in C. To address this, we have implemented an `operator*` overload that simplifies converting an object of type `ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` to a C-style free function pointer.
+In embedded MCU development, it is often necessary to pass a C-style free function pointer as an argument, as existing libraries are typically written in C. To address this, we have implemented an `operator*` overload that simplifies converting an object of type `ebd::fn` / `ebd::unique_fn` / `ebd::classic_fn` / `ebd::fn_ref` to a C-style free function pointer.
 
 If the object encapsulated by the function wrapper is a valid function pointer, this mechanism returns the pointer; otherwise, it returns nullptr. Basically, it is equivalent to a highly restricted `target()` method.
 
@@ -262,7 +262,7 @@ export namespace ebd {
   using ::ebd::basic_fn;
   using ::ebd::fn;
   using ::ebd::unique_fn;
-  using ::ebd::safe_fn;
+  using ::ebd::classic_fn;
   using ::ebd::fn_ref;
   using ::ebd::make_fn;
 }
@@ -276,7 +276,7 @@ import ebd.function;
 auto main() -> int {
     ebd::fn<void()> fn1 = []() { /* ... */ };
     ebd::unique_fn<void()> fn2 = []() { /* ... */ };
-    ebd::safe_fn<void()> fn3 = []() { /* ... */ };
+    ebd::classic_fn<void()> fn3 = []() { /* ... */ };
     ebd::fn_ref<void()> fn4 = fn2;
     auto fn5 = ebd::make_fn([]() { /* ... */ });
 
@@ -301,11 +301,11 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 ### Branch elimination
 
-`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` completely eliminate runtime checks for empty function states during invocation, significantly boosting performance of frequent function calls.
+`ebd::fn` / `ebd::unique_fn` / `ebd::classic_fn` / `ebd::fn_ref` completely eliminate runtime checks for empty function states during invocation, significantly boosting performance of frequent function calls.
 
 ### Smart forwarding
 
-`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` enable scalar arguments and small-sized trivial arguments to be passed via registers instead of having to be passed via the stack as in `std::function`. This significantly reduces the memory access overhead during parameter passing.
+`ebd::fn` / `ebd::unique_fn` / `ebd::classic_fn` / `ebd::fn_ref` enable scalar arguments and small-sized trivial arguments to be passed via registers instead of having to be passed via the stack as in `std::function`. This significantly reduces the memory access overhead during parameter passing.
 
 ### Zero-stack overhead
 
@@ -313,7 +313,7 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 ### Stateless elimination
 
-`ebd::fn` / `ebd::unique_fn` / `ebd::safe_fn` / `ebd::fn_ref` do not store the functor or its pointer if the functor is stateless (e.g., empty classes with trivial operations). This reduces memory access operations and improves cache efficiency.
+`ebd::fn` / `ebd::unique_fn` / `ebd::classic_fn` / `ebd::fn_ref` do not store the functor or its pointer if the functor is stateless (e.g., empty classes with trivial operations). This reduces memory access operations and improves cache efficiency.
 
 > Click [x64-asm](./docs/perf/x86_64_msvc_asm_analysis.md), [rv32-asm](./docs/perf/riscv_gcc_asm_analysis.md) and [arm32-asm](./docs/perf/arm_gcc_asm_analysis.md) to see more details.
 

--- a/docs/api/basic_fn.md
+++ b/docs/api/basic_fn.md
@@ -68,7 +68,7 @@ view(42);
 
 ## Notes
 
-- Prefer using the predefined aliases (`ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, `ebd::fn_view`) unless you need a combination not covered by them.
+- Prefer using the predefined aliases (`ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, `ebd::fn_ref`) unless you need a combination not covered by them.
 - The buffer size is automatically aligned to the nearest alignment boundary.
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
 
@@ -77,5 +77,5 @@ view(42);
 - [`ebd::detail::function`](./detail/function.md) - The underlying implementation
 - [`ebd::fn`](./fn.md) - For copyable callables
 - [`ebd::unique_fn`](./unique_fn.md) - For move-only callables
-- [`ebd::safe_fn`](./safe_fn.md) - For exception-safe callables
+- [`ebd::classic_fn`](./classic_fn.md) - For callables with `std::bad_function_call` on empty
 - [`ebd::fn_ref`](./fn_ref.md) - For non-owning views of callables

--- a/docs/api/classic_fn.md
+++ b/docs/api/classic_fn.md
@@ -1,8 +1,8 @@
-# `ebd::fn`
+# `ebd::classic_fn`
 
 ## Overview
 
-`ebd::fn` is a function object wrapper for copyable and callable objects. It is an alias of `ebd::detail::function` with specific configuration parameters optimized for copyable callables.
+`ebd::classic_fn` is a function object wrapper for copyable and callable objects. It is an alias of `ebd::detail::function` with specific configuration parameters that match the traditional `std::function` behavior: calling an empty wrapper throws `std::bad_function_call`. (if exceptions are enabled)
 
 ## Template Parameters
 
@@ -13,18 +13,18 @@
 
 ## Configuration
 
-`ebd::fn` is configured with the following parameters:
+`ebd::classic_fn` is configured with the following parameters:
 
 | Configuration | Value | Description |
 |---------------|-------|-------------|
 | `IsCopyable` | `true` | The callable object must be copyable. |
 | `IsView` | `false` | This is not a view; the wrapper owns the callable object. |
-| `IsThrowing` | `false` | The wrapper will call `std::terminate()` when called in an empty state. |
+| `IsThrowing` | `true` | The wrapper will throw `std::bad_function_call` when called in an empty state. |
 | `AssertObjectNoThrow` | `false` | The callable object does not need to be nothrow-constructible or nothrow-destructible. |
 
 ## Member Functions
 
-All member functions of `ebd::detail::function` are available for `ebd::fn`. For detailed documentation, see [`ebd::detail::function`](./detail/function.md).
+All member functions of `ebd::detail::function` are available for `ebd::classic_fn`. For detailed documentation, see [`ebd::detail::function`](./detail/function.md).
 
 ## Usage Examples
 
@@ -33,8 +33,8 @@ All member functions of `ebd::detail::function` are available for `ebd::fn`. For
 ```cpp
 #include "embed/embed_function.hpp"
 
-// Create a function wrapper for a void(int) signature
-ebd::fn<void(int)> fn;
+// Create a classic function wrapper for a void(int) signature
+ebd::classic_fn<void(int)> fn;
 
 // Assign a function pointer
 void foo(int x) { /* do something */ }
@@ -44,20 +44,13 @@ fn(42);
 // Assign a lambda
 fn = [](int x) { /* do something */ };
 fn(42);
-
-// Assign a functor
-struct Functor {
-    void operator()(int x) { /* do something */ }
-};
-fn = Functor{};
-fn(42);
 ```
 
 ### With Custom Buffer Size
 
 ```cpp
-// Create a function wrapper with a custom buffer size
-ebd::fn<void(int), 32> fn; // 32-byte buffer
+// Create a classic function wrapper with a custom buffer size
+ebd::classic_fn<void(int), 32> fn; // 32-byte buffer
 
 // Assign a larger lambda with captures
 int value = 42;
@@ -67,14 +60,14 @@ fn(100);
 
 ## Notes
 
-- `ebd::fn` is copyable and owns the callable object it wraps.
+- `ebd::classic_fn` is copyable and owns the callable object it wraps.
 - The buffer size is automatically aligned to the nearest alignment boundary.
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
-- When called in an empty state, `ebd::fn` will call `std::terminate()`.
+- When called in an empty state, `ebd::classic_fn` will throw `std::bad_function_call` (if exceptions are enabled), matching `std::function` behavior.
 
 ## See Also
 
 - [`ebd::detail::function`](./detail/function.md) - The underlying implementation
+- [`ebd::fn`](./fn.md) - For copyable callables (terminate on empty)
 - [`ebd::unique_fn`](./unique_fn.md) - For move-only callables
-- [`ebd::classic_fn`](./classic_fn.md) - For callables with `std::bad_function_call` on empty
 - [`ebd::fn_ref`](./fn_ref.md) - For non-owning views of callables

--- a/docs/api/detail/function.md
+++ b/docs/api/detail/function.md
@@ -276,7 +276,7 @@ int result = add(10, 20); // result = 30
 
 ## Notes
 
-- The `ebd::detail::function` class is not intended for direct use. Instead, use the predefined aliases such as `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, and `ebd::fn_view`.
+- The `ebd::detail::function` class is not intended for direct use. Instead, use the predefined aliases such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`.
 - The buffer size is automatically aligned to the nearest alignment boundary.
 - The function wrapper supports all callable objects, including free functions, lambdas, functors, static member functions, and member functions.
 - When `Config::isView` is `true`, the wrapper acts as a non-owning view, similar to `std::function_ref`.

--- a/docs/api/fn_ref.md
+++ b/docs/api/fn_ref.md
@@ -99,8 +99,8 @@ process_data(100, &handle_result);
 
 - `ebd::fn_ref` is a non-owning view, so the underlying callable object must outlive the view.
 - `ebd::fn_ref` is trivially copyable and has minimal overhead.
-- The buffer size is fixed to `detail::default_buffer_size::ref_buf`, which is sufficient to store function pointers and member pointers.
-- `ebd::fn_ref` cannot be initialized with rvalue references, as it would create a dangling reference.
+- The buffer size is fixed to `detail::default_buffer_size::ref_buf`, which is sufficient to store function pointers.
+- `ebd::fn_ref` now can be initialized with rvalue references, although it may create a dangling reference. (same as `std::function_ref`)
 
 ## Compare `ebd::fn_ref` with `std::function_ref`
 
@@ -125,4 +125,4 @@ process_data(100, &handle_result);
 - [`ebd::detail::function`](./detail/function.md) - The underlying implementation
 - [`ebd::fn`](./fn.md) - For copyable callables
 - [`ebd::unique_fn`](./unique_fn.md) - For move-only callables
-- [`ebd::safe_fn`](./safe_fn.md) - For exception-safe callables
+- [`ebd::classic_fn`](./classic_fn.md) - For callables with `std::bad_function_call` on empty

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -9,7 +9,7 @@ It can:
 - deduce the signature of a lambda or other uniquely callable functor,
 - choose `ebd::fn` or `ebd::unique_fn` automatically,
 - build an empty wrapper with an explicit signature,
-- create a wrapper with a specific wrapper type such as `ebd::safe_fn` or `ebd::fn_ref`.
+- create a wrapper with a specific wrapper type such as `ebd::classic_fn` or `ebd::fn_ref`.
 
 ## Overloads
 
@@ -18,16 +18,12 @@ It can:
 ```cpp
 template <typename Signature, typename Functor,
           typename Class = detail::remove_cvref_t<Functor>,
-          std::size_t BufferSize = sizeof(Class),
-          typename Fn = detail::conditional_t<
-              std::is_copy_constructible<Class>::value,
-              fn<Signature, BufferSize>,
-              unique_fn<Signature, BufferSize>>,
           bool NoThrow = detail::is_nothrow_construct_from_functor<Functor&&>::value>
-EMBED_NODISCARD inline Fn make_fn(Functor&& functor) noexcept(NoThrow);
+EMBED_NODISCARD inline fn<Signature, sizeof(Class)>
+make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
-Creates a wrapper for a class-type callable when the signature is specified explicitly. For copyable functors, the resulting type is `ebd::fn<Signature, BufferSize>`.
+Creates an `ebd::fn` for a class-type callable when the signature is specified explicitly. The buffer size is automatically deduced as `sizeof(Class)`.
 
 ### 2. Move-only functor with explicit signature
 
@@ -61,11 +57,21 @@ make_fn(Ret (*func_ptr)(Args...)) noexcept;
 
 Creates an `ebd::fn` from a free-function pointer and deduces both signature and buffer size.
 
+### 4b. noexcept function pointer with deduced signature (C++17+)
+
+```cpp
+template <typename Ret, typename... Args>
+EMBED_NODISCARD inline fn<Ret(Args...) const noexcept, sizeof(Ret(*)(Args...) noexcept)>
+make_fn(Ret (*func_ptr)(Args...) noexcept) noexcept;
+```
+
+Creates an `ebd::fn` from a noexcept free-function pointer. The noexcept qualifier is preserved in the signature. Only available when noexcept is part of the type system (C++17 or `__cpp_noexcept_function_type >= 201510L`).
+
 ### 5. Function pointer with explicit signature
 
 ```cpp
 template <typename Signature,
-          typename FunctionPtr = typename detail::unwrap_signature<Signature>::pure_sig*>
+          typename FunctionPtr = typename detail::unwrap_signature<Signature>::pure_sig_noex*>
 EMBED_NODISCARD inline fn<Signature, sizeof(FunctionPtr)>
 make_fn(FunctionPtr func_ptr) noexcept;
 ```
@@ -118,7 +124,7 @@ template <typename Class, typename Ret, typename... Args>
 EMBED_NODISCARD inline auto
 make_fn(Ret(Class::* memfunc)(Args...) C V REF NOEXCEPT) noexcept
 -> fn<
-    Ret(detail::get_qualified_with_t<int REF, C V Class>, Args...) const,
+    Ret(detail::get_qualified_with_t<int REF, C V Class>, Args...) const NOEXCEPT,
     sizeof(memfunc)
    >;
 ```
@@ -143,10 +149,11 @@ Creates an `ebd::fn` from a pointer to member function using the specified signa
 template <typename Class, typename T,
           typename Ret = typename detail::invoke_result<T Class::*, Class&>::type>
 EMBED_NODISCARD inline auto make_fn(T Class::* ptr_memobj) noexcept
--> fn<Ret(Class&) const, sizeof(ptr_memobj)>;
+-> fn<Ret(Class&) const noexcept(detail::is_nothrow_invocable_r<Ret, T Class::*, Class&>::value),
+     sizeof(ptr_memobj)>;
 ```
 
-Creates an `ebd::fn` that reads a member object from an instance.
+Creates an `ebd::fn` that reads a member object from an instance. The noexcept qualifier is deduced from the member access expression.
 
 ### 12. In-place construction (C++17+)
 
@@ -174,7 +181,7 @@ template <template <class, std::size_t> class Fn,
           typename RawSig = typename detail::is_ebd_fn<Deduction>::signature,
           typename Signature = detail::conditional_t<
               std::is_void<SpecifiedSig>::value,
-              detail::noexcept_qualify_like_t<Functor, Fn, RawSig>,
+              detail::get_correct_signature_t<Fn, RawSig>,
               SpecifiedSig>,
           std::size_t BufferSize = sizeof(detail::decay_t<Functor>),
           typename FnWrapper = Fn<Signature, BufferSize>,
@@ -182,7 +189,7 @@ template <template <class, std::size_t> class Fn,
 EMBED_NODISCARD inline FnWrapper make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
-Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, or `ebd::fn_ref`. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(functor)`.
+Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(functor)`.
 
 ## Usage Examples
 
@@ -228,7 +235,7 @@ int value = mem_obj(obj);
 ### Explicit Wrapper Type
 
 ```cpp
-auto safe = ebd::make_fn<ebd::safe_fn>([]() noexcept { /* ... */ });
+auto safe = ebd::make_fn<ebd::classic_fn>([]() { /* ... */ });
 
 void bar() {}
 auto ref = ebd::make_fn<ebd::fn_ref>(&bar);
@@ -253,7 +260,7 @@ int value = fn();
 
 - `ebd::make_fn` returns `ebd::fn` for copyable deduced callables and `ebd::unique_fn` for move-only deduced callables.
 - When the callable is ambiguous, such as an overloaded function, specify the signature explicitly.
-- The explicit-wrapper overload accepts `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, and `ebd::fn_ref`.
+- The explicit-wrapper overload accepts `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`.
 - `ebd::fn_view` is still available as a deprecated alias of `ebd::fn_ref`.
 - When deduction fails, the fallback overload triggers a static assertion with guidance.
 
@@ -261,5 +268,5 @@ int value = fn();
 
 - [`ebd::fn`](./fn.md) - Copyable owning wrapper
 - [`ebd::unique_fn`](./unique_fn.md) - Move-only owning wrapper
-- [`ebd::safe_fn`](./safe_fn.md) - Non-throwing wrapper
+- [`ebd::classic_fn`](./classic_fn.md) - Classic wrapper with `std::bad_function_call` on empty
 - [`ebd::fn_ref`](./fn_ref.md) - Non-owning wrapper

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -176,20 +176,20 @@ Constructs the callable directly inside the wrapper buffer. The returned wrapper
 ```cpp
 template <template <class, std::size_t> class Fn,
           typename SpecifiedSig = void,
-          typename Functor,
-          typename Deduction = decltype(make_fn(std::declval<Functor>())),
+          typename... Args,
+          typename Deduction = decltype(make_fn(std::declval<Args>()...)),
           typename RawSig = typename detail::is_ebd_fn<Deduction>::signature,
           typename Signature = detail::conditional_t<
               std::is_void<SpecifiedSig>::value,
               detail::get_correct_signature_t<Fn, RawSig>,
               SpecifiedSig>,
-          std::size_t BufferSize = sizeof(detail::decay_t<Functor>),
+          std::size_t BufferSize = Deduction::get_buffer_size(),
           typename FnWrapper = Fn<Signature, BufferSize>,
-          bool NoThrow = noexcept(FnWrapper(std::declval<Functor>()))>
-EMBED_NODISCARD inline FnWrapper make_fn(Functor&& functor) noexcept(NoThrow);
+          bool NoThrow = noexcept(FnWrapper(std::declval<Args>()...))>
+EMBED_NODISCARD inline FnWrapper make_fn(Args&&... args) noexcept(NoThrow);
 ```
 
-Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(functor)`.
+Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. Accepts multiple arguments: the wrapper type and signature are deduced from `make_fn(args...)`, and the buffer size is taken from the deduced result. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(args...)`. This also enables in-place construction with a specific wrapper, e.g. `make_fn<ebd::fn>(std::in_place_type<Functor>, 0)`.
 
 ## Usage Examples
 
@@ -241,6 +241,15 @@ void bar() {}
 auto ref = ebd::make_fn<ebd::fn_ref>(&bar);
 
 auto ref2 = ebd::make_fn<ebd::fn_ref, void()>(bar);
+
+// Multiple arguments, e.g. in-place construction with a specific wrapper.
+struct Counter {
+    explicit Counter(int v) : value(v) {}
+    int operator()() const { return value; }
+    int value;
+};
+auto fn = ebd::make_fn<ebd::fn>(std::in_place_type<Counter>, 42);
+int value = fn();
 ```
 
 ### In-place Construction
@@ -260,7 +269,7 @@ int value = fn();
 
 - `ebd::make_fn` returns `ebd::fn` for copyable deduced callables and `ebd::unique_fn` for move-only deduced callables.
 - When the callable is ambiguous, such as an overloaded function, specify the signature explicitly.
-- The explicit-wrapper overload accepts `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`.
+- The explicit-wrapper overload accepts multiple arguments and works with `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`. The buffer size is deduced from the `make_fn(args...)` result instead of `sizeof(Functor)`.
 - `ebd::fn_view` is still available as a deprecated alias of `ebd::fn_ref`.
 - When deduction fails, the fallback overload triggers a static assertion with guidance.
 

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -171,7 +171,25 @@ noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs
 
 Constructs the callable directly inside the wrapper buffer. The returned wrapper type is deduced from the functor.
 
-### 13. Explicit wrapper type
+### 13. From `std::constant_wrapper` (C++26+)
+
+```cpp
+template <auto Cw, typename Fn>
+EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>) noexcept;
+```
+
+Creates an `ebd::fn_ref` from a `std::constant_wrapper` (P3007) of a free function or other callable. The signature is deduced automatically. Only available when `__cpp_lib_constant_wrapper >= 202603L`.
+
+### 14. From `std::constant_wrapper` of a member pointer and an object (C++26+)
+
+```cpp
+template <auto Cw, typename Fn, typename Tp>
+EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>, Tp&& obj) noexcept;
+```
+
+Creates an `ebd::fn_ref` from a `std::constant_wrapper` together with an object (`obj` or `&obj`). The object binds to the **first parameter** of the wrapped callable (the *instance* for a member function or member object pointer, or the *first argument* of a free function), and that parameter is removed from the deduced signature.
+
+### 15. Explicit wrapper type
 
 ```cpp
 template <template <class, std::size_t> class Fn,
@@ -265,6 +283,26 @@ auto fn = ebd::make_fn(std::in_place_type<Functor>, 42);
 int value = fn();
 ```
 
+### `std::constant_wrapper` (C++26+)
+
+```cpp
+void free_func(int a, int b) { /* ... */ }
+struct MyClass {
+    void method(int a, int b) { /* ... */ }
+    int value;
+};
+
+// From a constant_wrapper of a free function.
+auto cw_fn = ebd::make_fn(std::cw<&free_func>);
+
+// From a constant_wrapper of a member function + instance.
+MyClass obj;
+auto cw_mem = ebd::make_fn(std::cw<&MyClass::method>, obj);
+
+// From a constant_wrapper of a member object + instance.
+auto cw_mem_obj = ebd::make_fn(std::cw<&MyClass::value>, &obj);
+```
+
 ## Notes
 
 - `ebd::make_fn` returns `ebd::fn` for copyable deduced callables and `ebd::unique_fn` for move-only deduced callables.
@@ -272,6 +310,7 @@ int value = fn();
 - The explicit-wrapper overload accepts multiple arguments and works with `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`. The buffer size is deduced from the `make_fn(args...)` result instead of `sizeof(Functor)`.
 - `ebd::fn_view` is still available as a deprecated alias of `ebd::fn_ref`.
 - When deduction fails, the fallback overload triggers a static assertion with guidance.
+- The `std::constant_wrapper` overloads (C++26+) return `ebd::fn_ref` and are `constexpr`. They replace the removed `ebd::fn_ref` CTAD deduction guides for `std::constant_wrapper`.
 
 ## See Also
 

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -201,13 +201,14 @@ template <template <class, std::size_t> class Fn,
               std::is_void<SpecifiedSig>::value,
               detail::get_correct_signature_t<Fn, RawSig>,
               SpecifiedSig>,
-          std::size_t BufferSize = Deduction::get_buffer_size(),
+          std::size_t BufferSize =
+              detail::get_correct_buffer_size<Fn<int(), 0>, Deduction::get_buffer_size(), Args...>::value,
           typename FnWrapper = Fn<Signature, BufferSize>,
           bool NoThrow = noexcept(FnWrapper(std::declval<Args>()...))>
 EMBED_NODISCARD inline FnWrapper make_fn(Args&&... args) noexcept(NoThrow);
 ```
 
-Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. Accepts multiple arguments: the wrapper type and signature are deduced from `make_fn(args...)`, and the buffer size is taken from the deduced result. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(args...)`. This also enables in-place construction with a specific wrapper, e.g. `make_fn<ebd::fn>(std::in_place_type<Functor>, 0)`.
+Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. Accepts multiple arguments: the wrapper type and signature are deduced from `make_fn(args...)`, and the buffer size is taken from the deduced result (when an argument is another ebd wrapper that is not directly config-convertible, the buffer is sized to fit that wrapper object for indirect wrapping). If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(args...)`. This also enables in-place construction with a specific wrapper, e.g. `make_fn<ebd::fn>(std::in_place_type<Functor>, 0)`.
 
 ## Usage Examples
 

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -178,7 +178,7 @@ template <auto Cw, typename Fn>
 EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>) noexcept;
 ```
 
-Creates an `ebd::fn_ref` from a `std::constant_wrapper` (P3007) of a free function or other callable. The signature is deduced automatically. Only available when `__cpp_lib_constant_wrapper >= 202603L`.
+Creates an `ebd::fn_ref` from a `std::constant_wrapper` (P3948) of a free function or other callable. The signature is deduced automatically. Only available when `__cpp_lib_constant_wrapper >= 202603L`.
 
 ### 14. From `std::constant_wrapper` of a member pointer and an object (C++26+)
 

--- a/docs/api/safe_fn.md
+++ b/docs/api/safe_fn.md
@@ -1,81 +1,20 @@
 # `ebd::safe_fn`
 
-## Overview
+## *Deprecated*
 
-`ebd::safe_fn` is a safe function object wrapper for copyable and callable objects. It is an alias of `ebd::detail::function` with specific configuration parameters optimized for exception-safe operations.
+Please use [`ebd::fn`](./fn.md) instead.
 
-## Template Parameters
+### Migration Note
 
-| Parameter | Description |
-|-----------|-------------|
-| `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_buffer_size::value` if omitted. |
-
-## Configuration
-
-`ebd::safe_fn` is configured with the following parameters:
-
-| Configuration | Value | Description |
-|---------------|-------|-------------|
-| `IsCopyable` | `true` | The callable object must be copyable. |
-| `IsView` | `false` | This is not a view; the wrapper owns the callable object. |
-| `IsThrowing` | `false` | The wrapper will not throw `std::bad_function_call` when called in an empty state; instead, it will call `std::terminate()`. |
-| `AssertObjectNoThrow` | `true` | The callable object must be nothrow-constructible, nothrow-destructible, nothrow-copy-constructible, and nothrow-move-constructible. |
-
-## Member Functions
-
-All member functions of `ebd::detail::function` are available for `ebd::safe_fn`. For detailed documentation, see [`ebd::detail::function`](./detail/function.md).
-
-## Usage Examples
-
-### Basic Usage
+The `safe_fn` alias still works but has been deprecated. If you migrate to `ebd::fn`, note that `AssertObjectNoThrow` changes to `false` — meaning `ebd::fn` no longer requires the callable object to be noexcept-constructible/destructible. If you need the `AssertObjectNoThrow=true` guarantee, use `ebd::basic_fn` directly:
 
 ```cpp
-#include "embed/embed_function.hpp"
-
-// Create a safe function wrapper for a void(int) signature
-ebd::safe_fn<void(int)> fn;
-
-// Assign a function pointer
-void foo(int x) noexcept { /* do something */ }
-fn = &foo;
-fn(42);
-
-// Assign a noexcept lambda
-fn = [](int x) noexcept { /* do something */ };
-fn(42);
-
-// Assign a noexcept functor
-struct NoThrowFunctor {
-    void operator()(int x) noexcept { /* do something */ }
-};
-fn = NoThrowFunctor{};
-fn(42);
+template <typename Signature, std::size_t BufferSize = ebd::detail::default_buffer_size::value>
+using my_safe_fn = ebd::basic_fn<
+    Signature, ebd::detail::get_aligned_size(BufferSize),
+    true,  // IsCopyable
+    false, // IsView
+    false, // IsThrowing
+    true   // AssertObjectNoThrow
+>;
 ```
-
-### With Custom Buffer Size
-
-```cpp
-// Create a safe function wrapper with a custom buffer size
-ebd::safe_fn<void(int), 32> fn; // 32-byte buffer
-
-// Assign a larger noexcept lambda with captures
-int value = 42;
-fn = [value](int x) noexcept { /* use value */ };
-fn(100);
-```
-
-## Notes
-
-- `ebd::safe_fn` is copyable and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest alignment boundary.
-- The callable object must be noexcept in all operations (construction, destruction, copy, move).
-- If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
-- When called in an empty state, `ebd::safe_fn` will call `std::terminate()` instead of throwing an exception.
-
-## See Also
-
-- [`ebd::detail::function`](./detail/function.md) - The underlying implementation
-- [`ebd::fn`](./fn.md) - For copyable callables (non-noexcept)
-- [`ebd::unique_fn`](./unique_fn.md) - For move-only callables
-- [`ebd::fn_ref`](./fn_ref.md) - For non-owning views of callables

--- a/docs/api/unique_fn.md
+++ b/docs/api/unique_fn.md
@@ -19,7 +19,7 @@
 |---------------|-------|-------------|
 | `IsCopyable` | `false` | The callable object can be move-only (copyable objects are also accepted but only move operations will be used). |
 | `IsView` | `false` | This is not a view; the wrapper owns the callable object. |
-| `IsThrowing` | `true` | The wrapper will throw `std::bad_function_call` when called in an empty state. |
+| `IsThrowing` | `false` | The wrapper will call `std::terminate()` when called in an empty state. |
 | `AssertObjectNoThrow` | `false` | The callable object does not need to be nothrow-constructible or nothrow-destructible. |
 
 ## Member Functions
@@ -76,11 +76,11 @@ fn(100);
 - `ebd::unique_fn` is move-only and owns the callable object it wraps.
 - The buffer size is automatically aligned to the nearest alignment boundary.
 - If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
-- When called in an empty state, `ebd::unique_fn` will throw `std::bad_function_call` (if exceptions are enabled).
+- When called in an empty state, `ebd::unique_fn` will call `std::terminate()`.
 
 ## See Also
 
 - [`ebd::detail::function`](./detail/function.md) - The underlying implementation
 - [`ebd::fn`](./fn.md) - For copyable callables
-- [`ebd::safe_fn`](./safe_fn.md) - For exception-safe callables
+- [`ebd::classic_fn`](./classic_fn.md) - For callables with `std::bad_function_call` on empty
 - [`ebd::fn_ref`](./fn_ref.md) - For non-owning views of callables

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -6,6 +6,7 @@
 - `make_fn` now preserves the `noexcept` qualifier when deducing signatures for lambdas and functors (it was previously stripped for `ebd::fn`/`ebd::unique_fn`). For example, `make_fn([]() noexcept {})` now yields `fn<void() const noexcept>` instead of `fn<void() const>` (Since C++17).
 - `ebd::safe_fn` is deprecated. Use `ebd::fn` for terminate-on-empty, or `ebd::basic_fn` directly if you need the `AssertObjectNoThrow` guarantee.
 - The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` has been removed.
+- If the user creates the `fn_ref` object from `nullptr` in the **debugging mode**, then regardless of whether the user has defined the macro `EMBED_FN_HOOK_DEBUG` or not, the `std::terminate()` function will be called.
 
 **✨ New Features**
 - Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`).

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -7,12 +7,14 @@
 - `ebd::safe_fn` is deprecated. Use `ebd::fn` for terminate-on-empty, or `ebd::basic_fn` directly if you need the `AssertObjectNoThrow` guarantee.
 - The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` has been removed.
 - If the user creates the `fn_ref` object from `nullptr` in the **debugging mode**, then regardless of whether the user has defined the macro `EMBED_FN_HOOK_DEBUG` or not, the `std::terminate()` function will be called.
+- The `ebd::fn_ref` CTAD deduction guides for `std::constant_wrapper` (C++26) have been removed. Use `ebd::make_fn(std::cw<...>)` instead.
 
 **✨ New Features**
 - Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`).
 - Added a `make_fn` overload for `noexcept` function pointers (C++17+), which preserves the `noexcept` qualifier in the wrapper's signature.
 - noexcept qualifiers are now propagated through `make_fn` for member function pointers and member object pointers.
 - `make_fn<FnWrapper>` now accepts multiple arguments, enabling in-place construction with a specific wrapper type, e.g. `make_fn<ebd::classic_fn>(std::in_place_type<Functor>, args...)`.
+- Added `make_fn` overloads for `std::constant_wrapper` (C++26+), which deduce and return an `ebd::fn_ref` from `std::cw<fn>` or `std::cw<member_fn>` + object.
 
 **🛠️ Optimizations and Improvements**
 - Refactored noexcept propagation: replaced the complex `noexcept_qualify_like` trait with a simpler `get_correct_signature` trait that decides based on wrapper config (`IsView || !IsThrowing`).

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,17 +1,21 @@
 **🔧 Fixed Bugs**
-- None.
+- `operator*` now returns a `noexcept` function pointer when the stored signature includes `noexcept`, instead of returning `nullptr`.
 
 **⚠️ Breaking Changes**
-- None.
+- `ebd::fn` and `ebd::unique_fn` now call `std::terminate()` on empty call instead of throwing `std::bad_function_call`. If you need `std::bad_function_call` on empty call, use the new `ebd::classic_fn`.
+- `make_fn` now preserves the `noexcept` qualifier when deducing signatures for lambdas and functors (it was previously stripped for `ebd::fn`/`ebd::unique_fn`). For example, `make_fn([]() noexcept {})` now yields `fn<void() const noexcept>` instead of `fn<void() const>` (Since C++17).
+- `ebd::safe_fn` is deprecated. Use `ebd::fn` for terminate-on-empty, or `ebd::basic_fn` directly if you need the `AssertObjectNoThrow` guarantee.
+- The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` has been removed.
 
 **✨ New Features**
-- None.
+- Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`).
+- Added a `make_fn` overload for `noexcept` function pointers (C++17+), which preserves the `noexcept` qualifier in the wrapper's signature.
+- noexcept qualifiers are now propagated through `make_fn` for member function pointers and member object pointers.
 
 **🛠️ Optimizations and Improvements**
-- None.
+- Refactored noexcept propagation: replaced the complex `noexcept_qualify_like` trait with a simpler `get_correct_signature` trait that decides based on wrapper config (`IsView || !IsThrowing`).
+- Removed `sig_with_noexcept` from `get_unique_signature`; `type` now directly includes `noexcept` when applicable.
+- Removed outdated `@todo` and `@experimental` comments.
 
 **📌 Notes**
-- **The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` will be removed in v2.2.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.
-- **The function wrapper `ebd::fn_view` and `ebd::safe_fn` will be removed in v2.2.0**. If you still rely on it, please inform us in the [issues](https://github.com/Kim-J-Smith/Embedded-Function/issues) section.
-- **The function wrapper `ebd::fn` and `ebd::unique_fn` will not throw exceptions on empty calls in v2.2.0**.
-- As of v2.1.11, the usage of `std::constant_wrapper` and `std::meta::is_complete_type` remains **experimental**. These features have been officially adopted in the C++26 standard (`ISO/IEC 14882:2026`) and will become fully stable starting from **v2.2.0**.
+- None.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,5 +1,7 @@
 **🔧 Fixed Bugs**
 - `operator*` now returns a `noexcept` function pointer when the stored signature includes `noexcept`, instead of returning `nullptr`. (#117)
+- `make_fn(wrapper)` no longer matches the lambda/functor overload; it now correctly takes the copy/move path, so the deduced `BufferSize` is not enlarged unnecessarily. (#127)
+- `make_fn<FnWrapper>(wrapper)` now computes the correct `BufferSize`: it uses the deduced size when the wrapper configs are directly convertible, otherwise it sizes the buffer to fit the wrapper object for indirect wrapping. (#127)
 
 **⚠️ Breaking Changes**
 - `ebd::fn` and `ebd::unique_fn` now call `std::terminate()` on empty call instead of throwing `std::bad_function_call`. If you need `std::bad_function_call` on empty call, use the new `ebd::classic_fn`. (#117)

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -12,6 +12,7 @@
 - Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`).
 - Added a `make_fn` overload for `noexcept` function pointers (C++17+), which preserves the `noexcept` qualifier in the wrapper's signature.
 - noexcept qualifiers are now propagated through `make_fn` for member function pointers and member object pointers.
+- `make_fn<FnWrapper>` now accepts multiple arguments, enabling in-place construction with a specific wrapper type, e.g. `make_fn<ebd::classic_fn>(std::in_place_type<Functor>, args...)`.
 
 **🛠️ Optimizations and Improvements**
 - Refactored noexcept propagation: replaced the complex `noexcept_qualify_like` trait with a simpler `get_correct_signature` trait that decides based on wrapper config (`IsView || !IsThrowing`).

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,25 +1,25 @@
 **🔧 Fixed Bugs**
-- `operator*` now returns a `noexcept` function pointer when the stored signature includes `noexcept`, instead of returning `nullptr`.
+- `operator*` now returns a `noexcept` function pointer when the stored signature includes `noexcept`, instead of returning `nullptr`. (#117)
 
 **⚠️ Breaking Changes**
-- `ebd::fn` and `ebd::unique_fn` now call `std::terminate()` on empty call instead of throwing `std::bad_function_call`. If you need `std::bad_function_call` on empty call, use the new `ebd::classic_fn`.
-- `make_fn` now preserves the `noexcept` qualifier when deducing signatures for lambdas and functors (it was previously stripped for `ebd::fn`/`ebd::unique_fn`). For example, `make_fn([]() noexcept {})` now yields `fn<void() const noexcept>` instead of `fn<void() const>` (Since C++17).
-- `ebd::safe_fn` is deprecated. Use `ebd::fn` for terminate-on-empty, or `ebd::basic_fn` directly if you need the `AssertObjectNoThrow` guarantee.
-- The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` has been removed.
-- If the user creates the `fn_ref` object from `nullptr` in the **debugging mode**, then regardless of whether the user has defined the macro `EMBED_FN_HOOK_DEBUG` or not, the `std::terminate()` function will be called.
-- The `ebd::fn_ref` CTAD deduction guides for `std::constant_wrapper` (C++26) have been removed. Use `ebd::make_fn(std::cw<...>)` instead.
+- `ebd::fn` and `ebd::unique_fn` now call `std::terminate()` on empty call instead of throwing `std::bad_function_call`. If you need `std::bad_function_call` on empty call, use the new `ebd::classic_fn`. (#117)
+- `make_fn` now preserves the `noexcept` qualifier when deducing signatures for lambdas and functors (it was previously stripped for `ebd::fn`/`ebd::unique_fn`). For example, `make_fn([]() noexcept {})` now yields `fn<void() const noexcept>` instead of `fn<void() const>` (Since C++17). (#117)
+- `ebd::safe_fn` is deprecated. Use `ebd::fn` for terminate-on-empty, or `ebd::basic_fn` directly if you need the `AssertObjectNoThrow` guarantee. (#117)
+- The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` has been removed. (#116)
+- If the user creates the `fn_ref` object from `nullptr` in the *debugging mode*, then regardless of whether the user has defined the macro `EMBED_FN_HOOK_DEBUG` or not, the `std::terminate()` function will be called. (#121)
+- The `ebd::fn_ref` CTAD deduction guides for `std::constant_wrapper` (C++26) have been removed. Use `ebd::make_fn(std::cw<...>)` instead. (#124)
 
 **✨ New Features**
-- Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`).
-- Added a `make_fn` overload for `noexcept` function pointers (C++17+), which preserves the `noexcept` qualifier in the wrapper's signature.
-- noexcept qualifiers are now propagated through `make_fn` for member function pointers and member object pointers.
-- `make_fn<FnWrapper>` now accepts multiple arguments, enabling in-place construction with a specific wrapper type, e.g. `make_fn<ebd::classic_fn>(std::in_place_type<Functor>, args...)`.
-- Added `make_fn` overloads for `std::constant_wrapper` (C++26+), which deduce and return an `ebd::fn_ref` from `std::cw<fn>` or `std::cw<member_fn>` + object.
+- Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`). (#117)
+- Added a `make_fn` overload for `noexcept` function pointers (C++17+), which preserves the `noexcept` qualifier in the wrapper's signature. (#117)
+- noexcept qualifiers are now propagated through `make_fn` for member function pointers and member object pointers. (#117)
+- `make_fn<FnWrapper>` now accepts multiple arguments, enabling in-place construction with a specific wrapper type, e.g. `make_fn<ebd::classic_fn>(std::in_place_type<Functor>, args...)`. (#123)
+- Added `make_fn` overloads for `std::constant_wrapper` (C++26+), which deduce and return an `ebd::fn_ref` from `std::cw<fn>` or `std::cw<member_fn>` + object. (#124)
 
 **🛠️ Optimizations and Improvements**
-- Refactored noexcept propagation: replaced the complex `noexcept_qualify_like` trait with a simpler `get_correct_signature` trait that decides based on wrapper config (`IsView || !IsThrowing`).
-- Removed `sig_with_noexcept` from `get_unique_signature`; `type` now directly includes `noexcept` when applicable.
-- Removed outdated `@todo` and `@experimental` comments.
+- Refactored noexcept propagation: replaced the complex `noexcept_qualify_like` trait with a simpler `get_correct_signature` trait that decides based on wrapper config (`IsView || !IsThrowing`). (#120)
+- Removed `sig_with_noexcept` from `get_unique_signature`; `type` now directly includes `noexcept` when applicable. (#117)
+- Removed outdated `@todo` and `@experimental` comments. (#116)
 
 **📌 Notes**
-- None.
+- v2.1.11 planned to remove `ebd::fn_view` and `ebd::safe_fn` in v2.2.0. Instead of removal, both are kept as *deprecated* aliases (see the Breaking Changes section above) to avoid breaking existing code.

--- a/example/basic_usage.cpp
+++ b/example/basic_usage.cpp
@@ -1,4 +1,4 @@
-/// basic_usage.cpp — four wrapper types: fn, unique_fn, safe_fn, fn_ref
+/// basic_usage.cpp — four wrapper types: fn, unique_fn, classic_fn, fn_ref
 #include <iostream>
 #include <memory>
 #include <embed/embed_function.hpp>
@@ -26,7 +26,7 @@ fn  mul: 12
 fn2 mul: 30
 ufn  : 101
 ufn2 : 102
-Printer: Hello safe_fn!
+Printer: Hello classic_fn!
 ref  : 70
 empty_fn is empty
 ===
@@ -52,10 +52,10 @@ int main() {
     ebd::unique_fn<int(int)> ufn2 = std::move(ufn);  // move
     std::cout << "ufn2 : " << ufn2(2) << '\n';
 
-    // ebd::safe_fn — copyable, requires noexcept callable
-    ebd::safe_fn<void(const char*)> sfn;
-    sfn = Printer{};
-    sfn("Hello safe_fn!");
+    // ebd::classic_fn — copyable, throws on empty (like std::function)
+    ebd::classic_fn<void(const char*)> cfn;
+    cfn = Printer{};
+    cfn("Hello classic_fn!");
 
     // ebd::fn_ref — non-owning view (zero overhead)
     int factor = 10;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1,9 +1,9 @@
 /**
  * @file        embed_function.hpp
  *
- * @date        2026-2-7
+ * @date        2026-8-6
  *
- * @version     2.1.11
+ * @version     2.2.0
  *
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.
@@ -274,19 +274,26 @@
 # define EMBED_DETAIL_ALIAS
 #endif
 
-#if defined(__OPTIMIZE__) || defined(NDEBUG) || !defined(EMBED_FN_HOOK_DEBUG)
+#if defined(__OPTIMIZE__) || defined(NDEBUG)
 # define EMBED_DETAIL_FAIL_MESSAGE(message)
 # define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)
 #else
-# define EMBED_DETAIL_FAIL_MESSAGE(message)                                             \
-  do {                                                                                  \
-    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) ":\n\t" message "\n"); \
-  } while(0) /* Output message together with file name and line number. */
-# define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)                               \
-  do { if (!(expression)) {                                                             \
-    EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) ":\n\t" message "\n"); \
-    std::terminate();                                                                   \
-  } } while(0) /* Output message and terminate procedure if expression is false. */
+# ifndef EMBED_FN_HOOK_DEBUG
+#  define EMBED_FN_HOOK_DEBUG(message) // NOP
+# endif
+
+// Output message together with file name and line number.
+# define EMBED_DETAIL_FAIL_MESSAGE(message) \
+  do { EMBED_FN_HOOK_DEBUG(__FILE__ ":" EMBED_DETAIL_TEXT(__LINE__) ":\n\t" message "\n"); } while(false)
+
+// Output message and terminate procedure if expression is false.
+# define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)                 \
+  do {                                                                    \
+    if (!(expression)) {                                                  \
+      EMBED_DETAIL_FAIL_MESSAGE(message " [(" #expression ") == false]"); \
+      std::terminate();                                                   \
+    }                                                                     \
+  } while(false)
 #endif
 
 #if __cpp_lib_unreachable >= 202202L
@@ -2161,9 +2168,9 @@ namespace command {
           typename std::constant_wrapper<remove_cvref_t<Args>::value>; } && ...)) {
         static_assert(!requires { typename std::constant_wrapper<
               std::invoke(Cw::value, remove_cvref_t<Args>::value...)>; },
-          "[ref.ctor]/11.2 `cw<fn>(args...)` must be equivalent to `fn(args...)`, "
-          "otherwise the intended behavior for a non-owning function wrapper (fn_ref) "
-          "constructed from `cw<fn>` would be ambiguous."
+          "[func.wrap.ref.ctor]/11.2 `cw<fn>(args...)` must be equivalent to "
+          "`fn(args...)`, otherwise the intended behavior for a non-owning "
+          "function wrapper (fn_ref) constructed from `cw<fn>` would be ambiguous."
         );
       }
     }

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2369,11 +2369,18 @@ namespace crtp_mixins {
     using function_ptr_t = typename unwrap_signature<Signature>::pure_sig_noex*;
 
   public:
-    // If the value stored in m_erasure is a pointer to a free function,
-    // return that pointer. Otherwise, return `nullptr`.
-    /// @warning If the addresses of different functions may be the same
-    /// (which is not in accordance with the C++ standard), then this function
-    /// has undefined behavior. For MSVC in release mode, `/OPT:NOICF` is needed.
+    /**
+     * @brief   If the value stored in m_erasure is a pointer to a free function,
+     *          return that pointer. Otherwise, return `nullptr`.
+     * 
+     * @note    [expr.eq]/4 Two function pointers compare equal, if and only if
+     *          both of them point to the same function.
+     *          See <https://eel.is/c++draft/expr.eq#4.2>.
+     * 
+     * @warning Some implementations do not comply with the standard.
+     *          For example, in MSVC release mode, `/OPT:NOICF` is needed to
+     *          avoid unexpected behaviour.
+     */
     function_ptr_t operator*() const noexcept {
       using invoker_impl_t = typename Self::command_t::invoker_impl_t;
       using invoker_t = conditional_t<IsView,
@@ -2935,7 +2942,7 @@ namespace crtp_mixins {
 
 
 /**
- * @brief A basic function wrapper that users can customize.
+ * @brief Basic polymorphic function wrapper.
  *
  * This alias provides the most flexible way to instantiate a function wrapper
  * by directly specifying all configuration parameters. It is intended for
@@ -3004,7 +3011,7 @@ using basic_fn = detail::function<
   /* Signature = */   Signature
 >;
 
-/// @brief A function object wrapper for copyable and callable objects.
+/// @brief Owning polymorphic copyable function wrapper.
 /// @note Invoking the wrapper in an empty state calls `std::terminate`.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
@@ -3019,7 +3026,7 @@ using fn = basic_fn<
   /* AssertObjectNoThrow = */ false
 >;
 
-/// @brief A function object wrapper for movable and callable objects.
+/// @brief Owning polymorphic function wrapper.
 /// @note Invoking the wrapper in an empty state calls `std::terminate`.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
@@ -3034,7 +3041,7 @@ using unique_fn = basic_fn<
   /* AssertObjectNoThrow = */ false
 >;
 
-/// @brief A function object wrapper for copyable and callable objects.
+/// @brief Classic owning polymorphic function wrapper. (like `std::function`)
 /// @throws `std::bad_function_call` if invoked in an empty state.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
@@ -3049,7 +3056,7 @@ using classic_fn = basic_fn<
   /* AssertObjectNoThrow = */ false
 >;
 
-/// @brief A non-owning polymorphic function wrapper.
+/// @brief Non-owning polymorphic function wrapper.
 /// @note Empty state of this wrapper has been removed.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam Unused - Unused.
@@ -3343,6 +3350,7 @@ noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs
 /// @brief make_fn[12]: Make function with specified wrapper.
 /// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`.
 /// @return `Fn<Signature, sizeof(functor)>`
+/// TODO: support muti-params.
 EMBED_DETAIL_TEMPLATE_BEGIN(
   template <class, std::size_t> class Fn,
   typename SpecifiedSig = void,

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -940,15 +940,22 @@ inline namespace fn_traits {
 
   // Implement the "is_ebd_fn" trait.
   template <typename T>
-  struct is_ebd_fn_impl : public std::false_type
-  { using signature = void; };
+  struct is_ebd_fn_impl : public std::false_type {
+    using signature = void;
+    using config = void;
+    static constexpr std::size_t buffer = 0;
+  };
 
   template <std::size_t Buf, typename Cfg, typename Sig>
   struct is_ebd_fn_impl<function<Buf, Cfg, Sig>>
   : public bool_constant<
     unwrap_signature<Sig>::isSignature
     && is_config_package<Cfg>::value
-  > { using signature = Sig; };
+  > {
+    using signature = Sig;
+    using config = Cfg;
+    static constexpr std::size_t buffer = Buf;
+  };
 
   // Check whether the type is `ebd::detail::function` or not.
   template <typename T>
@@ -1033,6 +1040,16 @@ inline namespace fn_traits {
       is_callable_from_pkg<Signature, dec_func, ret, args_pack>::value;
   };
 
+  // Check the `Config` convertible.
+  template <typename CfgTo, typename CfgFrom>
+  struct is_config_convertible {
+    static constexpr bool value =
+      CfgTo::isCopyable <= CfgFrom::isCopyable // Copyable to Move-only is OK.
+      && CfgTo::isView == CfgFrom::isView
+      && CfgTo::isThrowing == CfgFrom::isThrowing
+      && CfgTo::assertNoThrow <= CfgFrom::assertNoThrow; // Assert to non-assert is OK.
+  };
+
   // Implement `is_convertible_from_specialization`.
   template <typename To, typename From>
   struct is_convertible_from_specialization_impl : public std::false_type {};
@@ -1060,11 +1077,7 @@ inline namespace fn_traits {
     static constexpr bool buf_ok = BufTo >= BufFrom;
 
     // Check the Configuration.
-    static constexpr bool cfg_ok =
-      CfgTo::isCopyable <= CfgFrom::isCopyable // Copyable to Move-only is OK.
-      && CfgTo::isView == CfgFrom::isView
-      && CfgTo::isThrowing == CfgFrom::isThrowing
-      && CfgTo::assertNoThrow <= CfgFrom::assertNoThrow; // Assert to non-assert is OK.
+    static constexpr bool cfg_ok = is_config_convertible<CfgTo, CfgFrom>::value;
 
     // In view mode, the requires is special.
     // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3961r1.html>.
@@ -1670,6 +1683,24 @@ inline namespace fn_traits {
     // Use template parameter `Val` to avoid violating ODR.
     bool Val = logical_and<is_complete_here<Args>()...>::value>
   constexpr bool each_param_is_complete_here(T<Args...>) noexcept { return Val; }
+
+  template <bool IsWrapper /*=false*/, typename FnWrapper, std::size_t Candidate, typename Arg>
+  struct get_correct_buffer_size_helper { static constexpr std::size_t value = Candidate; };
+  template <typename FnWrapper, std::size_t Candidate, typename OtherWrapper>
+  struct get_correct_buffer_size_helper</*IsWrapper=*/true, FnWrapper, Candidate, OtherWrapper> {
+    static constexpr std::size_t value =
+      is_config_convertible<
+        typename is_ebd_fn<FnWrapper>::config, typename is_ebd_fn<OtherWrapper>::config>::value
+      ? Candidate : sizeof(remove_cvref_t<OtherWrapper>);
+  };
+
+  // Get the correct buffer size for `make_fn<FnWrapper>`.
+  template <typename FnWrapper, std::size_t Candidate, typename... Args>
+  struct get_correct_buffer_size { static constexpr std::size_t value = Candidate; };
+
+  template <typename FnWrapper, std::size_t Candidate, typename Arg>
+  struct get_correct_buffer_size<FnWrapper, Candidate, Arg>
+  : public get_correct_buffer_size_helper<is_ebd_fn<Arg>::value, FnWrapper, Candidate, Arg> {};
 
 } // end namespace fn_traits
 
@@ -3240,6 +3271,8 @@ EMBED_DETAIL_REQUIRES_END(
   detail::is_unique_callable<Class>::value
   // [Require] The signature must be valid.
   && detail::unwrap_signature<Signature>::isSignature
+  // [Require] The Lambda cannot be ebd::detail::function.
+  && (!detail::is_ebd_fn<Class>::value)
 )
 EMBED_NODISCARD inline Fn make_fn(Lambda&& fn) noexcept(NoThrow) {
   return detail::make_function_impl<Fn, NoThrow>(std::forward<Lambda>(fn));
@@ -3388,7 +3421,8 @@ EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Signature = detail::conditional_t<std::is_void<SpecifiedSig>::value,
                            /* Auto deduce */ detail::get_correct_signature_t<Fn, RawSig>,
           /* Use user specified signature */ SpecifiedSig>,
-  std::size_t BufferSize = Deduction::get_buffer_size(),
+  std::size_t BufferSize =
+    detail::get_correct_buffer_size<Fn<int(), 0>, Deduction::get_buffer_size(), Args...>::value,
   typename FnWrapper = Fn<Signature, BufferSize>,
   bool NoThrow = noexcept(FnWrapper(std::declval<Args>()...))
 )

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -207,7 +207,7 @@
 #if ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
 // The noexcept-specification is a part of the function type and
 // may appear as part of any function declarator. (Since C++17)
-// See <https://en.cppreference.com/w/cpp/language/noexcept_spec>.
+// See <https://cppreference.com/w/cpp/language/noexcept_spec>.
 
 # define EMBED_DETAIL_FN_EXPAND(F) \
   EMBED_DETAIL_FN_EXPAND_IMPL(F, ) EMBED_DETAIL_FN_EXPAND_IMPL(F, noexcept)
@@ -336,7 +336,7 @@ inline namespace cxx_traits {
 
   /// @brief Types from <type_traits> have been implemented,
   /// consistent with the standard behavior (C++14 ~ C++23).
-  /// See <https://en.cppreference.com/w/cpp/header/type_traits.html>.
+  /// See <https://cppreference.com/w/cpp/header/type_traits.html>.
 
   template <typename... Args> using void_t = typename make_void<Args...>::type;
 
@@ -579,7 +579,7 @@ inline namespace cxx_traits {
   };
 
   // Get the invoke result and invoke tag.
-  // See <https://en.cppreference.com/w/cpp/types/result_of.html>.
+  // See <https://cppreference.com/w/cpp/types/result_of.html>.
   template <typename Func, typename... ArgsT>
   struct invoke_result : public invoke_result_impl<
     std::is_member_function_pointer<
@@ -647,7 +647,7 @@ inline namespace cxx_traits {
   template <typename Func, typename... Args>
   using call_is_nothrow = call_is_nothrow_helper<Func, args_package<Args...>>;
 
-  // See <https://en.cppreference.com/w/cpp/types/reference_converts_from_temporary.html>.
+  // See <https://cppreference.com/w/cpp/types/reference_converts_from_temporary.html>.
   template <typename To, typename From>
   struct reference_converts_from_temporary
   : public bool_constant<
@@ -708,7 +708,7 @@ inline namespace cxx_traits {
 # pragma GCC diagnostic pop
 #endif
 
-  // See <https://en.cppreference.com/w/cpp/types/is_invocable.html>.
+  // See <https://cppreference.com/w/cpp/types/is_invocable.html>.
   template <typename Ret, typename Func, typename... Args>
   struct is_invocable_r : public bool_constant<
     is_invocable_impl<invoke_result<Func, Args...>, Ret>::type::value
@@ -771,7 +771,7 @@ inline namespace cxx_traits {
     );
   }
 
-  // See <https://en.cppreference.com/w/cpp/utility/functional/invoke.html>.
+  // See <https://cppreference.com/w/cpp/utility/functional/invoke.html>.
   template <typename Result, typename Callee, typename... Args>
   EMBED_CXX14_CONSTEXPR enable_if_t<
     is_invocable_r<Result, Callee, Args...>::value

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3350,30 +3350,28 @@ noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs
 /// @brief make_fn[12]: Make function with specified wrapper.
 /// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`.
 /// @return `Fn<Signature, sizeof(functor)>`
-/// TODO: support muti-params.
 EMBED_DETAIL_TEMPLATE_BEGIN(
   template <class, std::size_t> class Fn,
   typename SpecifiedSig = void,
-  typename Functor,
-  typename Deduction = decltype(make_fn(std::declval<Functor>())),
+  typename... Args,
+  typename Deduction = decltype(make_fn(std::declval<Args>()...)),
   typename RawSig = typename detail::is_ebd_fn<Deduction>::signature,
-  typename Signature = detail::conditional_t<
-    std::is_void<SpecifiedSig>::value,
-    detail::get_correct_signature_t<Fn, RawSig>, SpecifiedSig
-  >,
-  std::size_t BufferSize = sizeof(detail::decay_t<Functor>),
+  typename Signature = detail::conditional_t<std::is_void<SpecifiedSig>::value,
+                           /* Auto deduce */ detail::get_correct_signature_t<Fn, RawSig>,
+          /* Use user specified signature */ SpecifiedSig>,
+  std::size_t BufferSize = Deduction::get_buffer_size(),
   typename FnWrapper = Fn<Signature, BufferSize>,
-  bool NoThrow = noexcept(FnWrapper(std::declval<Functor>()))
+  bool NoThrow = noexcept(FnWrapper(std::declval<Args>()...))
 )
 EMBED_DETAIL_REQUIRES_END(
   detail::is_ebd_fn<FnWrapper>::value
   && detail::unwrap_signature<Signature>::isSignature
 )
 EMBED_NODISCARD EMBED_CXX20_CONSTEXPR inline
-FnWrapper make_fn(Functor&& functor) noexcept(NoThrow) {
+FnWrapper make_fn(Args&&... args) noexcept(NoThrow) {
   return detail::make_function_impl<
     /* Fn = */ FnWrapper, /* NoThrow = */ NoThrow
-  >(std::forward<Functor>(functor));
+  >(std::forward<Args>(args)...);
 }
 
 // When all other make_fn() fail to match the input parameters,
@@ -3385,6 +3383,7 @@ constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused>()) { retur
 template <template <class, std::size_t> class Unused>
 constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0>>()) { return 0; }
 
+/// TODO: @deprecated Use make_fn instead.
 #if __cpp_lib_constant_wrapper >= 202603L
 namespace detail {
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -180,10 +180,10 @@
 # include <type_traits> // std::enable_if, ...
 # if EMBED_CXX_VERSION >= 201703L
 #  include <initializer_list>
-# endif // >= C++17
+# endif // C++ >= 17
 # if __cpp_impl_reflection >= 202506L && EMBED_HAS_INCLUDE(<meta>)
 #  include <meta>       // std::meta::is_complete_type(C++26)
-# endif // >= C++26
+# endif // C++ >= 26
 #else
 # error The 'embed_function.hpp' requires the support of syntax features of C++11.\
  You can use the '-std=c++11' compilation option, or simply switch to a newer compiler.
@@ -2839,7 +2839,7 @@ namespace crtp_mixins {
       m_command.template emplace_init<Fn>(&m_erasure, il, std::forward<CArgs>(args)...);
     }
 
-#endif
+#endif // C++ >= 17
 
 #if __cpp_lib_constant_wrapper >= 202603L
 
@@ -2893,7 +2893,7 @@ namespace crtp_mixins {
       }
     }
 
-#endif
+#endif // C++ >= 26
 
   };
 
@@ -3168,7 +3168,7 @@ make_fn(Ret (*func_ptr) (Args...) noexcept) noexcept {
   >(func_ptr);
 }
 
-#endif
+#endif // C++ >= 17
 
 /// @brief make_fn[4]: Make function for function pointer with specified signature.
 /// @return `fn<Signature, sizeof(FunctionPtr)>`
@@ -3345,9 +3345,38 @@ noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs
   >(std::in_place_type<Functor>, il, std::forward<CArgs>(args)...);
 }
 
-#endif
+#endif // C++ >= 17
 
-/// @brief make_fn[12]: Make function with specified wrapper.
+#if __cpp_lib_constant_wrapper >= 202603L
+
+/// @brief make_fn[12]: Make function from `std::cw<fn>`.
+/// @return `fn_ref<Auto-Deduction>`
+template <auto Cw, typename Fn>
+EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>) noexcept {
+  using sig_raw = typename detail::is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature;
+  using sig_correct = detail::get_correct_signature_t<fn_ref, sig_raw>;
+
+  return detail::make_function_impl<
+    /* Fn = */ fn_ref<sig_correct>, /* NoThrow = */ true
+  >(std::constant_wrapper<Cw, Fn>{});
+}
+
+/// @brief make_fn[13]: Make function from `std::cw<callable>` and `obj`/`&obj`, binding the first parameter.
+/// @return `fn_ref<Auto-Deduction>`
+template <auto Cw, typename Fn, typename Tp>
+EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>, Tp&& obj) noexcept {
+  using sig_raw = typename detail::is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature;
+  using sig_wip = detail::get_correct_signature_t<fn_ref, sig_raw>;
+  using sig_correct = detail::skip_first_arg_sig_t<sig_wip>;
+
+  return detail::make_function_impl<
+    /* Fn = */ fn_ref<sig_correct>, /* NoThrow = */ true
+  >(std::constant_wrapper<Cw, Fn>{}, std::forward<Tp>(obj));
+}
+
+#endif // C++ >= 26
+
+/// @brief make_fn[14]: Make function with specified wrapper.
 /// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`.
 /// @return `Fn<Signature, sizeof(functor)>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
@@ -3382,33 +3411,6 @@ template <typename Unused = void,
 constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused>()) { return 0; }
 template <template <class, std::size_t> class Unused>
 constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0>>()) { return 0; }
-
-/// TODO: @deprecated Use make_fn instead.
-#if __cpp_lib_constant_wrapper >= 202603L
-namespace detail {
-
-  /// @brief `fn_ref` CTAD guides from `std::constant_wrapper`.
-
-  template <typename Fn>
-  using make_fn_ref_deduction_sig_t = get_correct_signature_t<
-    fn_ref, typename is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature>;
-
-  template <auto Cw, typename Fn>
-  function(std::constant_wrapper<Cw, Fn>) -> function<
-    default_buffer_size::ref_buf,
-    config_package<true, true, false, false>, // fn_ref
-    make_fn_ref_deduction_sig_t<Fn>
-  >;
-
-  template <auto Cw, typename Fn, typename Tp>
-  function(std::constant_wrapper<Cw, Fn>, Tp&&) -> function<
-    default_buffer_size::ref_buf,
-    config_package<true, true, false, false>, // fn_ref
-    skip_first_arg_sig_t<make_fn_ref_deduction_sig_t<Fn>>
-  >;
-
-} // end namespace detail
-#endif // ^^^ __cpp_lib_constant_wrapper >= 202603L
 
 } // end namespace ebd
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -16,9 +16,6 @@
 
 // Just like function pointers, it is quick and efficient.
 
-/// @deprecated @b EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER
-/// If this macro is defined, bigger default buffer size will be used.
-
 /// @b EMBED_FN_CONFIG_DISABLE_SMART_FORWARD
 /// If this macro is defined, `smart_forward_t` will fall back to Perfect Forwarding.
 
@@ -917,6 +914,7 @@ inline namespace fn_traits {
     using ret   = Ret;                                                        \
     using args  = args_package<Args...>;                                      \
     using pure_sig = Ret(Args...);                                            \
+    using pure_sig_noex = Ret(Args...) NOEXCEPT;                              \
     static constexpr bool hasConst = std::is_const<int C>::value;             \
     static constexpr bool hasVolatile = std::is_volatile<int V>::value;       \
     static constexpr bool hasRRef = std::is_rvalue_reference<int REF>::value; \
@@ -1118,17 +1116,9 @@ inline namespace fn_traits {
   struct default_buffer_size {
     // The buffer size for ebd::fn_ref. Stop supporting pointer-to-members.
     static constexpr std::size_t ref_buf = sizeof(void (*) ());
-    static constexpr std::size_t view_buf = ref_buf;
-#if defined(EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER)
-    /// @deprecated @todo TODO: Remove this in version-2.2.0.
-    static constexpr std::size_t value_c1 = 6 * sizeof(void*);
-    static constexpr std::size_t value_c2 = sizeof(::std::function<void()>);
-    static constexpr std::size_t value = value_c1 > value_c2 ? value_c1 : value_c2;
-#else
     static constexpr std::size_t value = sizeof(void (UndefinedClass::*) ());
-#endif
 
-    // The alignment for owning wrappers (ebd::fn, ebd::unique_fn, ebd::safe_fn).
+    // The alignment for owning wrappers (ebd::fn, ebd::unique_fn, ebd::classic_fn).
     // Using alignof(std::max_align_t) ensures that objects with the maximum
     // fundamental alignment can be stored in the internal buffer.
     static constexpr std::size_t align_value = alignof(std::max_align_t);
@@ -1249,8 +1239,7 @@ inline namespace fn_traits {
 #define EMBED_DETAIL_ADD_QUALIFIER_WITH_THIS_DEFINE(C, V, REF, NOEXCEPT)  \
   template <typename This, typename Ret, typename... Args>                \
   struct add_qualifier_like<This C V REF, Ret(Args...) NOEXCEPT> {        \
-    using type = Ret(Args...) C V REF;                                    \
-    using sig_with_noexcept = Ret(Args...) C V REF NOEXCEPT;              \
+    using type = Ret(Args...) C V REF NOEXCEPT;                           \
     using sig_without_ref = Ret(Args...) C V NOEXCEPT;                    \
   };
 
@@ -1265,13 +1254,10 @@ inline namespace fn_traits {
       "T must be a function pointer or pointer to member function.");
   };
 
-  // The Config::isThrowing of ebd::fn and ebd::unique_fn is true.
-  // So `get_unique_signature_impl` will ignore the `noexcept` specifier.
 #define EMBED_DETAIL_GET_UNIQUE_SIGNATURE_IMPL_DEFINE(C, V, REF, NOEXCEPT)        \
   template <typename Fn, typename Class, typename Ret, typename... Args>          \
   struct get_unique_signature_impl<Fn, Ret(Class::*)(Args...) C V REF NOEXCEPT> { \
-    using type = Ret(Args...) C V REF;                                            \
-    using sig_with_noexcept = Ret(Args...) C V REF NOEXCEPT;                      \
+    using type = Ret(Args...) C V REF NOEXCEPT;                                   \
   };
 
   EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_GET_UNIQUE_SIGNATURE_IMPL_DEFINE)
@@ -1315,15 +1301,13 @@ inline namespace fn_traits {
     requires is_statically_callable<Fn, Args...>::value
   struct get_unique_signature_impl<Fn, Ret(*)(Args...)> {
     using type = Ret(Args...) const;
-    using sig_with_noexcept = Ret(Args...) const;
   };
 
   // noexcept(true)
   template <typename Fn, typename Ret, typename... Args>
     requires is_statically_callable<Fn, Args...>::value
   struct get_unique_signature_impl<Fn, Ret(*)(Args...) noexcept> {
-    using type = Ret(Args...) const;
-    using sig_with_noexcept = Ret(Args...) const noexcept;
+    using type = Ret(Args...) const noexcept;
   };
 
 #endif
@@ -1333,14 +1317,12 @@ inline namespace fn_traits {
     bool Unique = is_unique_callable<Functor>::value>
   struct get_unique_signature {
     using type = void;
-    using sig_with_noexcept = void;
   };
 
   template <typename Functor>
   struct get_unique_signature<Functor, /* Unique = */ true> {
     using impl_t = get_unique_signature_impl<Functor, decltype(&Functor::operator())>;
     using type = typename impl_t::type;
-    using sig_with_noexcept = typename impl_t::sig_with_noexcept;
   };
 
   template <typename T>
@@ -1411,7 +1393,6 @@ inline namespace fn_traits {
   using get_member_fn_type_t = typename get_member_fn_type<Signature>::type;
 
 #if __cpp_lib_reflection >= 202506L
-  /// @todo experimental `std::meta::is_complete_type`
   // Use template parameter `Val` to avoid violating ODR.
   template <typename T, bool Val = std::meta::is_complete_type(^^T)>
   consteval bool is_complete_here() noexcept { return Val; }
@@ -1494,7 +1475,7 @@ inline namespace fn_traits {
       "                             ^^^^^^^^^^^^^^^^^\n"
       "                                     |\n"
       "         The value should be greater than `sizeof(CallableObject)`\n\n"
-      "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, etc."
+      "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, etc."
     );
 
     static_assert(buffer_alignment_is_enough<Functor, Config, ErasureT>::value,
@@ -1542,68 +1523,29 @@ inline namespace fn_traits {
   struct is_constant_wrapper<std::constant_wrapper<Val, T>> : std::true_type {};
 #endif
 
-  template <typename Functor, typename FnSample, typename Sig, typename = void>
-  struct noexcept_qualify_like { using type = Sig; };
+  template <typename Function, typename Signature>
+  struct get_correct_signature; // Undefined
 
-#if ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
-
-  template <typename T, typename = void>
-  struct noexcept_qualify_like_helper : std::false_type {};
-
-  template <typename Ret, typename... Args>
-  struct noexcept_qualify_like_helper<Ret(*)(Args...) noexcept, void>
-  : std::true_type {};
-
-  template <typename Mp, typename Class>
-  struct noexcept_qualify_like_helper<Mp Class::*> : std::true_type {};
-
-  template <typename Functor>
-  struct noexcept_qualify_like_helper<
-    Functor, enable_if_t<is_unique_callable<Functor>::value>>
-  : bool_constant<unwrap_signature<
-    typename get_unique_signature<Functor>::sig_with_noexcept
-  >::isNoexcept> {};
-
-# define EMBED_DETAIL_HELPER_MEMPTR_DEFINE(C, V, REF, NOEXCEPT)               \
-  template <typename Ret, typename Class, typename... Args>                   \
-  struct noexcept_qualify_like_helper<Ret(Class::*)(Args...) C V REF NOEXCEPT>\
-  : bool_constant<unwrap_signature<void() NOEXCEPT>::isNoexcept> {};
-
-  EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_HELPER_MEMPTR_DEFINE)
-
-# undef EMBED_DETAIL_HELPER_MEMPTR_DEFINE
-
-# define EMBED_DETAIL_NOEXCEPT_QUALIFY_LIKE_DEFINE(C, V, REF, NOEXCEPT)     \
-  template <typename Functor, typename Ret, typename... Args,               \
-    std::size_t Buf, typename Sig,                                          \
-    bool IsCopyable, bool IsView, bool IsThrowing, bool AssertObjectNoThrow \
-  > struct noexcept_qualify_like<                                           \
-    /* Functor = */ Functor,                                                \
-    /* FnSample = */ function<Buf, config_package<                          \
-      IsCopyable, IsView, IsThrowing, AssertObjectNoThrow>, Sig>,           \
-    /* Sig = */ Ret(Args...) C V REF NOEXCEPT,                              \
-    enable_if_t<IsView || !IsThrowing>                                      \
-  > {                                                                       \
-    using is_nothrow = typename noexcept_qualify_like_helper<Functor>::type;\
-/* MSVC 14.36~14.44 regression: noexcept(is_nothrow::value) trigger ICE. */ \
-    using sig_normal = conditional_t<is_nothrow::value,                     \
-      Ret(Args...) C V REF noexcept, Ret(Args...) C V REF>;                 \
-    using sig_view = conditional_t<is_nothrow::value,                       \
-      Ret(Args...) C V noexcept, Ret(Args...) C V>;                         \
-    using type = conditional_t<IsView, sig_view, sig_normal>;               \
+#define EMBED_DETAIL_GET_CORRECT_SIGNATURE_DEFINE(C, V, REF, NOEXCEPT)                  \
+  template <std::size_t Buf, typename Cfg, typename Sig, typename Ret, typename... Args>\
+  struct get_correct_signature<function<Buf, Cfg, Sig>, Ret(Args...) C V REF NOEXCEPT> {\
+    /* MSVC 14.36~14.44 regression: noexcept(!Cfg::isThrowing) trigger ICE. */          \
+    using sig_normal = conditional_t<!Cfg::isThrowing,                                  \
+      Ret(Args...) C V REF NOEXCEPT, Ret(Args...) C V REF>;                             \
+    using sig_view = Ret(Args...) C V NOEXCEPT;                                         \
+    using type = conditional_t<Cfg::isView, sig_view, sig_normal>;                      \
   };
 
-  EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_NOEXCEPT_QUALIFY_LIKE_DEFINE)
+  EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_GET_CORRECT_SIGNATURE_DEFINE)
 
-# undef EMBED_DETAIL_NOEXCEPT_QUALIFY_LIKE_DEFINE
+#undef EMBED_DETAIL_GET_CORRECT_SIGNATURE_DEFINE
 
-#endif
-
-  // Add noexcept qualifier if the Functor is noexcept free function,
-  // and the function wrapper or reference support `noexcept`.
-  template <typename Functor, template <class, std::size_t> class Fn, typename Sig>
-  using noexcept_qualify_like_t =
-    typename noexcept_qualify_like<decay_t<Functor>, Fn<void(), sizeof(void(*)())>, Sig>::type;
+  // Remove `noexcept` qualifier if the `Fn` is configured to `IsThrowing = true`
+  // as well as `IsView = false`, and remove `&` or `&&` qualifier if the `Fn` is
+  // configured to `IsView = true`.
+  template <template <class, std::size_t> class Fn, typename Sig>
+  using get_correct_signature_t =
+    typename get_correct_signature<Fn<Sig, sizeof(void(*)())>, Sig>::type;
 
   // Check if `T` is the stateless standard operator wrapper.
   template <typename T> struct is_std_op_wrapper : std::false_type {};
@@ -1679,7 +1621,7 @@ inline namespace fn_traits {
       "The `Signature` is like `void()`, `float(int,int) const`;\n"
       "The `BufferSize` is the size (in bytes) of the internal storage;\n"
       "The `FnWrapper` is an alias of `ebd::basic_fn` and has `template <class, std::size_t>` "
-      "as a template argument list, such as `ebd::fn_ref`, `ebd::safe_fn`, etc. If omitted, "
+      "as a template argument list, such as `ebd::fn_ref`, `ebd::classic_fn`, etc. If omitted, "
       "the `FnWrapper` will be inferred to be `ebd::fn` if the `CallableObject` is copyable, "
       "and `ebd::unique_fn` otherwise."
     );
@@ -2417,7 +2359,7 @@ namespace crtp_mixins {
   template <typename Signature, typename Self, bool IsView, typename... Args>
   struct operator_dereference_impl<Signature, Self, IsView, args_package<Args...>> {
   private:
-    using function_ptr_t = typename unwrap_signature<Signature>::pure_sig*;
+    using function_ptr_t = typename unwrap_signature<Signature>::pure_sig_noex*;
 
   public:
     // If the value stored in m_erasure is a pointer to a free function,
@@ -2506,7 +2448,7 @@ namespace crtp_mixins {
       "                  ^^^^^^^^^\n"
       "                      |\n"
       " should be like `void()`, `int(int) const`, etc\n\n"
-      "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, `ebd::fn_ref`, etc."
+      "`FnWrapper` can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, `ebd::fn_ref`, etc."
     );
 
     // Assert each parameter type is a complete class.
@@ -2887,8 +2829,6 @@ namespace crtp_mixins {
 
 #if __cpp_lib_constant_wrapper >= 202603L
 
-    /// @todo experimental
-
     // Create function reference with given `std::constant_wrapper` param.
     template <auto Val, typename Fn>
       requires Config::isView
@@ -2993,7 +2933,7 @@ namespace crtp_mixins {
  * This alias provides the most flexible way to instantiate a function wrapper
  * by directly specifying all configuration parameters. It is intended for
  * advanced use cases where none of the predefined aliases (`fn`, `unique_fn`,
- * `safe_fn`, `fn_ref`) satisfy the required combination of copyability,
+ * `classic_fn`, `fn_ref`) satisfy the required combination of copyability,
  * view semantics, exception behavior, and no‑throw assertions.
  *
  * @tparam Signature              Function signature, e.g., `void(int, char)`,
@@ -3026,7 +2966,7 @@ namespace crtp_mixins {
  *                                Violations trigger a `static_assert`.
  *
  * @note                          Prefer using the predefined aliases (`fn`,
- *                                `unique_fn`, `safe_fn`, `fn_ref`) unless you
+ *                                `unique_fn`, `classic_fn`, `fn_ref`) unless you
  *                                need a combination not covered by them.
  *
  * @example                       A move-only, non‑throwing wrapper:
@@ -3058,6 +2998,7 @@ using basic_fn = detail::function<
 >;
 
 /// @brief A function object wrapper for copyable and callable objects.
+/// @note Invoking the wrapper in an empty state calls `std::terminate`.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
 /// And the buffer size will be aligned automatically.
@@ -3067,11 +3008,12 @@ using fn = basic_fn<
   /* BufferSize = */          detail::get_aligned_size(BufferSize),
   /* IsCopyable = */          true,
   /* IsView = */              false,
-  /* IsThrowing = */          true,
+  /* IsThrowing = */          false,
   /* AssertObjectNoThrow = */ false
 >;
 
 /// @brief A function object wrapper for movable and callable objects.
+/// @note Invoking the wrapper in an empty state calls `std::terminate`.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
 /// And the buffer size will be aligned automatically.
@@ -3081,26 +3023,27 @@ using unique_fn = basic_fn<
   /* BufferSize = */          detail::get_aligned_size(BufferSize),
   /* IsCopyable = */          false,
   /* IsView = */              false,
-  /* IsThrowing = */          true,
+  /* IsThrowing = */          false,
   /* AssertObjectNoThrow = */ false
 >;
 
-/// @brief A SAFE function object wrapper for copyable and callable objects.
-/// @throws Strong noexcept guarantee. (ASSERT-NO-THROW)
+/// @brief A function object wrapper for copyable and callable objects.
+/// @throws `std::bad_function_call` if invoked in an empty state.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
 /// And the buffer size will be aligned automatically.
 template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
-using safe_fn = basic_fn<
+using classic_fn = basic_fn<
   /* Signature = */           Signature,
   /* BufferSize = */          detail::get_aligned_size(BufferSize),
   /* IsCopyable = */          true,
   /* IsView = */              false,
-  /* IsThrowing = */          false,
-  /* AssertObjectNoThrow = */ true
+  /* IsThrowing = */          true,
+  /* AssertObjectNoThrow = */ false
 >;
 
 /// @brief A non-owning polymorphic function wrapper.
+/// @note Empty state of this wrapper has been removed.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam Unused - Unused.
 template <typename Signature, std::size_t Unused = 0 /* Unused */>
@@ -3116,6 +3059,11 @@ using fn_ref = basic_fn<
 /// @deprecated Use `fn_ref` instead.
 template <typename Signature, std::size_t Unused = 0 /* Unused */>
 using fn_view EMBED_DEPRECATED("Use fn_ref instead") = fn_ref<Signature>;
+
+/// @deprecated Use `fn` instead.
+template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+using safe_fn EMBED_DEPRECATED("Use fn instead") = basic_fn<
+  Signature, detail::get_aligned_size(BufferSize), true, false, false, true>;
 
 
 /// @brief make_fn[0]: Make function with specified signature for copyable functor.
@@ -3192,13 +3140,28 @@ make_fn(Ret (*func_ptr) (Args...)) noexcept {
     /* NoThrow = */ true
   >(func_ptr);
 }
+#if ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
+
+/// @brief make_fn[3.5]: Make function for noexcept function pointer.
+/// (auto deduce signature and buffer size; the `noexcept` qualifier is preserved)
+/// @return `fn<Ret(Args...) const noexcept, sizeof(Ret(*)(Args...) noexcept)>`
+template <typename Ret, typename... Args>
+EMBED_NODISCARD inline fn<Ret(Args...) const noexcept, sizeof(Ret(*)(Args...) noexcept)>
+make_fn(Ret (*func_ptr) (Args...) noexcept) noexcept {
+  return detail::make_function_impl<
+    fn<Ret(Args...) const noexcept, sizeof(Ret(*)(Args...) noexcept)>,
+    /* NoThrow = */ true
+  >(func_ptr);
+}
+
+#endif
 
 /// @brief make_fn[4]: Make function for function pointer with specified signature.
 /// @return `fn<Signature, sizeof(FunctionPtr)>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Signature, // [User specify] function signature.
   // [Auto] The type of the function pointer.
-  typename FunctionPtr = typename detail::unwrap_signature<Signature>::pure_sig*
+  typename FunctionPtr = typename detail::unwrap_signature<Signature>::pure_sig_noex*
 )
 EMBED_DETAIL_REQUIRES_END(
   // [Require] First template argument must be signature.
@@ -3268,23 +3231,25 @@ EMBED_NODISCARD inline Fn make_fn(Lambda&& fn) noexcept(NoThrow) {
   return detail::make_function_impl<Fn, NoThrow>(std::forward<Lambda>(fn));
 }
 
-#define EMBED_DETAIL_MAKE_FN_DEFINE(C, V, REF, NOEXCEPT)                        \
-  template <typename Class, typename Ret, typename... Args>                     \
-  EMBED_NODISCARD inline auto                                                   \
-  make_fn(Ret(Class::* memfunc)(Args...) C V REF NOEXCEPT) noexcept             \
-  -> fn<                                                                        \
-    Ret(detail::get_qualified_with_t<int REF, C V Class>, Args...) const,       \
-    sizeof(memfunc)                                                             \
-  > {                                                                           \
-    using qualified_class_t = detail::get_qualified_with_t<int REF, C V Class>; \
-    using signature_t = Ret (qualified_class_t, Args...) const;                 \
-    using fn_t = fn<signature_t, sizeof(memfunc)>;                              \
-    return detail::make_function_impl<fn_t, /* NoThrow = */ true>(memfunc);     \
+#define EMBED_DETAIL_MAKE_FN_DEFINE(C, V, REF, NOEXCEPT)                          \
+  template <typename Class, typename Ret, typename... Args>                       \
+  EMBED_NODISCARD inline auto                                                     \
+  make_fn(Ret(Class::* memfunc)(Args...) C V REF NOEXCEPT) noexcept               \
+  -> fn<                                                                          \
+    Ret(detail::get_qualified_with_t<int REF, C V Class>, Args...) const NOEXCEPT,\
+    sizeof(memfunc)                                                               \
+  > {                                                                             \
+    using qualified_class_t = detail::get_qualified_with_t<int REF, C V Class>;   \
+    using signature_t = Ret (qualified_class_t, Args...) const NOEXCEPT;          \
+    using fn_t = fn<signature_t, sizeof(memfunc)>;                                \
+    return detail::make_function_impl<fn_t, /* NoThrow = */ true>(memfunc);       \
   }
 
 /// @brief make_fn[8]: Make function for pointer to member function.
 /// (auto deduce signature and buffer size)
 /// @return `fn<Ret(Class, Args...) const, sizeof(Ret(Class::*)(Args...))>`
+///         The deduced signature preserves the `noexcept` qualifier of the
+///         member function when noexcept is part of the type system (C++17+).
 EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_MAKE_FN_DEFINE)
 
 #undef EMBED_DETAIL_MAKE_FN_DEFINE
@@ -3313,13 +3278,18 @@ make_fn(MemFuncPtr memfunc_ptr) noexcept {
 }
 
 /// @brief make_fn[10]: Make function for pointer to member object.
-/// @return `fn<T(Class&) const, sizeof(ptr_memobj)>`
+/// @return `fn<Ret(Class&) const, sizeof(ptr_memobj)>`, where `Ret` is deduced
+///         from invoking the member pointer with `Class&`. A `noexcept`
+///         qualifier is added when the member access and the conversion to
+///         `Ret` cannot throw (C++17+).
 template <typename Class, typename T,
   typename Ret = typename detail::invoke_result<T Class::*, Class&>::type>
 EMBED_NODISCARD inline auto make_fn(T Class::* ptr_memobj) noexcept
--> fn<Ret(Class&) const, sizeof(ptr_memobj)> {
+-> fn<Ret(Class&) const EMBED_CXX17_NOEXCEPT_(
+    detail::is_nothrow_invocable_r<Ret, T Class::*, Class&>::value), sizeof(ptr_memobj)> {
   return detail::make_function_impl<
-    fn<Ret(Class&) const, sizeof(ptr_memobj)>,
+    fn<Ret(Class&) const EMBED_CXX17_NOEXCEPT_(
+      detail::is_nothrow_invocable_r<Ret, T Class::*, Class&>::value), sizeof(ptr_memobj)>,
     /* NoThrow = */ true
   >(ptr_memobj);
 }
@@ -3364,7 +3334,7 @@ noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs
 #endif
 
 /// @brief make_fn[12]: Make function with specified wrapper.
-/// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::safe_fn`, or `ebd::fn_ref`.
+/// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`.
 /// @return `Fn<Signature, sizeof(functor)>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
   template <class, std::size_t> class Fn,
@@ -3374,7 +3344,7 @@ EMBED_DETAIL_TEMPLATE_BEGIN(
   typename RawSig = typename detail::is_ebd_fn<Deduction>::signature,
   typename Signature = detail::conditional_t<
     std::is_void<SpecifiedSig>::value,
-    detail::noexcept_qualify_like_t<Functor, Fn, RawSig>, SpecifiedSig
+    detail::get_correct_signature_t<Fn, RawSig>, SpecifiedSig
   >,
   std::size_t BufferSize = sizeof(detail::decay_t<Functor>),
   typename FnWrapper = Fn<Signature, BufferSize>,
@@ -3406,8 +3376,8 @@ namespace detail {
   /// @brief `fn_ref` CTAD guides from `std::constant_wrapper`.
 
   template <typename Fn>
-  using make_fn_ref_deduction_sig_t = noexcept_qualify_like_t<
-    Fn, fn_ref, typename is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature>;
+  using make_fn_ref_deduction_sig_t = get_correct_signature_t<
+    fn_ref, typename is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature>;
 
   template <auto Cw, typename Fn>
   function(std::constant_wrapper<Cw, Fn>) -> function<
@@ -3468,7 +3438,6 @@ namespace detail {
 # undef EMBED_NODISCARD
 # undef EMBED_DEPRECATED
 
-# undef EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER
 # undef EMBED_FN_CONFIG_DISABLE_SMART_FORWARD
 # undef EMBED_FN_CONFIG_UNDEF_MACROS
 # undef EMBED_FN_HOOK_DEBUG

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 # test-use macros
 set(
   TEST_USE_MACROS ${TEST_USE_MACROS}
-  # "EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER"
   # "EMBED_FN_CONFIG_DISABLE_SMART_FORWARD"
   # "EMBED_FN_CONFIG_UNDEF_MACROS"
   # "EMBED_FN_HOOK_DEBUG(msg)"
@@ -170,7 +169,7 @@ file(
   GLOB EMBED_FUNCTION_FAIL_TEST_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn_ref/fail/*.fail.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn/fail/*.fail.cpp"
-  "${CMAKE_CURRENT_SOURCE_DIR}/conformance/safe_fn/fail/*.fail.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/conformance/__safe_fn/fail/*.fail.cpp"
 )
 
 get_property(PATH_INCLUDES DIRECTORY PROPERTY INCLUDE_DIRECTORIES)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 # Project name.
 project(
-    "embed_function_2.0.x-GoogleTest"
+    "embed_function_2.2.x-GoogleTest"
     LANGUAGES CXX
 )
 
@@ -68,6 +68,9 @@ file(
     GLOB EMBED_FUNCTION_TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn_ref/*.pass.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn/*.pass.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conformance/__safe_fn/*.pass.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conformance/unique_fn/*.pass.cpp"
 )
 
 # Target executable file.
@@ -170,6 +173,7 @@ file(
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn_ref/fail/*.fail.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn/fail/*.fail.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/__safe_fn/fail/*.fail.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/conformance/unique_fn/fail/*.fail.cpp"
 )
 
 get_property(PATH_INCLUDES DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
@@ -206,12 +210,20 @@ message(STATUS "===---------------------- FAIL TEST BEGIN ----------------------
 message(STATUS "Flags: ${FAIL_TEST_CMAKE_FLAGS}")
 
 foreach(FAIL_TEST_SRC ${EMBED_FUNCTION_FAIL_TEST_FILES})
-  get_filename_component(FAIL_TEST_NAME ${FAIL_TEST_SRC} NAME_WE)
-  get_filename_component(FAIL_TEST_FILE ${FAIL_TEST_SRC} NAME)
+  file(
+    RELATIVE_PATH FAIL_TEST_REL_PATH 
+    ${CMAKE_CURRENT_SOURCE_DIR}/conformance 
+    ${FAIL_TEST_SRC}
+  )
+
+  # Use a unique bindir per test so that tests sharing a file name do not
+  # reuse the same try_compile binary directory.
+  string(REPLACE "/" "_" FAIL_TEST_UNIQUE_NAME "${FAIL_TEST_REL_PATH}")
+  string(REPLACE ".fail.cpp" "" FAIL_TEST_UNIQUE_NAME "${FAIL_TEST_UNIQUE_NAME}")
 
   try_compile(
     COMPILE_RESULT
-    ${CMAKE_CURRENT_BINARY_DIR}/fail_test/${FAIL_TEST_NAME}
+    ${CMAKE_CURRENT_BINARY_DIR}/fail_test/${FAIL_TEST_UNIQUE_NAME}
     SOURCES ${FAIL_TEST_SRC}
     CMAKE_FLAGS "${FAIL_TEST_CMAKE_FLAGS}"
     COMPILE_DEFINITIONS "${CMAKE_CXX_FLAGS} ${FAIL_TEST_INCLUDE_PATH_CMD}"
@@ -220,13 +232,13 @@ foreach(FAIL_TEST_SRC ${EMBED_FUNCTION_FAIL_TEST_FILES})
   if(${COMPILE_RESULT})
     message(
       FATAL_ERROR
-      "[  ERROR   ]: ${FAIL_TEST_FILE} passed but it should be rejected!"
+      "[  ERROR   ]: \"${FAIL_TEST_REL_PATH}\" passed but it should be rejected!"
       " See ${FAIL_TEST_SRC}"
     )
   else()
     message(
       STATUS
-      "[  PASSED  ]: ${FAIL_TEST_FILE} correctly rejected"
+      "[  PASSED  ]: \"${FAIL_TEST_REL_PATH}\" correctly rejected"
     )
   endif()
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ file(
     "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn/*.pass.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/conformance/__safe_fn/*.pass.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/conformance/unique_fn/*.pass.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/conformance/classic_fn/*.pass.cpp"
 )
 
 # Target executable file.
@@ -174,6 +175,7 @@ file(
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/fn/fail/*.fail.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/__safe_fn/fail/*.fail.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/conformance/unique_fn/fail/*.fail.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/conformance/classic_fn/fail/*.fail.cpp"
 )
 
 get_property(PATH_INCLUDES DIRECTORY PROPERTY INCLUDE_DIRECTORIES)

--- a/test/conformance/__safe_fn/fail/incomplete_param.fail.cpp
+++ b/test/conformance/__safe_fn/fail/incomplete_param.fail.cpp
@@ -1,0 +1,10 @@
+#include "test_fallback_macros.hpp"
+
+#include "test_function.hpp"
+
+struct IncompleteStruct;
+
+int main() {
+  // Parameter types cannot be incomplete.
+  ebd::__safe_fn<int(IncompleteStruct)> f; // FAIL
+}

--- a/test/conformance/__safe_fn/fail/not_assert_nothrow.fail.cpp
+++ b/test/conformance/__safe_fn/fail/not_assert_nothrow.fail.cpp
@@ -10,5 +10,5 @@ struct not_assert_nothrowing {
 
 int main() {
   not_assert_nothrowing not_assert_nothrow{};
-  ebd::safe_fn<int(int, int)> f = not_assert_nothrow; // FAIL
+  ebd::__safe_fn<int(int, int)> f = not_assert_nothrow; // FAIL
 }

--- a/test/conformance/classic_fn/fail/to_same_buf_fn.fail.cpp
+++ b/test/conformance/classic_fn/fail/to_same_buf_fn.fail.cpp
@@ -1,0 +1,8 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+int main() {
+  ebd::classic_fn<void(), sizeof(void*)> f_classic;
+  ebd::fn<void(), sizeof(void*)> f = f_classic; // FAIL
+}

--- a/test/conformance/classic_fn/fail/to_same_buf_unique_fn.fail.cpp
+++ b/test/conformance/classic_fn/fail/to_same_buf_unique_fn.fail.cpp
@@ -1,0 +1,8 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+int main() {
+  ebd::classic_fn<void(), sizeof(void*)> f_classic;
+  ebd::unique_fn<void(), sizeof(void*)> f = f_classic; // FAIL
+}

--- a/test/conformance/fn/fail/assign_noexcept.1.fail.cpp
+++ b/test/conformance/fn/fail/assign_noexcept.1.fail.cpp
@@ -5,10 +5,10 @@
 
 int main() {
 #if __cpp_noexcept_function_type >= 201510L && EMBED_CXX_VERSION >= 201703L
-  ebd::safe_fn<int() noexcept> f_noexcept = ebd_test_free_func_noexcept;
-  ebd::safe_fn<int() noexcept(false)> f_maythrow = ebd_test_free_func_maythrow;
+  ebd::fn<int() noexcept> f_noexcept = ebd_test_free_func_noexcept;
+  ebd::fn<int() noexcept(false)> f_maythrow = ebd_test_free_func_maythrow;
 
-  f_maythrow = f_noexcept; // FAIL (size)
+  f_noexcept = f_maythrow; // FAIL
 #else
   static_assert(false, "FAIL"); // FAIL
 #endif

--- a/test/conformance/fn/fail/assign_noexcept.2.fail.cpp
+++ b/test/conformance/fn/fail/assign_noexcept.2.fail.cpp
@@ -5,10 +5,10 @@
 
 int main() {
 #if __cpp_noexcept_function_type >= 201510L && EMBED_CXX_VERSION >= 201703L
-  ebd::safe_fn<int() noexcept> f_noexcept = ebd_test_free_func_noexcept;
-  ebd::safe_fn<int() noexcept(false)> f_maythrow = ebd_test_free_func_maythrow;
+  ebd::fn<int() noexcept> f_noexcept = ebd_test_free_func_noexcept;
+  ebd::fn<int() noexcept(false)> f_maythrow = ebd_test_free_func_maythrow;
 
-  f_noexcept = f_maythrow; // FAIL
+  f_maythrow = f_noexcept; // FAIL (size)
 #else
   static_assert(false, "FAIL"); // FAIL
 #endif

--- a/test/conformance/fn/fail/incomplete_param.fail.cpp
+++ b/test/conformance/fn/fail/incomplete_param.fail.cpp
@@ -1,0 +1,10 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+struct IncompleteStruct;
+
+int main() {
+  // Parameter types cannot be incomplete.
+  ebd::fn<int(IncompleteStruct)> f; // FAIL
+}

--- a/test/conformance/fn/fail/to_same_buf_classic_fn.fail.cpp
+++ b/test/conformance/fn/fail/to_same_buf_classic_fn.fail.cpp
@@ -1,0 +1,8 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+int main() {
+  ebd::fn<void(), sizeof(void*)> f_normal;
+  ebd::classic_fn<void(), sizeof(void*)> f = f_normal; // FAIL
+}

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -174,18 +174,22 @@ TEST(Conformance_fn_ref, conformance_addition_pass) {
     static constexpr auto size_ = sizeof(ebd::fn_ref<int(int,int)>);
     ebd::fn<int(int,int), size_> f2 = f1;
     ebd::unique_fn<int(int,int), size_> f3 = f1;
-    ebd::safe_fn<int(int,int), size_> f4 = f1;
+    ebd::classic_fn<int(int,int), size_> f4 = f1;
+    ebd::__safe_fn<int(int,int), size_> f8 = f1;
     ASSERT_EQ(f1(1, 42), 43);
     ASSERT_EQ(f2(1, 42), 43);
     ASSERT_EQ(f3(1, 42), 43);
     ASSERT_EQ(f4(1, 42), 43);
+    ASSERT_EQ(f8(1, 42), 43);
 
     auto f5 = ebd::make_fn<ebd::fn>(f1);
     auto f6 = ebd::make_fn<ebd::unique_fn>(f1);
-    auto f7 = ebd::make_fn<ebd::safe_fn>(f1);
+    auto f7 = ebd::make_fn<ebd::classic_fn>(f1);
+    auto f9 = ebd::make_fn<ebd::__safe_fn>(f1);
     ASSERT_EQ(f5(2, 42), 44);
     ASSERT_EQ(f6(2, 42), 44);
     ASSERT_EQ(f7(2, 42), 44);
+    ASSERT_EQ(f9(2, 42), 44);
   }
 
   {

--- a/test/conformance/fn_ref/constant_wrapper.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper.pass.cpp
@@ -182,16 +182,12 @@ TEST(Conformance_fn_ref, constant_wrapper_pass) {
     }
   }
 
-#if __cpp_deduction_guides >= 201907L
-
   {
-    // constexpr and CTAD
-    constexpr ebd::fn_ref f = std::cw<&ebd_test_free_func_iii_add>;
+    // constexpr and make_fn
+    constexpr auto f = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add>);
     static_assert(std::is_same_v<decltype(f), const ebd::fn_ref<int(int, int) const>>);
     ASSERT_EQ(f(42, 42), 42 + 42);
   }
-
-#endif // ^^^ __cpp_deduction_guides >= 201907L
 
 }
 

--- a/test/conformance/fn_ref/constant_wrapper_ptr.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper_ptr.pass.cpp
@@ -366,25 +366,21 @@ TEST(Conformance_fn_ref, constant_wrapper_ptr_pass) {
     }
   }
 
-#if __cpp_deduction_guides >= 201907L
-
   {
-    // constexpr and CTAD
+    // constexpr and make_fn
     static ebd_test_member_fn obj;
-    constexpr ebd::fn_ref f(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, &obj);
+    constexpr auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, &obj);
     static_assert(std::is_same_v<decltype(f), const ebd::fn_ref<int(int, int)>>);
     ASSERT_EQ(f(42, 42), 42 + 42);
   }
 
   {
-    // standard CTAD guides
+    // make_fn
     static ebd_test_member_fn obj;
-    ebd::fn_ref f(std::cw<&ebd_test_member_fn::member_var>, &obj);
+    auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::member_var>, &obj);
     static_assert(std::is_same_v<decltype(f), ebd::fn_ref<int&() noexcept>>);
     ASSERT_EQ(f(), 0);
   }
-
-#endif // ^^^ __cpp_deduction_guides >= 201907L
 }
 
 #endif // __cpp_lib_constant_wrapper >= 202603L

--- a/test/conformance/fn_ref/constant_wrapper_ref.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper_ref.pass.cpp
@@ -388,38 +388,34 @@ TEST(Conformance_fn_ref, constant_wrapper_ref_pass) {
     }
   }
 
-#if __cpp_deduction_guides >= 201907L
-
   {
-    // constexpr and CTAD
+    // constexpr and make_fn
     static ebd_test_member_fn obj;
-    constexpr ebd::fn_ref f(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, obj);
+    constexpr auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, obj);
     static_assert(std::is_same_v<decltype(f), const ebd::fn_ref<int(int, int)>>);
     ASSERT_EQ(f(42, 42), 42 + 42);
   }
 
   {
-    // standard CTAD guides
+    // make_fn
     static ebd_test_member_fn obj;
-    ebd::fn_ref f(std::cw<&ebd_test_member_fn::member_var>, obj);
+    auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::member_var>, obj);
     static_assert(std::is_same_v<decltype(f), ebd::fn_ref<int&() noexcept>>);
     ASSERT_EQ(f(), 0);
 
     int a = 0;
-    ebd::fn_ref f2(std::cw<&ebd_test_free_func_iii_add>, a);
+    auto f2 = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add>, a);
     static_assert(std::is_same_v<decltype(f2), ebd::fn_ref<int(int)>>);
     ASSERT_EQ(f2(42), 42);
 
-    ebd::fn_ref f3(std::cw<&ebd_test_free_func_iii_add_noexcept>, a);
+    auto f3 = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add_noexcept>, a);
     static_assert(std::is_same_v<decltype(f3), ebd::fn_ref<int(int&) noexcept>>);
     ASSERT_EQ(f3(a), 0);
 
-    ebd::fn_ref f4(std::cw<&ebd_test_free_func_iii_add_const>, a);
+    auto f4 = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add_const>, a);
     static_assert(std::is_same_v<decltype(f4), ebd::fn_ref<int(const int&) const>>);
     ASSERT_EQ(f4(42), 42);
   }
-
-#endif // ^^^ __cpp_deduction_guides >= 201907L
 
 }
 

--- a/test/conformance/fn_ref/fail/non_nullptr_init.1.fail.cpp
+++ b/test/conformance/fn_ref/fail/non_nullptr_init.1.fail.cpp
@@ -4,7 +4,7 @@
 #include "test_function.hpp"
 
 int main() {
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) || defined(EBD_TEST_USE_FALLBACK)
   static_assert(false, "");
 #else
   // ebd::fn_ref shouldn't be created from nullptr.

--- a/test/conformance/unique_fn/fail/incomplete_param.fail.cpp
+++ b/test/conformance/unique_fn/fail/incomplete_param.fail.cpp
@@ -1,0 +1,10 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+struct IncompleteStruct;
+
+int main() {
+  // Parameter types cannot be incomplete.
+  ebd::unique_fn<int(IncompleteStruct)> f; // FAIL
+}

--- a/test/conformance/unique_fn/fail/to_classic_fn.fail.cpp
+++ b/test/conformance/unique_fn/fail/to_classic_fn.fail.cpp
@@ -1,0 +1,8 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+int main() {
+  ebd::unique_fn<void(), sizeof(void*)> f_unique;
+  ebd::classic_fn<void(), 8 * sizeof(void*)> f = std::move(f_unique); // FAIL
+}

--- a/test/conformance/unique_fn/fail/to_fn.fail.cpp
+++ b/test/conformance/unique_fn/fail/to_fn.fail.cpp
@@ -1,0 +1,8 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+
+int main() {
+  ebd::unique_fn<void(), sizeof(void*)> f_unique;
+  ebd::fn<void(), 8 * sizeof(void*)> f = std::move(f_unique); // FAIL
+}

--- a/test/test_AssignAndConvert.cpp
+++ b/test/test_AssignAndConvert.cpp
@@ -31,11 +31,11 @@ TEST(AssignAndConvert, small_to_big) {
     ASSERT_EQ(cf_big != nullptr, true);
     ASSERT_EQ(cf_big(23665, 8427), 23665 + 8427);
 
-    ebd::__safe_fn<int(int, int) const, s_buf> sf_small = ebd_test_free_func_iii_add;
+    ebd::__safe_fn<int() const EBD_TEST_NOEXCEPT, s_buf> sf_small = ebd_test_free_func_noexcept;
     ASSERT_EQ(sf_small != nullptr, true);
-    ebd::__safe_fn<int(int, int) const, b_buf> sf_big = sf_small;
+    ebd::__safe_fn<int() const EBD_TEST_NOEXCEPT, b_buf> sf_big = sf_small;
     ASSERT_EQ(sf_big != nullptr, true);
-    ASSERT_EQ(sf_big(23665, 8427), 23665 + 8427);
+    ASSERT_EQ(sf_big(), 0);
 
     auto small = ebd::make_fn<int(int)>([](int v){ return v * 2; });
     using Big = ebd::fn<int(int), 8 * sizeof(void*)>;
@@ -174,6 +174,13 @@ TEST(AssignAndConvert, VolatileToNonVolatile) {
         // f_volatile = f_non_volatile; // Error
     }
     {
+        ebd::__safe_fn<void()> f_non_volatile;
+        ebd::__safe_fn<void() volatile> f_volatile;
+
+        f_non_volatile = f_volatile; // OK
+        // f_volatile = f_non_volatile; // Error
+    }
+    {
         ebd::fn_ref<void()> f_non_volatile = +[]{};
         ebd::fn_ref<void() volatile> f_volatile = +[]{};
 
@@ -205,6 +212,13 @@ TEST(AssignAndConvert, NonRefToLeftValueRef) {
         f_ref = f_non_ref; // OK
         // f_non_ref = f_ref; // Error
     }
+    {
+        ebd::__safe_fn<void()> f_non_ref;
+        ebd::__safe_fn<void() &> f_ref;
+
+        f_ref = f_non_ref; // OK
+        // f_non_ref = f_ref; // Error
+    }
 }
 
 // AssignAndConvert[8]
@@ -226,6 +240,13 @@ TEST(AssignAndConvert, NonRefToRightValueRef) {
     {
         ebd::classic_fn<void()> f_non_ref;
         ebd::classic_fn<void() &&> f_ref;
+
+        f_ref = f_non_ref; // OK
+        // f_non_ref = f_ref; // Error
+    }
+    {
+        ebd::__safe_fn<void()> f_non_ref;
+        ebd::__safe_fn<void() &&> f_ref;
 
         f_ref = f_non_ref; // OK
         // f_non_ref = f_ref; // Error
@@ -357,9 +378,85 @@ TEST(AssignAndConvert, SelfAssign) {
         ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
         ASSERT_EQ(ebd_test_counter::m_move_times, 0);
     }
+    {
+        ebd::classic_fn<int(int, int) const> f1 = ebd_test_free_func_iii_add;
+        ASSERT_EQ(f1(42, 0), 42);
+        f1 = f1;
+        ASSERT_EQ(f1(42, 1), 43);
+        f1 = std::move(f1);
+        ASSERT_EQ(f1(42, 2), 44);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::classic_fn>(ebd_test_counter{});
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 1);
+
+        ebd_test_counter::clear();
+        f2 = f2;
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        f2 = std::move(f2);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
 #if defined(__GNUC__) || defined(__clang__)
 # pragma GCC diagnostic pop
 #elif defined(_MSC_VER)
 # pragma warning(pop)
 #endif
+}
+
+// AssignAndConvert[10]
+TEST(AssignAndConvert, InterConvert) {
+    {
+        ebd::fn<int(int, int) const> f = ebd_test_free_func_iii_add;
+        auto f1 = ebd::make_fn<ebd::unique_fn>(f);
+        auto f2 = ebd::make_fn<ebd::classic_fn>(f);
+        auto f3 = ebd::make_fn<ebd::fn_ref>(f);
+        static_assert(f.get_buffer_size() == f1.get_buffer_size(), "BUG");
+        static_assert(f.get_buffer_size() < f2.get_buffer_size(), "BUG");
+        ASSERT_EQ(f(42, 0), 42);
+        ASSERT_EQ(f1(42, 0), 42);
+        ASSERT_EQ(f2(42, 0), 42);
+        ASSERT_EQ(f3(42, 0), 42);
+    }
+    {
+        ebd::unique_fn<int(int, int) const> f = ebd_test_free_func_iii_add;
+        auto f3 = ebd::make_fn<ebd::fn_ref>(f);
+        ASSERT_EQ(f(42, 0), 42);
+        ASSERT_EQ(f3(42, 0), 42);
+    }
+    {
+        ebd::classic_fn<int(int, int) const> f = ebd_test_free_func_iii_add;
+        auto f1 = ebd::make_fn<ebd::fn>(f);
+        auto f2 = ebd::make_fn<ebd::unique_fn>(f);
+        auto f3 = ebd::make_fn<ebd::fn_ref>(f);
+        static_assert(f.get_buffer_size() < f1.get_buffer_size(), "BUG");
+        static_assert(f.get_buffer_size() < f2.get_buffer_size(), "BUG");
+        ASSERT_EQ(f(42, 0), 42);
+        ASSERT_EQ(f1(42, 0), 42);
+        ASSERT_EQ(f2(42, 0), 42);
+        ASSERT_EQ(f3(42, 0), 42);
+    }
+    {
+        ebd::fn_ref<int(int, int) const> f = ebd_test_free_func_iii_add;
+        auto f1 = ebd::make_fn<ebd::fn>(f);
+        auto f2 = ebd::make_fn<ebd::unique_fn>(f);
+        auto f3 = ebd::make_fn<ebd::classic_fn>(f);
+        static_assert(f.get_buffer_size() < f1.get_buffer_size(), "BUG");
+        static_assert(f.get_buffer_size() < f2.get_buffer_size(), "BUG");
+        static_assert(f.get_buffer_size() < f3.get_buffer_size(), "BUG");
+        ASSERT_EQ(f(42, 0), 42);
+        ASSERT_EQ(f1(42, 0), 42);
+        ASSERT_EQ(f2(42, 0), 42);
+        ASSERT_EQ(f3(42, 0), 42);
+    }
 }

--- a/test/test_AssignAndConvert.cpp
+++ b/test/test_AssignAndConvert.cpp
@@ -231,3 +231,135 @@ TEST(AssignAndConvert, NonRefToRightValueRef) {
         // f_non_ref = f_ref; // Error
     }
 }
+
+int ebd_test_counter::m_create_times = 0;
+int ebd_test_counter::m_copy_times = 0;
+int ebd_test_counter::m_move_times = 0;
+int ebd_test_counter::m_delete_times = 0;
+
+// AssignAndConvert[9]
+TEST(AssignAndConvert, SelfAssign) {
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wself-move"
+# ifdef __clang__
+#  pragma GCC diagnostic ignored "-Wself-assign-overloaded" // only clang
+# endif
+#elif defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable : 26800) // for /analyze
+#endif
+    {
+        ebd::fn<int(int, int) const> f1 = ebd_test_free_func_iii_add;
+        ASSERT_EQ(f1(42, 0), 42);
+        f1 = f1;
+        ASSERT_EQ(f1(42, 1), 43);
+        f1 = std::move(f1);
+        ASSERT_EQ(f1(42, 2), 44);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::fn>(ebd_test_counter{});
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 1);
+
+        ebd_test_counter::clear();
+        f2 = f2;
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        f2 = std::move(f2);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+    {
+        ebd::unique_fn<int(int, int) const> f1 = ebd_test_free_func_iii_add;
+        ASSERT_EQ(f1(42, 0), 42);
+        f1 = std::move(f1);
+        ASSERT_EQ(f1(42, 2), 44);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::unique_fn>(ebd_test_counter{});
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 1);
+
+        ebd_test_counter::clear();
+        f2 = std::move(f2);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+    {
+        ebd::fn_ref<int(int, int) const> f1 = ebd_test_free_func_iii_add;
+        ASSERT_EQ(f1(42, 0), 42);
+        f1 = f1;
+        ASSERT_EQ(f1(42, 1), 43);
+        f1 = std::move(f1);
+        ASSERT_EQ(f1(42, 2), 44);
+
+        ebd_test_counter::clear();
+        auto obj = ebd_test_counter{};
+        auto f2 = ebd::make_fn<ebd::fn_ref>(obj);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        f2 = f2;
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        f2 = std::move(f2);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+    {
+        ebd::__safe_fn<int(int, int) const> f1 = ebd_test_free_func_iii_add;
+        ASSERT_EQ(f1(42, 0), 42);
+        f1 = f1;
+        ASSERT_EQ(f1(42, 1), 43);
+        f1 = std::move(f1);
+        ASSERT_EQ(f1(42, 2), 44);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::__safe_fn>(ebd_test_counter{});
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 1);
+
+        ebd_test_counter::clear();
+        f2 = f2;
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        f2 = std::move(f2);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+# pragma warning(pop)
+#endif
+}

--- a/test/test_AssignAndConvert.cpp
+++ b/test/test_AssignAndConvert.cpp
@@ -25,12 +25,17 @@ TEST(AssignAndConvert, small_to_big) {
     ASSERT_EQ(uf_big == nullptr, false);
     ASSERT_EQ(uf_big(23665, 666), 23665 + 666);
 
-    ebd::safe_fn<int() const EBD_TEST_NOEXCEPT, s_buf> sf_small = 
-        ebd_test_free_func_noexcept;
+    ebd::classic_fn<int(int, int) const, s_buf> cf_small = ebd_test_free_func_iii_add;
+    ASSERT_EQ(cf_small != nullptr, true);
+    ebd::classic_fn<int(int, int) const, b_buf> cf_big = cf_small;
+    ASSERT_EQ(cf_big != nullptr, true);
+    ASSERT_EQ(cf_big(23665, 8427), 23665 + 8427);
+
+    ebd::__safe_fn<int(int, int) const, s_buf> sf_small = ebd_test_free_func_iii_add;
     ASSERT_EQ(sf_small != nullptr, true);
-    ebd::safe_fn<int() const EBD_TEST_NOEXCEPT, b_buf> sf_big = sf_small;
+    ebd::__safe_fn<int(int, int) const, b_buf> sf_big = sf_small;
     ASSERT_EQ(sf_big != nullptr, true);
-    ASSERT_EQ(sf_big(), 0);
+    ASSERT_EQ(sf_big(23665, 8427), 23665 + 8427);
 
     auto small = ebd::make_fn<int(int)>([](int v){ return v * 2; });
     using Big = ebd::fn<int(int), 8 * sizeof(void*)>;
@@ -65,9 +70,18 @@ TEST(AssignAndConvert, SameTypeAssign) {
 }
 
 // AssignAndConvert[3]
-TEST(AssignAndConvert, SafeFnAssign) {
-    ebd::safe_fn<int(int)> f1 = [](int x) noexcept { return x + 7; };
-    ebd::safe_fn<int(int)> f2 = [](int x) noexcept { return x + 9; };
+TEST(AssignAndConvert, ClassicFnAssign) {
+    ebd::classic_fn<int(int)> f1 = [](int x) { return x + 7; };
+    ebd::classic_fn<int(int)> f2 = [](int x) { return x + 9; };
+    ASSERT_EQ(f1(1), 8);
+    f1 = f2;
+    ASSERT_EQ(f1(1), 10);
+}
+
+// AssignAndConvert[3.5]
+TEST(AssignAndConvert, __SafeFnAssign) {
+    ebd::__safe_fn<int(int)> f1 = [](int x) noexcept { return x + 7; };
+    ebd::__safe_fn<int(int)> f2 = [](int x) noexcept { return x + 9; };
     ASSERT_EQ(f1(1), 8);
     f1 = f2;
     ASSERT_EQ(f1(1), 10);
@@ -96,7 +110,18 @@ TEST(AssignAndConvert, StatelessAssign) {
         ASSERT_EQ(f3(2, 1), false);
     }
     {
-        ebd::safe_fn<bool(int, int)> f1 = std::less<int>{};
+        ebd::classic_fn<bool(int, int)> f1 = std::less<int>{};
+        auto f2 = f1;
+        ASSERT_EQ(f1(1, 2), true);
+        ASSERT_EQ(f1(2, 1), false);
+        ASSERT_EQ(f2(1, 2), true);
+        ASSERT_EQ(f2(2, 1), false);
+        auto f3 = std::move(f2);
+        ASSERT_EQ(f3(1, 2), true);
+        ASSERT_EQ(f3(2, 1), false);
+    }
+    {
+        ebd::__safe_fn<bool(int, int)> f1 = std::less<int>{};
         auto f2 = f1;
         ASSERT_EQ(f1(1, 2), true);
         ASSERT_EQ(f1(2, 1), false);
@@ -142,8 +167,8 @@ TEST(AssignAndConvert, VolatileToNonVolatile) {
         // f_volatile = f_non_volatile; // Error
     }
     {
-        ebd::safe_fn<void()> f_non_volatile;
-        ebd::safe_fn<void() volatile> f_volatile;
+        ebd::classic_fn<void()> f_non_volatile;
+        ebd::classic_fn<void() volatile> f_volatile;
 
         f_non_volatile = f_volatile; // OK
         // f_volatile = f_non_volatile; // Error
@@ -174,8 +199,8 @@ TEST(AssignAndConvert, NonRefToLeftValueRef) {
         // f_non_ref = f_ref; // Error
     }
     {
-        ebd::safe_fn<void()> f_non_ref;
-        ebd::safe_fn<void() &> f_ref;
+        ebd::classic_fn<void()> f_non_ref;
+        ebd::classic_fn<void() &> f_ref;
 
         f_ref = f_non_ref; // OK
         // f_non_ref = f_ref; // Error
@@ -199,8 +224,8 @@ TEST(AssignAndConvert, NonRefToRightValueRef) {
         // f_non_ref = f_ref; // Error
     }
     {
-        ebd::safe_fn<void()> f_non_ref;
-        ebd::safe_fn<void() &&> f_ref;
+        ebd::classic_fn<void()> f_non_ref;
+        ebd::classic_fn<void() &&> f_ref;
 
         f_ref = f_non_ref; // OK
         // f_non_ref = f_ref; // Error

--- a/test/test_BasicAttributes.cpp
+++ b/test/test_BasicAttributes.cpp
@@ -10,31 +10,36 @@
 TEST(BasicAttributes, SizeAndAlign) {
     using f_t = ebd::fn<void()>;
     using uf_t = ebd::unique_fn<void()>;
-    using sf_t = ebd::safe_fn<void()>;
-    using fv_t = ebd::fn_ref<void()>;
+    using cf_t = ebd::classic_fn<void()>;
+    using sf_t = ebd::__safe_fn<void()>;
+    using fr_t = ebd::fn_ref<void()>;
 
     ASSERT_EQ(f_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
     ASSERT_EQ(uf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
+    ASSERT_EQ(cf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
     ASSERT_EQ(sf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
-    ASSERT_EQ(fv_t::get_buffer_size() == ebd::detail::default_buffer_size::view_buf, true);
+    ASSERT_EQ(fr_t::get_buffer_size() == ebd::detail::default_buffer_size::ref_buf, true);
 
     ASSERT_EQ(alignof(f_t) == ebd::detail::default_buffer_size::align_value, true);
     ASSERT_EQ(alignof(uf_t) == ebd::detail::default_buffer_size::align_value, true);
+    ASSERT_EQ(alignof(cf_t) == ebd::detail::default_buffer_size::align_value, true);
     ASSERT_EQ(alignof(sf_t) == ebd::detail::default_buffer_size::align_value, true);
-    ASSERT_EQ(alignof(fv_t) == alignof(void(*)()), true);
+    ASSERT_EQ(alignof(fr_t) == alignof(void(*)()), true);
 
     ASSERT_EQ(sizeof(f_t) - f_t::get_buffer_size(), 2 * sizeof(void*));
     ASSERT_EQ(sizeof(uf_t) - uf_t::get_buffer_size(), 2 * sizeof(void*));
+    ASSERT_EQ(sizeof(cf_t) - cf_t::get_buffer_size(), 2 * sizeof(void*));
     ASSERT_EQ(sizeof(sf_t) - sf_t::get_buffer_size(), 2 * sizeof(void*));
-    ASSERT_EQ(sizeof(fv_t) - fv_t::get_buffer_size(), sizeof(void*));
+    ASSERT_EQ(sizeof(fr_t) - fr_t::get_buffer_size(), sizeof(void*));
 }
 
 // BasicAttributes[1]
 TEST(BasicAttributes, AbilityAndNoexcept) {
     using f_t = ebd::fn<void()>;
     using uf_t = ebd::unique_fn<void()>;
-    using sf_t = ebd::safe_fn<void()>;
-    using fv_t = ebd::fn_ref<void()>;
+    using cf_t = ebd::classic_fn<void()>;
+    using sf_t = ebd::__safe_fn<void()>;
+    using fr_t = ebd::fn_ref<void()>;
 
     // f_t
     ASSERT_EQ(std::is_move_constructible<f_t>::value == true, true);
@@ -54,7 +59,16 @@ TEST(BasicAttributes, AbilityAndNoexcept) {
     ASSERT_EQ(std::is_nothrow_move_assignable<uf_t>::value == false, true);
     ASSERT_EQ(std::is_nothrow_destructible<uf_t>::value == false, true);
 
-    // sf_t
+    // cf_t (classic_fn is copyable, like fn)
+    ASSERT_EQ(std::is_move_constructible<cf_t>::value == true, true);
+    ASSERT_EQ(std::is_move_assignable<cf_t>::value == true, true);
+    ASSERT_EQ(std::is_copy_constructible<cf_t>::value == true, true);
+    ASSERT_EQ(std::is_copy_assignable<cf_t>::value == true, true);
+    ASSERT_EQ(std::is_nothrow_copy_constructible<cf_t>::value == false, true);
+    ASSERT_EQ(std::is_nothrow_copy_assignable<cf_t>::value == false, true);
+    ASSERT_EQ(std::is_nothrow_destructible<cf_t>::value == false, true);
+
+    // sf_t (__safe_fn asserts nothrow, so copy/move/destroy are nothrow)
     ASSERT_EQ(std::is_move_constructible<sf_t>::value == true, true);
     ASSERT_EQ(std::is_move_assignable<sf_t>::value == true, true);
     ASSERT_EQ(std::is_copy_constructible<sf_t>::value == true, true);
@@ -65,16 +79,16 @@ TEST(BasicAttributes, AbilityAndNoexcept) {
     ASSERT_EQ(std::is_nothrow_move_assignable<sf_t>::value == true, true);
     ASSERT_EQ(std::is_nothrow_destructible<sf_t>::value == true, true);
 
-    // fv_t
-    ASSERT_EQ(std::is_move_constructible<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_move_assignable<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_copy_constructible<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_copy_assignable<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_nothrow_copy_constructible<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_nothrow_copy_assignable<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_nothrow_move_constructible<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_nothrow_move_assignable<fv_t>::value == true, true);
-    ASSERT_EQ(std::is_nothrow_destructible<fv_t>::value == true, true);
+    // fr_t
+    ASSERT_EQ(std::is_move_constructible<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_move_assignable<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_copy_constructible<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_copy_assignable<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_nothrow_copy_constructible<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_nothrow_copy_assignable<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_nothrow_move_constructible<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_nothrow_move_assignable<fr_t>::value == true, true);
+    ASSERT_EQ(std::is_nothrow_destructible<fr_t>::value == true, true);
 }
 
 // BasicAttributes[2]
@@ -100,21 +114,21 @@ TEST(BasicAttributes, DefaultConfig) {
     static_assert(
         std::is_same<
             ebd::fn<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, true, false>
+            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, false, false>
         >::value, 
         "The default config of ebd::fn has been changed!");
     static_assert(
         std::is_same<
             ebd::unique_fn<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), false, false, true, false>
+            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), false, false, false, false>
         >::value, 
         "The default config of ebd::unique_fn has been changed!");
     static_assert(
         std::is_same<
-            ebd::safe_fn<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, false, true>
+            ebd::classic_fn<void(), 0>, 
+            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, true, false>
         >::value, 
-        "The default config of ebd::safe_fn has been changed!");
+        "The default config of ebd::classic_fn has been changed!");
     static_assert(
         std::is_same<
             ebd::fn_ref<void(), 0>, 
@@ -141,8 +155,8 @@ TEST(BasicAttributes, SeemsIncomplete) {
         ASSERT_EQ(f2(nullptr), 43);
     }
     {
-        ebd::safe_fn<int(void)> f1 = [] { return 42; };
-        ebd::safe_fn<int(int[])> f2 = [](int[]) { return 43; };
+        ebd::classic_fn<int(void)> f1 = [] { return 42; };
+        ebd::classic_fn<int(int[])> f2 = [](int[]) { return 43; };
 
         ASSERT_EQ(f1(), 42);
         ASSERT_EQ(f2(nullptr), 43);

--- a/test/test_CompilerBugs.cpp
+++ b/test/test_CompilerBugs.cpp
@@ -28,7 +28,7 @@ TEST(CompilerBugs, GCC_Bug_106067) {
 }
 
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51452
-// https://en.cppreference.com/w/cpp/types/is_constructible.html#Notes
+// https://cppreference.com/w/cpp/types/is_constructible.html#Notes
 // GCC 5.1 ~ 15.2 has this "bug".
 // Clang 3.3 ~ 20.2 has this "bug".
 // MSVC v19.20 ~ v19.50 has this "bug".

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -770,5 +770,93 @@ TEST(InitFunction, noexcept_qualifier_tests) {
     }
 }
 
+// InitFunction[40]
+TEST(InitFunction, inplace_create) {
+    {
+        ebd_test_counter::clear();
+        ebd::fn<int(int) const noexcept> f1(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::fn>(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+    {
+        ebd_test_counter::clear();
+        ebd::unique_fn<int(int) const noexcept> f1(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::unique_fn>(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+    {
+        ebd_test_counter::clear();
+        ebd::classic_fn<int(int) const> f1(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::classic_fn>(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+    {
+        ebd_test_counter::clear();
+        ebd::__safe_fn<int(int) const noexcept> f1(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+
+        ebd_test_counter::clear();
+        auto f2 = ebd::make_fn<ebd::__safe_fn>(std::in_place_type<ebd_test_counter>);
+        ASSERT_EQ(ebd_test_counter::m_create_times, 1);
+        ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
+        ASSERT_EQ(ebd_test_counter::m_move_times, 0);
+    }
+}
+
 #endif // ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
 
+// InitFunction[41]
+TEST(InitFunction, from_implicit_func_ptr) {
+    {
+        ebd::fn<int(int) const> f = ebd_test_implicit_func_ptr{};
+        ASSERT_EQ(f(0), 42);
+    }
+    {
+        ebd::unique_fn<int(int) const> f = ebd_test_implicit_func_ptr{};
+        ASSERT_EQ(f(0), 42);
+    }
+    {
+        ebd::classic_fn<int(int) const> f = ebd_test_implicit_func_ptr{};
+        ASSERT_EQ(f(0), 42);
+    }
+    {
+        ebd::__safe_fn<int(int) const> f = ebd_test_implicit_func_ptr{};
+        ASSERT_EQ(f(0), 42);
+    }
+    {
+        auto obj = ebd_test_implicit_func_ptr{};
+        ebd::fn_ref<int(int) const> f = obj;
+        ASSERT_EQ(f(0), 42);
+    }
+}

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -781,7 +781,7 @@ TEST(InitFunction, inplace_create) {
         ASSERT_EQ(ebd_test_counter::m_move_times, 0);
 
         ebd_test_counter::clear();
-        auto f2 = ebd::make_fn<ebd::fn>(std::in_place_type<ebd_test_counter>);
+        auto f2 = ebd::make_fn<ebd::fn>(std::in_place_type<ebd_test_counter>, 0);
         ASSERT_EQ(ebd_test_counter::m_create_times, 1);
         ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
         ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
@@ -796,7 +796,7 @@ TEST(InitFunction, inplace_create) {
         ASSERT_EQ(ebd_test_counter::m_move_times, 0);
 
         ebd_test_counter::clear();
-        auto f2 = ebd::make_fn<ebd::unique_fn>(std::in_place_type<ebd_test_counter>);
+        auto f2 = ebd::make_fn<ebd::unique_fn>(std::in_place_type<ebd_test_counter>, 0);
         ASSERT_EQ(ebd_test_counter::m_create_times, 1);
         ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
         ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
@@ -811,7 +811,7 @@ TEST(InitFunction, inplace_create) {
         ASSERT_EQ(ebd_test_counter::m_move_times, 0);
 
         ebd_test_counter::clear();
-        auto f2 = ebd::make_fn<ebd::classic_fn>(std::in_place_type<ebd_test_counter>);
+        auto f2 = ebd::make_fn<ebd::classic_fn>(std::in_place_type<ebd_test_counter>, 0);
         ASSERT_EQ(ebd_test_counter::m_create_times, 1);
         ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
         ASSERT_EQ(ebd_test_counter::m_copy_times, 0);
@@ -826,7 +826,7 @@ TEST(InitFunction, inplace_create) {
         ASSERT_EQ(ebd_test_counter::m_move_times, 0);
 
         ebd_test_counter::clear();
-        auto f2 = ebd::make_fn<ebd::__safe_fn>(std::in_place_type<ebd_test_counter>);
+        auto f2 = ebd::make_fn<ebd::__safe_fn>(std::in_place_type<ebd_test_counter>, 0);
         ASSERT_EQ(ebd_test_counter::m_create_times, 1);
         ASSERT_EQ(ebd_test_counter::m_delete_times, 0);
         ASSERT_EQ(ebd_test_counter::m_copy_times, 0);

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -78,9 +78,13 @@ TEST(InitFunction, fn_freeFunction_template) {
 
 // InitFunction[4]
 TEST(InitFunction, fn_freeFunction_noexcept) { 
-    ebd::safe_fn<int() EBD_TEST_NOEXCEPT> f = ebd_test_free_func_noexcept;
+    ebd::fn<int() EBD_TEST_NOEXCEPT> f = ebd_test_free_func_noexcept;
     ASSERT_EQ(f.is_empty(), false);
     ASSERT_EQ(f(), 0);
+
+    ebd::__safe_fn<int() EBD_TEST_NOEXCEPT> sf = ebd_test_free_func_noexcept;
+    ASSERT_EQ(sf.is_empty(), false);
+    ASSERT_EQ(sf(), 0);
 
     auto f2 = ebd::make_fn(ebd_test_free_func_noexcept);
     ASSERT_EQ(f2.is_empty(), false);
@@ -174,10 +178,14 @@ TEST(InitFunction, fn_memberFunction_static_template) {
 
 // InitFunction[10]
 TEST(InitFunction, fn_memberFunction_static_noexcept) { 
-    // ebd::fn<int() noexcept> is invalid
-    ebd::safe_fn<int() EBD_TEST_NOEXCEPT> f = ebd_test_member_fn::static_mem_fn_noexcept;
+    // ebd::fn<int() noexcept> is valid now (IsThrowing=false)
+    ebd::fn<int() EBD_TEST_NOEXCEPT> f = ebd_test_member_fn::static_mem_fn_noexcept;
     ASSERT_EQ(f.is_empty(), false);
     ASSERT_EQ(f(), 0);
+
+    ebd::__safe_fn<int() EBD_TEST_NOEXCEPT> sf = ebd_test_member_fn::static_mem_fn_noexcept;
+    ASSERT_EQ(sf.is_empty(), false);
+    ASSERT_EQ(sf(), 0);
 
     auto f2 = ebd::make_fn(ebd_test_member_fn::static_mem_fn_noexcept);
     ASSERT_EQ(f2.is_empty(), false);
@@ -283,9 +291,13 @@ TEST(InitFunction, fn_memberFunction_template) {
 TEST(InitFunction, fn_memberFunction_noexcept) { 
     using C_t = ebd_test_member_fn;
     C_t c;
-    ebd::safe_fn<int(C_t&) EBD_TEST_NOEXCEPT> f = &C_t::mem_fn_noexcept;
+    ebd::fn<int(C_t&) EBD_TEST_NOEXCEPT> f = &C_t::mem_fn_noexcept;
     ASSERT_EQ(f.is_empty(), false);
     ASSERT_EQ(f(c), 0);
+
+    ebd::__safe_fn<int(C_t&) EBD_TEST_NOEXCEPT> sf = &C_t::mem_fn_noexcept;
+    ASSERT_EQ(sf.is_empty(), false);
+    ASSERT_EQ(sf(c), 0);
 
     auto f2 = ebd::make_fn(&C_t::mem_fn_noexcept);
     ASSERT_EQ(f2.is_empty(), false);
@@ -544,8 +556,9 @@ TEST(InitFunction, fn_ref_static_member_function) {
 TEST(InitFunction, make_fn_SpecifiedWrapper) {
     auto f1 = ebd::make_fn<ebd::fn>(&ebd_test_member_fn::static_mem_fn_ii_add);
     auto f2 = ebd::make_fn<ebd::unique_fn>(&ebd_test_member_fn::static_mem_fn_ii_add);
-    auto f3 = ebd::make_fn<ebd::safe_fn>(&ebd_test_member_fn::static_mem_fn_ii_add);
+    auto f3 = ebd::make_fn<ebd::classic_fn>(&ebd_test_member_fn::static_mem_fn_ii_add);
     auto f4 = ebd::make_fn<ebd::fn_ref>(&ebd_test_member_fn::static_mem_fn_ii_add);
+    auto f6 = ebd::make_fn<ebd::__safe_fn>(&ebd_test_member_fn::static_mem_fn_ii_add);
 
     auto f5 = ebd::make_fn<ebd::fn_ref>(&ebd_test_free_func_iii_add);
 
@@ -556,6 +569,8 @@ TEST(InitFunction, make_fn_SpecifiedWrapper) {
     ASSERT_EQ(f3 != nullptr, true);
     ASSERT_EQ(f3(3, 9), 3 + 9);
     ASSERT_EQ(f4(3, 9), 3 + 9);
+    ASSERT_EQ(f6 != nullptr, true);
+    ASSERT_EQ(f6(3, 9), 3 + 9);
 
     ASSERT_EQ(f5(23, 45), 23 + 45);
 }
@@ -612,7 +627,7 @@ TEST(InitFunction, std_op_wrapper) {
         ASSERT_EQ(f2(1, 0), true);
         ASSERT_EQ(f2(1, 2), false);
 
-        auto f3 = ebd::make_fn<ebd::safe_fn>(std::greater<int>{});
+        auto f3 = ebd::make_fn<ebd::classic_fn>(std::greater<int>{});
 
         ASSERT_EQ(f3(1, 0), true);
         ASSERT_EQ(f3(1, 2), false);
@@ -663,7 +678,7 @@ TEST(InitFunction, static_operator_call) {
     ASSERT_EQ(f2(1, 0), 1);
     ASSERT_EQ(f2(1, 2), 3);
 
-    auto f3 = ebd::make_fn<ebd::safe_fn>(ebd_test_static_call_operator{});
+    auto f3 = ebd::make_fn<ebd::classic_fn>(ebd_test_static_call_operator{});
 
     ASSERT_EQ(f3(1, 0), 1);
     ASSERT_EQ(f3(1, 2), 3);
@@ -718,7 +733,11 @@ TEST(InitFunction, from_large_alignment) {
         ASSERT_EQ(f(), 42);
     }
     {
-        ebd::safe_fn<int() const> f = ebd_test_large_alignment{};
+        ebd::classic_fn<int() const> f = ebd_test_large_alignment{};
+        ASSERT_EQ(f(), 42);
+    }
+    {
+        ebd::__safe_fn<int() const> f = ebd_test_large_alignment{};
         ASSERT_EQ(f(), 42);
     }
     {
@@ -727,3 +746,29 @@ TEST(InitFunction, from_large_alignment) {
         ASSERT_EQ(f(), 42);
     }
 }
+
+#if ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
+
+// InitFunction[39]
+TEST(InitFunction, noexcept_qualifier_tests) {
+    {
+        auto f1 = ebd::make_fn(ebd_test_free_func_iii_add_noexcept);
+        static_assert(
+            std::is_same_v<decltype(f1),
+            ebd::fn<int(int&,int&) const noexcept, sizeof(void(*)())>>,
+            "");
+        auto f2 = ebd::make_fn<int(int,int,int) const>(ebd_test_free_func_overload);
+        static_assert(
+            std::is_same_v<decltype(f2),
+            ebd::fn<int(int,int,int) const, sizeof(void(*)())>>,
+            "");
+        auto f3 = ebd::make_fn<int(int,int,int) const noexcept>(ebd_test_free_func_overload);
+        static_assert(
+            std::is_same_v<decltype(f3),
+            ebd::fn<int(int,int,int) const noexcept, sizeof(void(*)())>>,
+            "");
+    }
+}
+
+#endif // ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
+

--- a/test/test_Lifetime.cpp
+++ b/test/test_Lifetime.cpp
@@ -42,12 +42,12 @@ TEST(LifetimeTest, no_double_free_in_assignment) {
     }
     ASSERT_EQ(free_count, 4);
 
-    // safe_fn
+    // classic_fn
     free_count = 0;
     {
         no_double_free_checker checker; // 1
-        ebd::safe_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
-        ebd::safe_fn<int()> f2;
+        ebd::classic_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::classic_fn<int()> f2;
         f2 = f1; // 1
     }
     ASSERT_EQ(free_count, 4);
@@ -55,8 +55,27 @@ TEST(LifetimeTest, no_double_free_in_assignment) {
     free_count = 0;
     {
         no_double_free_checker checker; // 1
-        ebd::safe_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
-        ebd::safe_fn<int()> f2;
+        ebd::classic_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::classic_fn<int()> f2;
+        f2 = std::move(f1); // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    // __safe_fn
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::__safe_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::__safe_fn<int()> f2;
+        f2 = f1; // 1
+    }
+    ASSERT_EQ(free_count, 4);
+
+    free_count = 0;
+    {
+        no_double_free_checker checker; // 1
+        ebd::__safe_fn<int()> f1 = [checker]() { return checker.m_var; }; // 2
+        ebd::__safe_fn<int()> f2;
         f2 = std::move(f1); // 1
     }
     ASSERT_EQ(free_count, 4);

--- a/test/test_Swap.cpp
+++ b/test/test_Swap.cpp
@@ -24,8 +24,8 @@ TEST(TestSwap, fn_ref_swap) {
     ASSERT_EQ(f2(3, 4), 3 + 4);
 }
 
-TEST(TestSwap, safe_fn_swap) {
-    auto f1 = ebd::safe_fn<int(int, int)>(ebd_test_free_func_iii_add);
+TEST(TestSwap, unique_fn_swap) {
+    auto f1 = ebd::unique_fn<int(int, int)>(ebd_test_free_func_iii_add);
     decltype(f1) f2;
 
     f2.swap(f1);
@@ -35,8 +35,19 @@ TEST(TestSwap, safe_fn_swap) {
     ASSERT_EQ(f2(3, 4), 3 + 4);
 }
 
-TEST(TestSwap, unique_fn_swap) {
-    auto f1 = ebd::unique_fn<int(int, int)>(ebd_test_free_func_iii_add);
+TEST(TestSwap, classic_fn_swap) {
+    auto f1 = ebd::classic_fn<int(int, int)>(ebd_test_free_func_iii_add);
+    decltype(f1) f2;
+
+    f2.swap(f1);
+
+    ASSERT_EQ(f1 == nullptr, true);
+    ASSERT_EQ(f2 == nullptr, false);
+    ASSERT_EQ(f2(3, 4), 3 + 4);
+}
+
+TEST(TestSwap, __safe_fn_swap) {
+    auto f1 = ebd::__safe_fn<int(int, int)>(ebd_test_free_func_iii_add);
     decltype(f1) f2;
 
     f2.swap(f1);
@@ -91,9 +102,9 @@ TEST(TestSwap, NonTrivialSwap) {
     {
         Test_t t{};
         t.m_var = 42;
-        ebd::safe_fn<int() const> f1 = t;
+        ebd::classic_fn<int() const> f1 = t;
         t.m_var = 43;
-        ebd::safe_fn<int() const> f2 = t;
+        ebd::classic_fn<int() const> f2 = t;
 
         TestSwap_NonTrivialSwap_Flag = 0;
         f1.swap(f2);

--- a/test/test_ThrowDeath.cpp
+++ b/test/test_ThrowDeath.cpp
@@ -62,6 +62,13 @@ TEST(ThrowDeath, mix_throw_and_death) {
 
     f2 = nullptr;
     EXPECT_DEATH(f2(2), "");
+
+    auto f3 = ebd::make_fn<ebd::classic_fn>(ebd_test_operator_unambiguous{});
+    ASSERT_EQ(f3.is_empty(), false);
+    ASSERT_EQ(f3(3), 3);
+
+    f3.clear();
+    EBD_EXPECT_THROW(f3(3), std::bad_function_call);
 }
 
 #if !defined(_MSC_VER)

--- a/test/test_ThrowDeath.cpp
+++ b/test/test_ThrowDeath.cpp
@@ -8,36 +8,41 @@
 
 // ThrowDeath[0]
 TEST(ThrowDeath, throw_bad_function_call) {
-    ebd::fn<void()> f1;
+    ebd::classic_fn<void()> f1;
     ASSERT_EQ(f1.is_empty(), true);
     ASSERT_EQ(static_cast<bool>(f1), false);
     EBD_EXPECT_THROW(f1(), std::bad_function_call);
+}
+
+// ThrowDeath[0.5]
+TEST(ThrowDeath, terminate_on_empty_call) {
+    ebd::fn<void()> f1;
+    ASSERT_EQ(f1.is_empty(), true);
+    ASSERT_EQ(static_cast<bool>(f1), false);
+    EXPECT_DEATH(f1(), "");
 
     ebd::unique_fn<void()> f2;
     ASSERT_EQ(f2.is_empty(), true);
     ASSERT_EQ(static_cast<bool>(f2), false);
-    EBD_EXPECT_THROW(f2(), std::bad_function_call);
+    EXPECT_DEATH(f2(), "");
+
+    ebd::__safe_fn<void()> sf;
+    ASSERT_EQ(sf.is_empty(), true);
+    ASSERT_EQ(static_cast<bool>(sf), false);
+    EXPECT_DEATH(sf(), "");
 
     auto f3 = ebd::make_fn<void()>();
     ASSERT_EQ(f3.is_empty(), true);
     ASSERT_EQ(static_cast<bool>(f3), false);
-    EBD_EXPECT_THROW(f3(), std::bad_function_call);
+    EXPECT_DEATH(f3(), "");
 
     auto f4 = ebd::make_fn<void()>(nullptr);
     ASSERT_EQ(f4.is_empty(), true);
     ASSERT_EQ(static_cast<bool>(f4), false);
-    EBD_EXPECT_THROW(f4(), std::bad_function_call);
+    EXPECT_DEATH(f4(), "");
 }
 
-// ThrowDeath[1]
-TEST(ThrowDeath, dead_when_empty_call) {
-    ebd::safe_fn<void()> f1;
-    ASSERT_EQ(f1.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(f1), false);
-    EXPECT_DEATH(f1(), "");
-}
-
-// ThrowDeath[2]
+// ThrowDeath[1] — fn/unique_fn terminate on empty; safe_fn (deprecated) also terminates
 TEST(ThrowDeath, mix_throw_and_death) {
     auto f1 = ebd::make_fn(ebd_test_free_func_iii_add);
     ASSERT_EQ(f1 != nullptr, true);
@@ -45,7 +50,7 @@ TEST(ThrowDeath, mix_throw_and_death) {
 
     f1.clear();
     ASSERT_EQ(f1 == nullptr, true);
-    EBD_EXPECT_THROW(f1(1, 2), std::bad_function_call);
+    EXPECT_DEATH(f1(1, 2), "");
 
     auto f2 = ebd::make_fn(ebd_test_operator_unambiguous{});
     ASSERT_EQ(f2 != nullptr, true);
@@ -56,15 +61,7 @@ TEST(ThrowDeath, mix_throw_and_death) {
     ASSERT_EQ(f2(3), 3);
 
     f2 = nullptr;
-    EBD_EXPECT_THROW(f2(2), std::bad_function_call);
-
-    ebd::safe_fn<int(char) const> f3 = 
-        static_cast<int(*)(char)>(&ebd_test_member_fn::static_mem_fn_overload);
-    ASSERT_EQ(f3 == nullptr, false);
-    ASSERT_EQ(f3('W'), OVL_CHAR);
-
-    f3.clear();
-    EXPECT_DEATH(f3('D'), "");
+    EXPECT_DEATH(f2(2), "");
 }
 
 #if !defined(_MSC_VER)

--- a/test/test_UnaryDereference.cpp
+++ b/test/test_UnaryDereference.cpp
@@ -33,3 +33,79 @@ TEST(UnaryDereference, fn_ref_freeFunction) {
     ebd::fn_ref<void()> f1 = ebd_test_free_func_v;
     ASSERT_EQ(*f1, &ebd_test_free_func_v);
 }
+
+#if ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
+
+TEST(UnaryDereference, noexcept_qualifier) {
+    {
+        auto f1 = ebd::make_fn<ebd::fn>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(std::is_same_v<decltype(*f1), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f1, &ebd_test_free_func_iii_add_noexcept);
+
+        auto f2 = ebd::make_fn<ebd::fn, int(int&, int&)>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f2), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f2, nullptr);
+
+        auto f3 = ebd::make_fn<ebd::fn, int(int&, int&) const>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f3), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f3, nullptr);
+
+        auto f4 = ebd::make_fn<ebd::fn, int(int&, int&) volatile>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f4), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f4, nullptr);
+    }
+    {
+        auto f1 = ebd::make_fn<ebd::unique_fn>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(std::is_same_v<decltype(*f1), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f1, &ebd_test_free_func_iii_add_noexcept);
+
+        auto f2 = ebd::make_fn<ebd::unique_fn, int(int&, int&)>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f2), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f2, nullptr);
+
+        auto f3 = ebd::make_fn<ebd::unique_fn, int(int&, int&) const>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f3), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f3, nullptr);
+
+        auto f4 = ebd::make_fn<ebd::unique_fn, int(int&, int&) volatile>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f4), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f4, nullptr);
+    }
+    {
+        // classic_fn is special.
+        auto f1 = ebd::make_fn<ebd::classic_fn>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f1), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f1, nullptr);
+
+        auto f2 = ebd::make_fn<ebd::classic_fn, int(int&, int&)>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f2), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f2, nullptr);
+
+        auto f3 = ebd::make_fn<ebd::classic_fn, int(int&, int&) const>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f3), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f3, nullptr);
+
+        auto f4 = ebd::make_fn<ebd::classic_fn, int(int&, int&) volatile>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f4), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f4, nullptr);
+    }
+    {
+        auto f1 = ebd::make_fn<ebd::fn_ref>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(std::is_same_v<decltype(*f1), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f1, &ebd_test_free_func_iii_add_noexcept);
+
+        auto f2 = ebd::make_fn<ebd::fn_ref, int(int&, int&)>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f2), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f2, nullptr);
+
+        auto f3 = ebd::make_fn<ebd::fn_ref, int(int&, int&) const>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f3), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f3, nullptr);
+
+        auto f4 = ebd::make_fn<ebd::fn_ref, int(int&, int&) volatile>(ebd_test_free_func_iii_add_noexcept);
+        static_assert(!std::is_same_v<decltype(*f4), decltype(&ebd_test_free_func_iii_add_noexcept)>, "BUG");
+        ASSERT_EQ(*f4, nullptr);
+    }
+}
+
+#endif

--- a/test/test_fallback_macros.hpp
+++ b/test/test_fallback_macros.hpp
@@ -6,11 +6,12 @@
 # define EMBED_HAS_BUILTIN(x) 0
 # define EMBED_HAS_ATTRIBUTE(x) 0
 # define EMBED_HAS_CXX_ATTRIBUTE(x) 0
+# define EMBED_HAS_FEATURE(x) 0
+# define EMBED_HAS_INCLUDE(x) 0
 # define EMBED_ABI_VISIBILITY(x)
 # define EMBED_INLINE inline
 # define EMBED_RESTRICT
 # define EMBED_NODISCARD
-# define EMBED_FALLTHROUGH()
 # define EMBED_DEPRECATED(x)
 
 #endif // defined(EBD_TEST_USE_FALLBACK)

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -250,6 +250,8 @@ struct ebd_test_counter {
     static int m_copy_times;
     static int m_move_times;
     static int m_delete_times;
+
+    ebd_test_counter(int) noexcept { m_create_times++; }
     ebd_test_counter() noexcept { m_create_times++; }
     ebd_test_counter(const ebd_test_counter&) noexcept { m_copy_times++; }
     ebd_test_counter(ebd_test_counter&&) noexcept { m_move_times++; }
@@ -263,4 +265,12 @@ struct ebd_test_counter {
     }
 
     int operator()(int n) const noexcept { return n + 42; }
+};
+
+struct ebd_test_implicit_func_ptr {
+    using func_ptr = int (*) (int);
+
+    operator func_ptr() const {
+        return [](int n) { return n + 42; };
+    }
 };

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -4,6 +4,18 @@
 #include "embed/embed_function.hpp"
 #include "gtest/gtest.h"
 
+namespace ebd {
+
+/// @attention TEST USE ONLY!
+template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+using __safe_fn = basic_fn<Signature, detail::get_aligned_size(BufferSize),
+                           true,    // Is Copyable
+                           false,   // Not View
+                           false,   // Not Throwing on empty calls
+                           true>;   // Assert Ctor/Dtor Nothrow
+
+} // namespace ebd
+
 #if ( EMBED_CXX_VERSION >= 201703L || __cpp_noexcept_function_type >= 201510L )
 # define EBD_TEST_NOEXCEPT noexcept
 #else
@@ -46,6 +58,7 @@ enum OverloadRes {
     OVL_DOUBLE,
     OVL_INT_INT,
     OVL_INT_FLOAT,
+    OVL_INT_INT_INT,
 };
 inline int ebd_test_free_func_overload() { return OVL_VOID; }
 inline int ebd_test_free_func_overload(int) { return OVL_INT; }
@@ -54,6 +67,7 @@ inline int ebd_test_free_func_overload(float) { return OVL_FLOAT; }
 inline int ebd_test_free_func_overload(double) { return OVL_DOUBLE; }
 inline int ebd_test_free_func_overload(int, int) { return OVL_INT_INT; }
 inline int ebd_test_free_func_overload(int, float) { return OVL_INT_FLOAT; }
+inline int ebd_test_free_func_overload(int, int, int) noexcept { return OVL_INT_INT_INT; }
 
 namespace ebd_test {
 

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -244,3 +244,23 @@ struct ebd_test_large_alignment {
     alignas(std::max_align_t) int m_var;
     int operator()() const { return 42; }
 };
+
+struct ebd_test_counter {
+    static int m_create_times;
+    static int m_copy_times;
+    static int m_move_times;
+    static int m_delete_times;
+    ebd_test_counter() noexcept { m_create_times++; }
+    ebd_test_counter(const ebd_test_counter&) noexcept { m_copy_times++; }
+    ebd_test_counter(ebd_test_counter&&) noexcept { m_move_times++; }
+    ~ebd_test_counter() noexcept { m_delete_times++; }
+
+    static void clear() noexcept {
+        m_create_times = 0;
+        m_copy_times = 0;
+        m_move_times = 0;
+        m_delete_times = 0;
+    }
+
+    int operator()(int n) const noexcept { return n + 42; }
+};


### PR DESCRIPTION
**🔧 Fixed Bugs**
- `operator*` now returns a `noexcept` function pointer when the stored signature includes `noexcept`, instead of returning `nullptr`. (#117)

**⚠️ Breaking Changes**
- `ebd::fn` and `ebd::unique_fn` now call `std::terminate()` on empty call instead of throwing `std::bad_function_call`. If you need `std::bad_function_call` on empty call, use the new `ebd::classic_fn`. (#117)
- `make_fn` now preserves the `noexcept` qualifier when deducing signatures for lambdas and functors (it was previously stripped for `ebd::fn`/`ebd::unique_fn`). For example, `make_fn([]() noexcept {})` now yields `fn<void() const noexcept>` instead of `fn<void() const>` (Since C++17). (#117)
- `ebd::safe_fn` is deprecated. Use `ebd::fn` for terminate-on-empty, or `ebd::basic_fn` directly if you need the `AssertObjectNoThrow` guarantee. (#117)
- The macro `EMBED_FN_CONFIG_USE_BIG_DEFAULT_BUFFER` has been removed. (#116)
- If the user creates the `fn_ref` object from `nullptr` in the *debugging mode*, then regardless of whether the user has defined the macro `EMBED_FN_HOOK_DEBUG` or not, the `std::terminate()` function will be called. (#121)
- The `ebd::fn_ref` CTAD deduction guides for `std::constant_wrapper` (C++26) have been removed. Use `ebd::make_fn(std::cw<...>)` instead. (#124)

**✨ New Features**
- Added `ebd::classic_fn`, a copyable wrapper that throws `std::bad_function_call` on empty call (like `std::function`). (#117)
- Added a `make_fn` overload for `noexcept` function pointers (C++17+), which preserves the `noexcept` qualifier in the wrapper's signature. (#117)
- noexcept qualifiers are now propagated through `make_fn` for member function pointers and member object pointers. (#117)
- `make_fn<FnWrapper>` now accepts multiple arguments, enabling in-place construction with a specific wrapper type, e.g. `make_fn<ebd::classic_fn>(std::in_place_type<Functor>, args...)`. (#123)
- Added `make_fn` overloads for `std::constant_wrapper` (C++26+), which deduce and return an `ebd::fn_ref` from `std::cw<fn>` or `std::cw<member_fn>` + object. (#124)

**🛠️ Optimizations and Improvements**
- Refactored noexcept propagation: replaced the complex `noexcept_qualify_like` trait with a simpler `get_correct_signature` trait that decides based on wrapper config (`IsView || !IsThrowing`). (#120)
- Removed `sig_with_noexcept` from `get_unique_signature`; `type` now directly includes `noexcept` when applicable. (#117)
- Removed outdated `@todo` and `@experimental` comments. (#116)

**📌 Notes**
- v2.1.11 planned to remove `ebd::fn_view` and `ebd::safe_fn` in v2.2.0. Instead of removal, both are kept as *deprecated* aliases (see the Breaking Changes section above) to avoid breaking existing code.