### PR TITLE
Add ADL swap() function.

### DIFF
--- a/benchmark/runtime/benchmark.hpp
+++ b/benchmark/runtime/benchmark.hpp
@@ -21,6 +21,24 @@ struct benchmark_trivial_struct {
     void* pod;
 };
 
+struct benchmark_non_trivial_struct_add42 {
+    void* pod;
+    benchmark_non_trivial_struct_add42() = default;
+    ~benchmark_non_trivial_struct_add42() = default;
+    benchmark_non_trivial_struct_add42(const benchmark_non_trivial_struct_add42&) noexcept {}
+
+    int operator()(int n) { return 42 + n; }
+};
+
+struct benchmark_non_trivial_struct_add43 {
+    void* pod;
+    benchmark_non_trivial_struct_add43() = default;
+    ~benchmark_non_trivial_struct_add43() = default;
+    benchmark_non_trivial_struct_add43(const benchmark_non_trivial_struct_add43&) noexcept {}
+
+    int operator()(int n) { return 43 + n; }
+};
+
 struct benchmark_call_trivial_struct {
     void* pod;
     benchmark_call_trivial_struct() : pod(nullptr) {

--- a/benchmark/runtime/benchmark_swap.cpp
+++ b/benchmark/runtime/benchmark_swap.cpp
@@ -1,0 +1,55 @@
+#include "benchmark.hpp"
+
+#include <functional>
+
+static void use_std_swap_trivial(picobench::state& s) {
+    ebd::fn<int(int)> f1 = +[](int n) { return 42 + n; };
+    ebd::fn<int(int)> f2 = +[](int n) { return 43 + n; };
+
+    for (auto _ : s) {
+        std::swap(f1, f2);
+    }
+    volatile int ret = f1(314); (void)ret;
+}
+
+static void use_adl_swap_trivial(picobench::state& s) {
+    ebd::fn<int(int)> f1 = +[](int n) { return 42 + n; };
+    ebd::fn<int(int)> f2 = +[](int n) { return 43 + n; };
+
+    using std::swap; // no use
+
+    for (auto _ : s) {
+        swap(f1, f2);
+    }
+    volatile int ret = f1(314); (void)ret;
+}
+
+BENCHMARK_UNIT(ADLSwapBenchmark.fn_swap_trivial);
+BENCHMARK_BASELINE(use_std_swap_trivial);
+BENCHMARK_NOTBASE(use_adl_swap_trivial);
+
+static void use_std_swap_non_trivial(picobench::state& s) {
+    ebd::fn<int(int)> f1 = benchmark_non_trivial_struct_add42{};
+    ebd::fn<int(int)> f2 = benchmark_non_trivial_struct_add43{};
+
+    for (auto _ : s) {
+        std::swap(f1, f2);
+    }
+    volatile int ret = f1(314); (void)ret;
+}
+
+static void use_adl_swap_non_trivial(picobench::state& s) {
+    ebd::fn<int(int)> f1 = benchmark_non_trivial_struct_add42{};
+    ebd::fn<int(int)> f2 = benchmark_non_trivial_struct_add43{};
+
+    using std::swap; // no use
+
+    for (auto _ : s) {
+        swap(f1, f2);
+    }
+    volatile int ret = f1(314); (void)ret;
+}
+
+BENCHMARK_UNIT(ADLSwapBenchmark.fn_swap_non_trivial);
+BENCHMARK_BASELINE(use_std_swap_non_trivial);
+BENCHMARK_NOTBASE(use_adl_swap_non_trivial);

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2960,6 +2960,12 @@ namespace crtp_mixins {
     return !fn.is_empty();
   }
 
+  // Swap function wrapper `a` and `b`.
+  template <std::size_t Buf, typename Cfg, typename Sig>
+  void swap(function<Buf, Cfg, Sig>& a, function<Buf, Cfg, Sig>& b)
+    noexcept(noexcept(a.swap(b)))
+  { a.swap(b); }
+
   // Make a function.
   template <typename Fn, bool NoThrow, typename... CArgs>
   EMBED_CXX20_CONSTEXPR inline

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1981,7 +1981,8 @@ namespace management {
     // Move trivial type-erased object from `src` to `dst`.
     template <typename Functor>
     static void trivially_move(erasure_base_t* dst, erasure_base_t* src)
-    noexcept(noexcept(trivially_clone<Functor>(dst, src))) { trivially_clone<Functor>(dst, src); }
+      noexcept(noexcept(trivially_clone<Functor>(dst, src)))
+    { trivially_clone<Functor>(dst, src); }
 
     // Using when M_erasure is empty.
     struct empty {

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2961,7 +2961,7 @@ namespace crtp_mixins {
     return !fn.is_empty();
   }
 
-  // Swap function wrapper `a` and `b`.
+  // Exchange the function wrapper `a` with the wrapper `b`.
   template <std::size_t Buf, typename Cfg, typename Sig>
   void swap(function<Buf, Cfg, Sig>& a, function<Buf, Cfg, Sig>& b)
     noexcept(noexcept(a.swap(b)))


### PR DESCRIPTION
feat & perf: add ADL swap() function.

## ADLSwapBenchmark.fn_swap_trivial:

 Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
--------------------------|--------:|----------:|--------:|-------:|----------:
 use_std_swap_trivial *   |   10000 |     0.110 |      11 |      - | 90661831.4
 use_adl_swap_trivial     |   10000 |     0.038 |       3 |  0.345 |262467191.6
 use_std_swap_trivial *   |  100000 |     1.195 |      11 |      - | 83703021.7
 use_adl_swap_trivial     |  100000 |     0.381 |       3 |  0.319 |262605042.0
 use_std_swap_trivial *   | 1000000 |    11.985 |      11 |      - | 83441111.4
 use_adl_swap_trivial     | 1000000 |     3.814 |       3 |  0.318 |262185050.2

## ADLSwapBenchmark.fn_swap_non_trivial:

 Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
--------------------------|--------:|----------:|--------:|-------:|----------:
 use_std_swap_non_trivial * |   10000 |     0.143 |      14 |      - | 69686411.1
 use_adl_swap_non_trivial |   10000 |     0.096 |       9 |  0.671 |103842159.9
 use_std_swap_non_trivial * |  100000 |     1.403 |      14 |      - | 71265678.4
 use_adl_swap_non_trivial |  100000 |     0.965 |       9 |  0.688 |103659168.7
 use_std_swap_non_trivial * | 1000000 |    14.968 |      14 |      - | 66808300.3
 use_adl_swap_non_trivial | 1000000 |     9.652 |       9 |  0.645 |103609764.2