### PR TITLE
perf: add EMBED_DETAIL_MSVC_INTRINSIC for MSVC.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -331,6 +331,12 @@
 # define EMBED_DETAIL_NOT_NULL(T) T
 #endif
 
+#if EMBED_HAS_CXX_ATTRIBUTE(msvc::intrinsic)
+# define EMBED_DETAIL_MSVC_INTRINSIC [[msvc::intrinsic]]
+#else
+# define EMBED_DETAIL_MSVC_INTRINSIC
+#endif
+
 namespace ebd EMBED_ABI_VISIBILITY(default) {
 namespace detail {
 
@@ -2264,8 +2270,8 @@ namespace crtp_mixins {
   { return const_cast<remove_const_t<Self>*>(static_cast<Self*>(self)); }
 #else
   template <typename Self, typename CRTP_Base>
-  EMBED_INLINE Self* gcc_ipa_cp_friendly_cast(CRTP_Base* self) noexcept
-  { return static_cast<Self*>(self); }
+  EMBED_DETAIL_MSVC_INTRINSIC EMBED_INLINE Self*
+  gcc_ipa_cp_friendly_cast(CRTP_Base* self) noexcept { return static_cast<Self*>(self); }
 #endif
 
   // Implement the 'operator()' for function.
@@ -3527,6 +3533,7 @@ constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0>>
 # pragma clang diagnostic pop
 #endif // ^^^ Pop the pushed warning for EMBED_DETAIL_NOT_NULL
 #undef EMBED_DETAIL_NOT_NULL
+#undef EMBED_DETAIL_MSVC_INTRINSIC
 #if defined(EMBED_FN_CONFIG_UNDEF_MACROS)
 // #undef most of the EMBED_* macros if EMBED_FN_CONFIG_UNDEF_MACROS is defined.
 // EMBED_CXX_VERSION and EMBED_CXX_ENABLE_EXCEPTION are reserved.


### PR DESCRIPTION
### `[[msvc::intrinsic]]`

The `[[msvc::intrinsic]]` attribute has three constraints on the function it's applied to:

- The function can't be recursive; its body must only have a return statement with a `static_cast` from the parameter type to the return type.
- The function can only accept a single parameter.
- The **`/permissive-`** compiler option is required. (The **`/std:c++20`** and later options imply **`/permissive-`** by default.)

The Microsoft-specific `[[msvc::intrinsic]]` attribute tells the compiler to inline a metafunction that acts as a named cast from the parameter type to the return type. When the attribute is present on a function definition, the compiler replaces all calls to that function with a simple cast. The `[[msvc::intrinsic]]` attribute is available in Visual Studio 2022 version 17.5 preview 2 and later versions. This attribute applies only to the specific function that follows it.

#### Example

In this sample code, the `[[msvc::intrinsic]]` attribute applied to the `my_move` function makes the compiler replace calls to the function with the inlined static cast in its body:

```cpp
template <typename T>
[[msvc::intrinsic]] T&& my_move(T&& t) { return static_cast<T&&>(t); }

void f() {
    int i = 0;
    i = my_move(i);
}
```
