### PR TITLE
 benchmark: add proxy as a new comparison target and update benchmark setup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ jobs:
   # Ubuntu check
   benchmark-on-ubuntu:
     if: github.repository_owner == 'Kim-J-Smith'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       # Get the code
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake
-          sudo apt-get install -y g++-14 clang
+          sudo apt-get install -y g++-16 clang
           sudo apt-get install python3
 
       # Config CMake for compilers
@@ -41,8 +41,8 @@ jobs:
         run: |
           cmake -B build -S . \
             -DCMAKE_CXX_STANDARD=23 \
-            -DCMAKE_C_COMPILER=gcc-14 \
-            -DCMAKE_CXX_COMPILER=g++-14
+            -DCMAKE_C_COMPILER=gcc-16 \
+            -DCMAKE_CXX_COMPILER=g++-16
 
       # Run benchmark
       - name: Run benchmark with C++

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install compilers
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build
+          sudo apt-get install -y cmake
           sudo apt-get install -y g++-14 clang
           sudo apt-get install python3
 
@@ -48,7 +48,7 @@ jobs:
       - name: Run benchmark with C++
         working-directory: benchmark
         run: |
-          cmake --build build --config Release --target benchmark -j$(nproc)
+          cmake --build build --config Release --target benchmark --parallel
           cd ./compiletime
           chmod a+x ./run_benchmark.sh
           ./run_benchmark.sh

--- a/README.md
+++ b/README.md
@@ -380,17 +380,25 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 **Embedded-Function has 5%~30% performance enhancement over `std::function`.**
 
-> *( `Compiler`: GCC-14 `Standard`: C++20 `Config`: -O2 `Tool`: [iboB/picobench](https://github.com/iboB/picobench) )*
+> *( `Compiler`: GCC-16 `Standard`: C++23 `Config`: -O2 `Tool`: [iboB/picobench](https://github.com/iboB/picobench) )*
 
 - **std**: Standard Template Library
 - **ebd**: Embedded-Function
 - **fu2**: [Naios/function2](https://github.com/Naios/function2)
 - **pro**: [ngcpp/proxy](https://github.com/ngcpp/proxy)
 
-### TODO: Update data
+### Functor.TrivialParameters:
 
  Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
 --------------------------|--------:|----------:|--------:|-------:|----------:
+ functor_trivial_`std` *  |    1000 |     0.004 |       3 |      - |250878073.3
+ functor_trivial_`ebd`    |    1000 |     0.001 |       0 |  0.231 |1085776330.1
+ functor_trivial_`fu2`    |    1000 |     0.003 |       3 |  0.829 |302571860.8
+ functor_trivial_`pro`    |    1000 |     0.003 |       3 |  0.804 |312012480.5
+ functor_trivial_`std` *  | 1000000 |     3.858 |       3 |      - |259225310.3
+ functor_trivial_`ebd`    | 1000000 |     0.865 |       0 |  0.224 |1155748694.0
+ functor_trivial_`fu2`    | 1000000 |     3.157 |       3 |  0.818 |316715483.1
+ functor_trivial_`pro`    | 1000000 |     3.158 |       3 |  0.819 |316677871.8
 
 > See [here](https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/benchmark.yml) for more benchmark results. Follow [`benchmark/README.md`](./benchmark/README.md) to run the benchmark in your platform.
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 - [C++26-`std::copyable_function`-P2548](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2548r6.pdf).
 
+- [Deprecating function in C++29 -P2721](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p2721r1.pdf)
+
+- [Proxy: A Pointer-Semantics-Based Polymorphism Library -P3086](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3086r5.html)
+
 ## 📚 Similar implementations
 
 - [std::function](https://cppreference.com/w/cpp/utility/functional/function)

--- a/README.md
+++ b/README.md
@@ -380,27 +380,17 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 **Embedded-Function has 5%~30% performance enhancement over `std::function`.**
 
-> *( `Compiler`: GCC-14 `Standard`: C++14 `Config`: -Os `Tool`: [picobench](https://github.com/iboB/picobench) `fu2`: [function2](https://github.com/Naios/function2) )*
+> *( `Compiler`: GCC-14 `Standard`: C++20 `Config`: -O2 `Tool`: [iboB/picobench](https://github.com/iboB/picobench) )*
 
-### StdOperatorWrapper.FunctionWrapperAsParams:
+- **std**: Standard Template Library
+- **ebd**: Embedded-Function
+- **fu2**: [Naios/function2](https://github.com/Naios/function2)
+- **pro**: [ngcpp/proxy](https://github.com/ngcpp/proxy)
+
+### TODO: Update data
 
  Name (* = baseline)      |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
 --------------------------|--------:|----------:|--------:|-------:|----------:
- `std::function` *        |   10000 |     0.090 |       8 |      - |111671952.5
- `fu2::function`          |   10000 |     0.176 |      17 |  1.968 | 56744349.7
- **`ebd::fn`**            |   10000 |     0.068 |       6 |  0.758 |147412179.2
- `fu2::function_view`     |   10000 |     0.034 |       3 |  0.379 |294602875.3
- **`ebd::fn_ref`**        |   10000 |     0.034 |       3 |  0.375 |297424305.5
- `std::function` *        |  100000 |     0.895 |       8 |      - |111756442.5
- `fu2::function`          |  100000 |     1.765 |      17 |  1.973 | 56644386.5
- **`ebd::fn`**            |  100000 |     0.678 |       6 |  0.758 |147444347.1
- `fu2::function_view`     |  100000 |     0.340 |       3 |  0.380 |294061429.4
- **`ebd::fn_ref`**        |  100000 |     0.308 |       3 |  0.345 |324361494.4
- `std::function` *        | 1000000 |     9.952 |       9 |      - |100481295.4
- `fu2::function`          | 1000000 |    17.733 |      17 |  1.782 | 56391833.9
- **`ebd::fn`**            | 1000000 |     6.832 |       6 |  0.686 |146378186.5
- `fu2::function_view`     | 1000000 |     3.420 |       3 |  0.344 |292392274.6
- **`ebd::fn_ref`**        | 1000000 |     3.249 |       3 |  0.326 |307826614.8
 
 > See [here](https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/benchmark.yml) for more benchmark results. Follow [`benchmark/README.md`](./benchmark/README.md) to run the benchmark in your platform.
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -71,7 +71,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     -Wold-style-cast
     -pedantic
     -fno-permissive
-    -Os
+    -O2
     -fmax-errors=50
     -fno-exceptions
   )
@@ -87,6 +87,6 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     -pedantic
     -fno-permissive
     -fno-exceptions
-    -Os
+    -O2
   )
 endif()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -64,29 +64,15 @@ if(MSVC)
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   target_compile_options(
     ${PROJECT_NAME} PRIVATE
-    -Wall
-    -Wextra
-    -Wpedantic
-    -Wconversion
-    -Wold-style-cast
-    -pedantic
-    -fno-permissive
+    # -Os
     -O2
-    -fmax-errors=50
-    -fno-exceptions
+    # -O3
   )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(
     ${PROJECT_NAME} PRIVATE
-    -Wall
-    -Wextra
-    -Wpedantic
-    -Wconversion
-    -Wold-style-cast
-    -Wno-sign-conversion
-    -pedantic
-    -fno-permissive
-    -fno-exceptions
+    # -Os
     -O2
+    # -O3
   )
 endif()

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -17,7 +17,7 @@ sudo apt update && sudo apt install cmake -y
 ```bash
 cd ./benchmark # Go to benchmark directory: <repo_root>/benchmark
 
-cmake -B build -S . -DCMAKE_CXX_STANDARD=14 # Generate build files (function2 need C++14)
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20 # Generate build files (proxy need C++20)
 
 cmake --build build --config Release --target benchmark --parallel
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -19,5 +19,5 @@ cd ./benchmark # Go to benchmark directory: <repo_root>/benchmark
 
 cmake -B build -S . -DCMAKE_CXX_STANDARD=14 # Generate build files (function2 need C++14)
 
-cmake --build build --config Release --target benchmark # Build and run benchmark. Add '-j 100' if slow.
+cmake --build build --config Release --target benchmark --parallel
 ```

--- a/benchmark/runtime/benchmark.hpp
+++ b/benchmark/runtime/benchmark.hpp
@@ -6,8 +6,8 @@
 #include "proxy/proxy.h"
 #include "picobench/picobench.hpp"
 
-#define BENCHMARK_TIMES {10000, 100000, 1000000}
-#define BENCHMARK_REPEAT 10
+#define BENCHMARK_TIMES {1000, 1000000}
+#define BENCHMARK_REPEAT 15
 
 #define BENCHMARK_UNIT(unit_name) \
     PICOBENCH_SUITE(#unit_name)

--- a/benchmark/runtime/benchmark.hpp
+++ b/benchmark/runtime/benchmark.hpp
@@ -3,6 +3,7 @@
 
 #include "embed/embed_function.hpp"
 #include "function2/function2.hpp"
+#include "proxy/proxy.h"
 #include "picobench/picobench.hpp"
 
 #define BENCHMARK_TIMES {10000, 100000, 1000000}

--- a/benchmark/runtime/benchmark_assignment.cpp
+++ b/benchmark/runtime/benchmark_assignment.cpp
@@ -58,10 +58,32 @@ static void copy_assign_small_trivial_fu2(picobench::state& s) {
     }
 }
 
+static void copy_assign_small_trivial_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto a1 = pro::make_proxy_inplace<Invoker>([](int x) { return x + 1; });
+    auto a2 = pro::make_proxy_inplace<Invoker>([](int x) { return x + 2; });
+    auto b = pro::proxy<Invoker>{};
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = (*b)(result);
+        auto* volatile ff = &b;
+        volatile int u = (**ff)(result); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentSmallTrivial);
 BENCHMARK_BASELINE(copy_assign_small_trivial_std);
 BENCHMARK_NOTBASE(copy_assign_small_trivial_ebd);
 BENCHMARK_NOTBASE(copy_assign_small_trivial_fu2);
+BENCHMARK_NOTBASE(copy_assign_small_trivial_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.MoveAssignment - Small Trivial Lambda
@@ -115,10 +137,32 @@ static void move_assign_small_trivial_fu2(picobench::state& s) {
     }
 }
 
+static void move_assign_small_trivial_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto b = pro::proxy<Invoker>{};
+    int result = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = pro::make_proxy_inplace<Invoker>([](int x) { return x + 1; });
+        auto a2 = pro::make_proxy_inplace<Invoker>([](int x) { return x + 2; });
+        b = std::move(toggle ? a1 : a2);
+        result = (*b)(result);
+        auto* volatile ff = &b;
+        volatile int u = (**ff)(result); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentSmallTrivial);
 BENCHMARK_BASELINE(move_assign_small_trivial_std);
 BENCHMARK_NOTBASE(move_assign_small_trivial_ebd);
 BENCHMARK_NOTBASE(move_assign_small_trivial_fu2);
+BENCHMARK_NOTBASE(move_assign_small_trivial_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.CopyAssignment - Large Capture Lambda
@@ -177,10 +221,32 @@ static void copy_assign_large_capture_fu2(picobench::state& s) {
     }
 }
 
+static void copy_assign_large_capture_pro(picobench::state& s) {
+    LargeCaptureData data1, data2;
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, size_t()>
+        ::restrict_layout<sizeof(LargeCaptureData)>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::support_relocation<pro::constraint_level::nothrow>
+        ::build;
+    auto a1 = pro::make_proxy_inplace<Invoker>([data1]() { return data1.numbers.size() + data1.str.size(); });
+    auto a2 = pro::make_proxy_inplace<Invoker>([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+    auto b = pro::proxy<Invoker>{};
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        auto* volatile ff = &b;
+        volatile size_t u = (**ff)(); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentLargeCapture);
 BENCHMARK_BASELINE(copy_assign_large_capture_std);
 BENCHMARK_NOTBASE(copy_assign_large_capture_ebd);
 BENCHMARK_NOTBASE(copy_assign_large_capture_fu2);
+BENCHMARK_NOTBASE(copy_assign_large_capture_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.MoveAssignment - Large Capture Lambda
@@ -242,10 +308,35 @@ static void move_assign_large_capture_fu2(picobench::state& s) {
     }
 }
 
+static void move_assign_large_capture_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, size_t()>
+        ::restrict_layout<sizeof(LargeCaptureData)>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::support_relocation<pro::constraint_level::nothrow>
+        ::build;
+    auto b = pro::proxy<Invoker>{};
+    size_t total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        LargeCaptureData data1, data2;
+        auto a1 = pro::make_proxy_inplace<Invoker>([data1]() { return data1.numbers.size() + data1.str.size(); });
+        auto a2 = pro::make_proxy_inplace<Invoker>([data2]() { return data2.numbers.size() + data2.str.size() + 1; });
+        b = std::move(toggle ? a1 : a2);
+        total += (*b)();
+        auto* volatile ff = &b;
+        volatile size_t u = (**ff)(); (void)u;
+        (void)total;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentLargeCapture);
 BENCHMARK_BASELINE(move_assign_large_capture_std);
 BENCHMARK_NOTBASE(move_assign_large_capture_ebd);
 BENCHMARK_NOTBASE(move_assign_large_capture_fu2);
+BENCHMARK_NOTBASE(move_assign_large_capture_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.CopyAssignment - Stateless Lambda (Small Buffer Optimization)
@@ -299,10 +390,32 @@ static void copy_assign_stateless_fu2(picobench::state& s) {
     }
 }
 
+static void copy_assign_stateless_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto a1 = pro::make_proxy_inplace<Invoker>(std::plus<int>{});
+    auto a2 = pro::make_proxy_inplace<Invoker>(std::minus<int>{});
+    auto b = pro::proxy<Invoker>{};
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        total = (*b)(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (**ff)(total, 1); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentStateless);
 BENCHMARK_BASELINE(copy_assign_stateless_std);
 BENCHMARK_NOTBASE(copy_assign_stateless_ebd);
 BENCHMARK_NOTBASE(copy_assign_stateless_fu2);
+BENCHMARK_NOTBASE(copy_assign_stateless_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.MoveAssignment - Stateless Lambda (Small Buffer Optimization)
@@ -356,10 +469,32 @@ static void move_assign_stateless_fu2(picobench::state& s) {
     }
 }
 
+static void move_assign_stateless_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto b = pro::proxy<Invoker>{};
+    int total = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = pro::make_proxy_inplace<Invoker>(std::plus<int>{});
+        auto a2 = pro::make_proxy_inplace<Invoker>(std::minus<int>{});
+        b = std::move(toggle ? a1 : a2);
+        total = (*b)(total, 1);
+        auto* volatile ff = &b;
+        volatile int u = (**ff)(total, 1); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentStateless);
 BENCHMARK_BASELINE(move_assign_stateless_std);
 BENCHMARK_NOTBASE(move_assign_stateless_ebd);
 BENCHMARK_NOTBASE(move_assign_stateless_fu2);
+BENCHMARK_NOTBASE(move_assign_stateless_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.CopyAssignment - Function Pointer
@@ -416,10 +551,32 @@ static void copy_assign_func_ptr_fu2(picobench::state& s) {
     }
 }
 
+static void copy_assign_func_ptr_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto a1 = pro::make_proxy_inplace<Invoker>(bench_func1);
+    auto a2 = pro::make_proxy_inplace<Invoker>(bench_func2);
+    auto b = pro::make_proxy_inplace<Invoker>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        result = (*b)(result);
+        auto* volatile ff = &b;
+        volatile int u = (**ff)(result); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentFuncPtr);
 BENCHMARK_BASELINE(copy_assign_func_ptr_std);
 BENCHMARK_NOTBASE(copy_assign_func_ptr_ebd);
 BENCHMARK_NOTBASE(copy_assign_func_ptr_fu2);
+BENCHMARK_NOTBASE(copy_assign_func_ptr_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.MoveAssignment - Function Pointer
@@ -473,10 +630,32 @@ static void move_assign_func_ptr_fu2(picobench::state& s) {
     }
 }
 
+static void move_assign_func_ptr_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto b = pro::make_proxy_inplace<Invoker>(bench_func1);
+    int result = 1;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = pro::make_proxy_inplace<Invoker>(bench_func1);
+        auto a2 = pro::make_proxy_inplace<Invoker>(bench_func2);
+        b = std::move(toggle ? a1 : a2);
+        result = (*b)(result);
+        auto* volatile ff = &b;
+        volatile int u = (**ff)(result); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentFuncPtr);
 BENCHMARK_BASELINE(move_assign_func_ptr_std);
 BENCHMARK_NOTBASE(move_assign_func_ptr_ebd);
 BENCHMARK_NOTBASE(move_assign_func_ptr_fu2);
+BENCHMARK_NOTBASE(move_assign_func_ptr_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.CopyAssignment - Between Same Type
@@ -536,10 +715,34 @@ static void copy_assign_same_type_fu2(picobench::state& s) {
     }
 }
 
+static void copy_assign_same_type_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void()>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto a1 = pro::make_proxy_inplace<Invoker>([]() {});
+    auto a2 = pro::make_proxy_inplace<Invoker>([]() {});
+    auto b = pro::make_proxy_inplace<Invoker>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        b = toggle ? a1 : a2;
+        (*b)();
+        dummy++;
+        auto* volatile ff = &b;
+        (**ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.CopyAssignmentSameType);
 BENCHMARK_BASELINE(copy_assign_same_type_std);
 BENCHMARK_NOTBASE(copy_assign_same_type_ebd);
 BENCHMARK_NOTBASE(copy_assign_same_type_fu2);
+BENCHMARK_NOTBASE(copy_assign_same_type_pro);
 
 // ----------------------------------------------------------------------------
 // AssignmentBenchmark.MoveAssignment - Between Same Type
@@ -599,7 +802,31 @@ static void move_assign_same_type_fu2(picobench::state& s) {
     }
 }
 
+static void move_assign_same_type_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void()>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    auto b = pro::make_proxy_inplace<Invoker>([]() {});
+    int dummy = 0;
+    bool toggle = false;
+
+    for (auto _ : s) {
+        toggle = !toggle;
+        auto a1 = pro::make_proxy_inplace<Invoker>([]() {});
+        auto a2 = pro::make_proxy_inplace<Invoker>([]() {});
+        b = std::move(toggle ? a1 : a2);
+        (*b)();
+        dummy++;
+        auto* volatile ff = &b;
+        (**ff)();
+        volatile int u = dummy; (void)u;
+    }
+}
+
 BENCHMARK_UNIT(AssignmentBenchmark.MoveAssignmentSameType);
 BENCHMARK_BASELINE(move_assign_same_type_std);
 BENCHMARK_NOTBASE(move_assign_same_type_ebd);
 BENCHMARK_NOTBASE(move_assign_same_type_fu2);
+BENCHMARK_NOTBASE(move_assign_same_type_pro);

--- a/benchmark/runtime/benchmark_create.cpp
+++ b/benchmark/runtime/benchmark_create.cpp
@@ -37,10 +37,27 @@ static void lambda_fu2(picobench::state& s) {
     }
 }
 
+static void lambda_pro(picobench::state& s) {
+    int a = 0;
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int()>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    for (auto _ : s) {
+        a++;
+        pro::proxy<Invoker> f = pro::make_proxy_inplace<Invoker>([a]() -> int { return a; });
+        auto* volatile ff = &f;
+        volatile int u = (**ff)(); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(CreateBenchmark.CaptureLambda);
 BENCHMARK_BASELINE(lambda_std);
 BENCHMARK_NOTBASE(lambda_ebd);
 BENCHMARK_NOTBASE(lambda_fu2);
+BENCHMARK_NOTBASE(lambda_pro);
 
 
 // ----------------------------------------------------------------------------
@@ -90,7 +107,25 @@ static void non_trivial_functor_fu2(picobench::state& s) {
     }
 }
 
+static void non_trivial_functor_pro(picobench::state& s) {
+    int a = 0;
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int()>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::support_relocation<pro::constraint_level::none>
+        ::build;
+
+    for (auto _ : s) {
+        a++;
+        pro::proxy<Invoker> f = pro::make_proxy_inplace<Invoker>(NonTrivialFunctor{a});
+        auto* volatile ff = &f;
+        volatile int u = (**ff)(); (void)u;
+    }
+}
+
 BENCHMARK_UNIT(CreateBenchmark.NonTrivialFunctor);
 BENCHMARK_BASELINE(non_trivial_functor_std);
 BENCHMARK_NOTBASE(non_trivial_functor_ebd);
 BENCHMARK_NOTBASE(non_trivial_functor_fu2);
+BENCHMARK_NOTBASE(non_trivial_functor_pro);

--- a/benchmark/runtime/benchmark_free_function.cpp
+++ b/benchmark/runtime/benchmark_free_function.cpp
@@ -40,9 +40,26 @@ static void free_scalar_fu2(picobench::state& s) {
     }
 }
 
+static void free_scalar_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int, int, int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    pro::proxy<Invoker> fn_scalar1_pro = pro::make_proxy_inplace<Invoker>(scalar_1);
+    pro::proxy<Invoker> fn_scalar2_pro = pro::make_proxy_inplace<Invoker>(scalar_2);
+
+    for (auto _ : s) {
+        (*fn_scalar1_pro)(0x111, 0x222, 0x333, 0x444);
+        (*fn_scalar2_pro)(0x222, 0x111, 0x333, 0x444);
+    }
+}
+
 BENCHMARK_BASELINE(free_scalar_std);
 BENCHMARK_NOTBASE(free_scalar_ebd);
 BENCHMARK_NOTBASE(free_scalar_fu2);
+BENCHMARK_NOTBASE(free_scalar_pro);
 
 
 BENCHMARK_UNIT(FreeFunction.TrivialParameters);
@@ -117,9 +134,31 @@ static void free_trivial_fu2(picobench::state& s) {
     }
 }
 
+static void free_trivial_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_trivial_struct, benchmark_trivial_struct,
+            benchmark_trivial_struct, benchmark_trivial_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    pro::proxy<Invoker> fn_trivial1_pro = pro::make_proxy_inplace<Invoker>(pass_trivial_args_1);
+    pro::proxy<Invoker> fn_trivial2_pro = pro::make_proxy_inplace<Invoker>(pass_trivial_args_2);
+
+    benchmark_trivial_struct trivial_;
+    trivial_.pod = nullptr;
+
+    for (auto _ : s) {
+        (*fn_trivial1_pro)(trivial_, trivial_, trivial_, trivial_);
+        (*fn_trivial2_pro)(trivial_, trivial_, trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(free_trivial_std);
 BENCHMARK_NOTBASE(free_trivial_ebd);
 BENCHMARK_NOTBASE(free_trivial_fu2);
+BENCHMARK_NOTBASE(free_trivial_pro);
 
 
 BENCHMARK_UNIT(FreeFunction.CopyHardParameters);
@@ -191,9 +230,30 @@ static void free_copyhard_fu2(picobench::state& s) {
     }
 }
 
+static void free_copyhard_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_copy_hard_struct, benchmark_copy_hard_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    pro::proxy<Invoker> fn_copy_hard1_pro = pro::make_proxy_inplace<Invoker>(pass_copy_hard_struct_1);
+    pro::proxy<Invoker> fn_copy_hard2_pro = pro::make_proxy_inplace<Invoker>(pass_copy_hard_struct_2);
+
+    benchmark_copy_hard_struct trivial_{};
+    fn_copy_hard1_pro.swap(fn_copy_hard2_pro);
+
+    for (auto _ : s) {
+        (*fn_copy_hard1_pro)(trivial_, trivial_);
+        (*fn_copy_hard2_pro)(trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(free_copyhard_std);
 BENCHMARK_NOTBASE(free_copyhard_ebd);
 BENCHMARK_NOTBASE(free_copyhard_fu2);
+BENCHMARK_NOTBASE(free_copyhard_pro);
 
 
 BENCHMARK_UNIT(FreeFunction.CallTrivialParameters);
@@ -266,9 +326,30 @@ static void free_calltrivial_fu2(picobench::state& s) {
     }
 }
 
+static void free_calltrivial_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    pro::proxy<Invoker> fn_trivial1_pro = pro::make_proxy_inplace<Invoker>(pass_call_trivial_args_1);
+    pro::proxy<Invoker> fn_trivial2_pro = pro::make_proxy_inplace<Invoker>(pass_call_trivial_args_2);
+
+    benchmark_call_trivial_struct trivial_{};
+
+    for (auto _ : s) {
+        (*fn_trivial1_pro)(trivial_, trivial_, trivial_, trivial_);
+        (*fn_trivial2_pro)(trivial_, trivial_, trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(free_calltrivial_std);
 BENCHMARK_NOTBASE(free_calltrivial_ebd);
 BENCHMARK_NOTBASE(free_calltrivial_fu2);
+BENCHMARK_NOTBASE(free_calltrivial_pro);
 
 
 BENCHMARK_UNIT(FreeFunction.CallWithStdStringAsParameters);
@@ -341,6 +422,27 @@ static void free_callstd_string_fu2(picobench::state& s) {
     }
 }
 
+static void free_callstd_string_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            std::string, std::string,
+            std::string, std::string)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    pro::proxy<Invoker> fn_std_string1_pro = pro::make_proxy_inplace<Invoker>(pass_call_std_string_args_1);
+    pro::proxy<Invoker> fn_std_string2_pro = pro::make_proxy_inplace<Invoker>(pass_call_std_string_args_2);
+
+    std::string std_string_{};
+
+    for (auto _ : s) {
+        (*fn_std_string1_pro)(std_string_, std_string_, std_string_, std_string_);
+        (*fn_std_string2_pro)(std_string_, std_string_, std_string_, std_string_);
+    }
+}
+
 BENCHMARK_BASELINE(free_callstd_string_std);
 BENCHMARK_NOTBASE(free_callstd_string_ebd);
 BENCHMARK_NOTBASE(free_callstd_string_fu2);
+BENCHMARK_NOTBASE(free_callstd_string_pro);

--- a/benchmark/runtime/benchmark_functor.cpp
+++ b/benchmark/runtime/benchmark_functor.cpp
@@ -68,9 +68,26 @@ static void functor_scalar_fu2(picobench::state& s) {
     }
 }
 
+static void functor_scalar_pro(picobench::state& s) {
+    functor_scalar f1, f2;
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int, int, int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    pro::proxy<Invoker> fn1 = pro::make_proxy_inplace<Invoker>(f1);
+    pro::proxy<Invoker> fn2 = pro::make_proxy_inplace<Invoker>(f2);
+
+    for (auto _ : s) {
+        (*fn1)(0x111, 0x222, 0x333, 0x444);
+        (*fn2)(0x222, 0x111, 0x333, 0x444);
+    }
+}
+
 BENCHMARK_BASELINE(functor_scalar_std);
 BENCHMARK_NOTBASE(functor_scalar_ebd);
 BENCHMARK_NOTBASE(functor_scalar_fu2);
+BENCHMARK_NOTBASE(functor_scalar_pro);
 
 
 // ----------------------------------------------------------------------------
@@ -136,9 +153,30 @@ static void functor_trivial_fu2(picobench::state& s) {
     }
 }
 
+static void functor_trivial_pro(picobench::state& s) {
+    functor_trivial f1, f2;
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_trivial_struct, benchmark_trivial_struct,
+            benchmark_trivial_struct, benchmark_trivial_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    pro::proxy<Invoker> fn1 = pro::make_proxy_inplace<Invoker>(f1);
+    pro::proxy<Invoker> fn2 = pro::make_proxy_inplace<Invoker>(f2);
+
+    benchmark_trivial_struct trivial_{nullptr};
+
+    for (auto _ : s) {
+        (*fn1)(trivial_, trivial_, trivial_, trivial_);
+        (*fn2)(trivial_, trivial_, trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(functor_trivial_std);
 BENCHMARK_NOTBASE(functor_trivial_ebd);
 BENCHMARK_NOTBASE(functor_trivial_fu2);
+BENCHMARK_NOTBASE(functor_trivial_pro);
 
 
 // ----------------------------------------------------------------------------
@@ -204,6 +242,27 @@ static void functor_calltrivial_fu2(picobench::state& s) {
     }
 }
 
+static void functor_calltrivial_pro(picobench::state& s) {
+    functor_call_trivial f1, f2;
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    pro::proxy<Invoker> fn1 = pro::make_proxy_inplace<Invoker>(f1);
+    pro::proxy<Invoker> fn2 = pro::make_proxy_inplace<Invoker>(f2);
+
+    benchmark_call_trivial_struct trivial_{};
+
+    for (auto _ : s) {
+        (*fn1)(trivial_, trivial_, trivial_, trivial_);
+        (*fn2)(trivial_, trivial_, trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(functor_calltrivial_std);
 BENCHMARK_NOTBASE(functor_calltrivial_ebd);
 BENCHMARK_NOTBASE(functor_calltrivial_fu2);
+BENCHMARK_NOTBASE(functor_calltrivial_pro);

--- a/benchmark/runtime/benchmark_lambda.cpp
+++ b/benchmark/runtime/benchmark_lambda.cpp
@@ -42,9 +42,27 @@ static void lambda_scalar_fu2(picobench::state& s) {
     }
 }
 
+static void lambda_scalar_pro(picobench::state& s) {
+    auto l1 = [](int, int, int, int) { volatile int unused = 1; (void)unused; return 0; };
+    auto l2 = [](int, int, int, int) { volatile int unused = 1; (void)unused; return 0; };
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int, int, int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    pro::proxy<Invoker> fn1 = pro::make_proxy_inplace<Invoker>(l1);
+    pro::proxy<Invoker> fn2 = pro::make_proxy_inplace<Invoker>(l2);
+
+    for (auto _ : s) {
+        (*fn1)(0x111, 0x222, 0x333, 0x444);
+        (*fn2)(0x222, 0x111, 0x333, 0x444);
+    }
+}
+
 BENCHMARK_BASELINE(lambda_scalar_std);
 BENCHMARK_NOTBASE(lambda_scalar_ebd);
 BENCHMARK_NOTBASE(lambda_scalar_fu2);
+BENCHMARK_NOTBASE(lambda_scalar_pro);
 
 
 // ----------------------------------------------------------------------------
@@ -90,11 +108,11 @@ static void lambda_trivial_ebd(picobench::state& s) {
 }
 
 static void lambda_trivial_fu2(picobench::state& s) {
-    auto l1 = [](benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct) { 
-        volatile int unused = 1; (void)unused; 
+    auto l1 = [](benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct) {
+        volatile int unused = 1; (void)unused;
     };
-    auto l2 = [](benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct) { 
-        volatile int unused = 2; (void)unused; 
+    auto l2 = [](benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct) {
+        volatile int unused = 2; (void)unused;
     };
     fu2::function<void(benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct)> fn1 = l1;
     fu2::function<void(benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct)> fn2 = l2;
@@ -107,9 +125,35 @@ static void lambda_trivial_fu2(picobench::state& s) {
     }
 }
 
+static void lambda_trivial_pro(picobench::state& s) {
+    auto l1 = [](benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct) {
+        volatile int unused = 1; (void)unused;
+    };
+    auto l2 = [](benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct, benchmark_trivial_struct) {
+        volatile int unused = 2; (void)unused;
+    };
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_trivial_struct, benchmark_trivial_struct,
+            benchmark_trivial_struct, benchmark_trivial_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    pro::proxy<Invoker> fn1 = pro::make_proxy_inplace<Invoker>(l1);
+    pro::proxy<Invoker> fn2 = pro::make_proxy_inplace<Invoker>(l2);
+
+    benchmark_trivial_struct trivial_{nullptr};
+
+    for (auto _ : s) {
+        (*fn1)(trivial_, trivial_, trivial_, trivial_);
+        (*fn2)(trivial_, trivial_, trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(lambda_trivial_std);
 BENCHMARK_NOTBASE(lambda_trivial_ebd);
 BENCHMARK_NOTBASE(lambda_trivial_fu2);
+BENCHMARK_NOTBASE(lambda_trivial_pro);
 
 
 // ----------------------------------------------------------------------------
@@ -155,11 +199,11 @@ static void lambda_calltrivial_ebd(picobench::state& s) {
 }
 
 static void lambda_calltrivial_fu2(picobench::state& s) {
-    auto l1 = [](benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct) { 
-        volatile int unused = 1; (void)unused; 
+    auto l1 = [](benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct) {
+        volatile int unused = 1; (void)unused;
     };
-    auto l2 = [](benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct) { 
-        volatile int unused = 2; (void)unused; 
+    auto l2 = [](benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct) {
+        volatile int unused = 2; (void)unused;
     };
     fu2::function<void(benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn1 = l1;
     fu2::function<void(benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn2 = l2;
@@ -172,6 +216,32 @@ static void lambda_calltrivial_fu2(picobench::state& s) {
     }
 }
 
+static void lambda_calltrivial_pro(picobench::state& s) {
+    auto l1 = [](benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct) {
+        volatile int unused = 1; (void)unused;
+    };
+    auto l2 = [](benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct, benchmark_call_trivial_struct) {
+        volatile int unused = 2; (void)unused;
+    };
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct)>
+        ::restrict_layout<ebd::fn<void()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+    pro::proxy<Invoker> fn1 = pro::make_proxy_inplace<Invoker>(l1);
+    pro::proxy<Invoker> fn2 = pro::make_proxy_inplace<Invoker>(l2);
+
+    benchmark_call_trivial_struct trivial_{};
+
+    for (auto _ : s) {
+        (*fn1)(trivial_, trivial_, trivial_, trivial_);
+        (*fn2)(trivial_, trivial_, trivial_, trivial_);
+    }
+}
+
 BENCHMARK_BASELINE(lambda_calltrivial_std);
 BENCHMARK_NOTBASE(lambda_calltrivial_ebd);
 BENCHMARK_NOTBASE(lambda_calltrivial_fu2);
+BENCHMARK_NOTBASE(lambda_calltrivial_pro);

--- a/benchmark/runtime/benchmark_move_only_function.cpp
+++ b/benchmark/runtime/benchmark_move_only_function.cpp
@@ -79,7 +79,7 @@ BENCHMARK_NOTBASE(scalar_params_pro);
 static void small_trivial_params_std(picobench::state& s) {
     std::move_only_function<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn = 
         [](benchmark_trivial_struct a, benchmark_trivial_struct b) { 
-            volatile void* res = a.pod;
+            void* volatile res = a.pod;
             (void)b; (void)res; 
         };
     benchmark_trivial_struct obj{};
@@ -92,7 +92,7 @@ static void small_trivial_params_std(picobench::state& s) {
 static void small_trivial_params_ebd(picobench::state& s) {
     ebd::unique_fn<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn = 
         [](benchmark_trivial_struct a, benchmark_trivial_struct b) { 
-            volatile void* res = a.pod;
+            void* volatile res = a.pod;
             (void)b; (void)res; 
         };
     benchmark_trivial_struct obj{};
@@ -105,7 +105,7 @@ static void small_trivial_params_ebd(picobench::state& s) {
 static void small_trivial_params_fu2(picobench::state& s) {
     fu2::unique_function<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn =
         [](benchmark_trivial_struct a, benchmark_trivial_struct b) {
-            volatile void* res = a.pod;
+            void* volatile res = a.pod;
             (void)b; (void)res;
         };
     benchmark_trivial_struct obj{};
@@ -123,7 +123,7 @@ static void small_trivial_params_pro(picobench::state& s) {
         ::build;
     pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
         [](benchmark_trivial_struct a, benchmark_trivial_struct b) {
-            volatile void* res = a.pod;
+            void* volatile res = a.pod;
             (void)b; (void)res;
         });
     benchmark_trivial_struct obj{};

--- a/benchmark/runtime/benchmark_move_only_function.cpp
+++ b/benchmark/runtime/benchmark_move_only_function.cpp
@@ -39,10 +39,10 @@ static void scalar_params_ebd(picobench::state& s) {
 }
 
 static void scalar_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(int, double, void*)> fn = 
-        [](int a, double b, void* c) { 
+    fu2::unique_function<void(int, double, void*)> fn =
+        [](int a, double b, void* c) {
             volatile int res = a + static_cast<int>(b);
-            (void)c; (void)res; 
+            (void)c; (void)res;
         };
 
     for (auto _ : s) {
@@ -50,10 +50,27 @@ static void scalar_params_fu2(picobench::state& s) {
     }
 }
 
+static void scalar_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(int, double, void*)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](int a, double b, void* c) {
+            volatile int res = a + static_cast<int>(b);
+            (void)c; (void)res;
+        });
+
+    for (auto _ : s) {
+        (*fn)(42, 3.14, nullptr);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.Scalar);
 BENCHMARK_BASELINE(scalar_params_std);
 BENCHMARK_NOTBASE(scalar_params_ebd);
 BENCHMARK_NOTBASE(scalar_params_fu2);
+BENCHMARK_NOTBASE(scalar_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 2: Small Trivial Struct (register-passable candidate)
@@ -86,10 +103,10 @@ static void small_trivial_params_ebd(picobench::state& s) {
 }
 
 static void small_trivial_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn = 
-        [](benchmark_trivial_struct a, benchmark_trivial_struct b) { 
+    fu2::unique_function<void(benchmark_trivial_struct, benchmark_trivial_struct)> fn =
+        [](benchmark_trivial_struct a, benchmark_trivial_struct b) {
             volatile void* res = a.pod;
-            (void)b; (void)res; 
+            (void)b; (void)res;
         };
     benchmark_trivial_struct obj{};
 
@@ -98,10 +115,29 @@ static void small_trivial_params_fu2(picobench::state& s) {
     }
 }
 
+static void small_trivial_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_trivial_struct, benchmark_trivial_struct)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](benchmark_trivial_struct a, benchmark_trivial_struct b) {
+            volatile void* res = a.pod;
+            (void)b; (void)res;
+        });
+    benchmark_trivial_struct obj{};
+
+    for (auto _ : s) {
+        (*fn)(obj, obj);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.SmallTrivial);
 BENCHMARK_BASELINE(small_trivial_params_std);
 BENCHMARK_NOTBASE(small_trivial_params_ebd);
 BENCHMARK_NOTBASE(small_trivial_params_fu2);
+BENCHMARK_NOTBASE(small_trivial_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 3: Multiple Trivial Params (4 params)
@@ -137,9 +173,9 @@ static void multi_trivial_params_ebd(picobench::state& s) {
 
 static void multi_trivial_params_fu2(picobench::state& s) {
     fu2::unique_function<void(benchmark_call_trivial_struct, benchmark_call_trivial_struct,
-                              benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn = 
-        [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b, 
-           benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) { 
+                              benchmark_call_trivial_struct, benchmark_call_trivial_struct)> fn =
+        [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b,
+           benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) {
             volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; (void)unused;
         };
     benchmark_call_trivial_struct obj{};
@@ -149,10 +185,30 @@ static void multi_trivial_params_fu2(picobench::state& s) {
     }
 }
 
+static void multi_trivial_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct,
+            benchmark_call_trivial_struct, benchmark_call_trivial_struct)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](benchmark_call_trivial_struct a, benchmark_call_trivial_struct b,
+           benchmark_call_trivial_struct c, benchmark_call_trivial_struct d) {
+            volatile int unused = 1; (void)a; (void)b; (void)c; (void)d; (void)unused;
+        });
+    benchmark_call_trivial_struct obj{};
+
+    for (auto _ : s) {
+        (*fn)(obj, obj, obj, obj);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.MultiTrivial);
 BENCHMARK_BASELINE(multi_trivial_params_std);
 BENCHMARK_NOTBASE(multi_trivial_params_ebd);
 BENCHMARK_NOTBASE(multi_trivial_params_fu2);
+BENCHMARK_NOTBASE(multi_trivial_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 4: Large Trivial Struct (not register-passable)
@@ -185,10 +241,10 @@ static void large_trivial_params_ebd(picobench::state& s) {
 }
 
 static void large_trivial_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(benchmark_huge_trivial_struct)> fn = 
-        [](benchmark_huge_trivial_struct a) { 
+    fu2::unique_function<void(benchmark_huge_trivial_struct)> fn =
+        [](benchmark_huge_trivial_struct a) {
             volatile char c = a.huge[0];
-            (void)c; 
+            (void)c;
         };
     benchmark_huge_trivial_struct obj{};
 
@@ -197,10 +253,28 @@ static void large_trivial_params_fu2(picobench::state& s) {
     }
 }
 
+static void large_trivial_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(benchmark_huge_trivial_struct)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](benchmark_huge_trivial_struct a) {
+            volatile char c = a.huge[0];
+            (void)c;
+        });
+    benchmark_huge_trivial_struct obj{};
+
+    for (auto _ : s) {
+        (*fn)(obj);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.LargeTrivial);
 BENCHMARK_BASELINE(large_trivial_params_std);
 BENCHMARK_NOTBASE(large_trivial_params_ebd);
 BENCHMARK_NOTBASE(large_trivial_params_fu2);
+BENCHMARK_NOTBASE(large_trivial_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 5: std::string Parameter
@@ -233,10 +307,10 @@ static void string_params_ebd(picobench::state& s) {
 }
 
 static void string_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(const std::string&)> fn = 
-        [](const std::string& str) { 
+    fu2::unique_function<void(const std::string&)> fn =
+        [](const std::string& str) {
             volatile size_t len = str.size();
-            (void)len; 
+            (void)len;
         };
     std::string test_str = "Hello, World! This is a test string for benchmarking.";
 
@@ -245,10 +319,28 @@ static void string_params_fu2(picobench::state& s) {
     }
 }
 
+static void string_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(const std::string&)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](const std::string& str) {
+            volatile size_t len = str.size();
+            (void)len;
+        });
+    std::string test_str = "Hello, World! This is a test string for benchmarking.";
+
+    for (auto _ : s) {
+        (*fn)(test_str);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.String);
 BENCHMARK_BASELINE(string_params_std);
 BENCHMARK_NOTBASE(string_params_ebd);
 BENCHMARK_NOTBASE(string_params_fu2);
+BENCHMARK_NOTBASE(string_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 6: Mixed Parameter Types (scalar + trivial + non-trivial)
@@ -283,10 +375,10 @@ static void mixed_params_ebd(picobench::state& s) {
 }
 
 static void mixed_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(int, benchmark_trivial_struct, const std::vector<int>&)> fn = 
-        [](int a, benchmark_trivial_struct b, const std::vector<int>& c) { 
+    fu2::unique_function<void(int, benchmark_trivial_struct, const std::vector<int>&)> fn =
+        [](int a, benchmark_trivial_struct b, const std::vector<int>& c) {
             volatile int res = a + static_cast<int>(c.size());
-            (void)b; (void)res; 
+            (void)b; (void)res;
         };
     benchmark_trivial_struct obj{};
     std::vector<int> vec = {1, 2, 3, 4, 5};
@@ -296,10 +388,30 @@ static void mixed_params_fu2(picobench::state& s) {
     }
 }
 
+static void mixed_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(
+            int, benchmark_trivial_struct, const std::vector<int>&)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](int a, benchmark_trivial_struct b, const std::vector<int>& c) {
+            volatile int res = a + static_cast<int>(c.size());
+            (void)b; (void)res;
+        });
+    benchmark_trivial_struct obj{};
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+
+    for (auto _ : s) {
+        (*fn)(42, obj, vec);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.Mixed);
 BENCHMARK_BASELINE(mixed_params_std);
 BENCHMARK_NOTBASE(mixed_params_ebd);
 BENCHMARK_NOTBASE(mixed_params_fu2);
+BENCHMARK_NOTBASE(mixed_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 7: Return Value (int)
@@ -326,7 +438,7 @@ static void return_int_ebd(picobench::state& s) {
 }
 
 static void return_int_fu2(picobench::state& s) {
-    fu2::unique_function<int(int, int)> fn = 
+    fu2::unique_function<int(int, int)> fn =
         [](int a, int b) { return a + b; };
 
     for (auto _ : s) {
@@ -335,10 +447,25 @@ static void return_int_fu2(picobench::state& s) {
     }
 }
 
+static void return_int_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int)>
+        ::restrict_layout<ebd::unique_fn<int()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](int a, int b) { return a + b; });
+
+    for (auto _ : s) {
+        volatile int res = (*fn)(100, 200);
+        (void)res;
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Return.Int);
 BENCHMARK_BASELINE(return_int_std);
 BENCHMARK_NOTBASE(return_int_ebd);
 BENCHMARK_NOTBASE(return_int_fu2);
+BENCHMARK_NOTBASE(return_int_pro);
 
 // ----------------------------------------------------------------------------
 // Test 8: Return Struct (by value)
@@ -381,12 +508,12 @@ static void return_struct_ebd(picobench::state& s) {
 }
 
 static void return_struct_fu2(picobench::state& s) {
-    fu2::unique_function<return_struct(int, double)> fn = 
-        [](int x, double y) { 
+    fu2::unique_function<return_struct(int, double)> fn =
+        [](int x, double y) {
             return_struct r{};
             r.a = x;
             r.b = y;
-            return r; 
+            return r;
         };
 
     for (auto _ : s) {
@@ -395,10 +522,30 @@ static void return_struct_fu2(picobench::state& s) {
     }
 }
 
+static void return_struct_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, return_struct(int, double)>
+        ::restrict_layout<ebd::unique_fn<return_struct()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](int x, double y) {
+            return_struct r{};
+            r.a = x;
+            r.b = y;
+            return r;
+        });
+
+    for (auto _ : s) {
+        volatile return_struct res = (*fn)(42, 3.14);
+        (void)res;
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Return.Struct);
 BENCHMARK_BASELINE(return_struct_std);
 BENCHMARK_NOTBASE(return_struct_ebd);
 BENCHMARK_NOTBASE(return_struct_fu2);
+BENCHMARK_NOTBASE(return_struct_pro);
 
 // ----------------------------------------------------------------------------
 // Test 9: std::array Params (fixed size)
@@ -431,10 +578,10 @@ static void array_params_ebd(picobench::state& s) {
 }
 
 static void array_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(std::array<int, 4>)> fn = 
-        [](std::array<int, 4> arr) { 
+    fu2::unique_function<void(std::array<int, 4>)> fn =
+        [](std::array<int, 4> arr) {
             volatile int sum = arr[0] + arr[1] + arr[2] + arr[3];
-            (void)sum; 
+            (void)sum;
         };
     std::array<int, 4> arr = {1, 2, 3, 4};
 
@@ -443,10 +590,28 @@ static void array_params_fu2(picobench::state& s) {
     }
 }
 
+static void array_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(std::array<int, 4>)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](std::array<int, 4> arr) {
+            volatile int sum = arr[0] + arr[1] + arr[2] + arr[3];
+            (void)sum;
+        });
+    std::array<int, 4> arr = {1, 2, 3, 4};
+
+    for (auto _ : s) {
+        (*fn)(arr);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.Array);
 BENCHMARK_BASELINE(array_params_std);
 BENCHMARK_NOTBASE(array_params_ebd);
 BENCHMARK_NOTBASE(array_params_fu2);
+BENCHMARK_NOTBASE(array_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 10: Copy Hard Struct (non-trivial)
@@ -479,10 +644,10 @@ static void copy_hard_params_ebd(picobench::state& s) {
 }
 
 static void copy_hard_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(benchmark_copy_hard_struct)> fn = 
-        [](benchmark_copy_hard_struct a) { 
+    fu2::unique_function<void(benchmark_copy_hard_struct)> fn =
+        [](benchmark_copy_hard_struct a) {
             volatile int dummy = 0;
-            (void)a; (void)dummy; 
+            (void)a; (void)dummy;
         };
     benchmark_copy_hard_struct obj{};
 
@@ -491,10 +656,28 @@ static void copy_hard_params_fu2(picobench::state& s) {
     }
 }
 
+static void copy_hard_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(benchmark_copy_hard_struct)>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](benchmark_copy_hard_struct a) {
+            volatile int dummy = 0;
+            (void)a; (void)dummy;
+        });
+    benchmark_copy_hard_struct obj{};
+
+    for (auto _ : s) {
+        (*fn)(obj);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.CopyHard);
 BENCHMARK_BASELINE(copy_hard_params_std);
 BENCHMARK_NOTBASE(copy_hard_params_ebd);
 BENCHMARK_NOTBASE(copy_hard_params_fu2);
+BENCHMARK_NOTBASE(copy_hard_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 11: Noexcept Qualified Function
@@ -525,10 +708,10 @@ static void noexcept_params_ebd(picobench::state& s) {
 }
 
 static void noexcept_params_fu2(picobench::state& s) {
-    fu2::unique_function<void(int, double) noexcept> fn = 
-        [](int a, double b) noexcept { 
+    fu2::unique_function<void(int, double) noexcept> fn =
+        [](int a, double b) noexcept {
             volatile int res = a + static_cast<int>(b);
-            (void)res; 
+            (void)res;
         };
 
     for (auto _ : s) {
@@ -536,10 +719,27 @@ static void noexcept_params_fu2(picobench::state& s) {
     }
 }
 
+static void noexcept_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, void(int, double) noexcept>
+        ::restrict_layout<ebd::unique_fn<void()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](int a, double b) noexcept {
+            volatile int res = a + static_cast<int>(b);
+            (void)res;
+        });
+
+    for (auto _ : s) {
+        (*fn)(42, 3.14);
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.Noexcept);
 BENCHMARK_BASELINE(noexcept_params_std);
 BENCHMARK_NOTBASE(noexcept_params_ebd);
 BENCHMARK_NOTBASE(noexcept_params_fu2);
+BENCHMARK_NOTBASE(noexcept_params_pro);
 
 // ----------------------------------------------------------------------------
 // Test 12: Const Qualified Function
@@ -566,7 +766,7 @@ static void const_params_ebd(picobench::state& s) {
 }
 
 static void const_params_fu2(picobench::state& s) {
-    fu2::unique_function<int(int, int) const> fn = 
+    fu2::unique_function<int(int, int) const> fn =
         [](int a, int b) { return a * b; };
 
     for (auto _ : s) {
@@ -575,9 +775,24 @@ static void const_params_fu2(picobench::state& s) {
     }
 }
 
+static void const_params_pro(picobench::state& s) {
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, int(int, int) const>
+        ::restrict_layout<ebd::unique_fn<int()>::get_buffer_size()>
+        ::build;
+    pro::proxy<Invoker> fn = pro::make_proxy_inplace<Invoker>(
+        [](int a, int b) { return a * b; });
+
+    for (auto _ : s) {
+        volatile int res = (*fn)(10, 20);
+        (void)res;
+    }
+}
+
 BENCHMARK_UNIT(MoveOnlyFunction.Params.Const);
 BENCHMARK_BASELINE(const_params_std);
 BENCHMARK_NOTBASE(const_params_ebd);
 BENCHMARK_NOTBASE(const_params_fu2);
+BENCHMARK_NOTBASE(const_params_pro);
 
 #endif

--- a/benchmark/runtime/benchmark_std_op.cpp
+++ b/benchmark/runtime/benchmark_std_op.cpp
@@ -67,9 +67,29 @@ static void std_op_wrapper_fn_view_fu2(picobench::state& s) {
     }
 }
 
+static void std_op_wrapper_fn_pro(picobench::state& s) {
+    auto less = std::less<int>{};
+    auto greater = std::greater<int>{};
+
+    using Invoker = pro::facade_builder
+        ::add_convention<pro::operator_dispatch<"()">, bool(int, int)>
+        ::restrict_layout<ebd::fn<int()>::get_buffer_size()>
+        ::support_copy<pro::constraint_level::nontrivial>
+        ::build;
+
+    auto f = [](pro::proxy<Invoker> f) { return (*f)(0x111, 0x222); };
+
+    for (auto _ : s) {
+        volatile bool res1 = f(pro::make_proxy_inplace<Invoker>(less));
+        volatile bool res2 = f(pro::make_proxy_inplace<Invoker>(greater));
+        (void)res1; (void)res2;
+    }
+}
+
 BENCHMARK_UNIT(StdOperatorWrapper.FunctionWrapperAsParams);
 BENCHMARK_BASELINE(std_op_wrapper_fn_std);
 BENCHMARK_NOTBASE(std_op_wrapper_fn_fu2);
 BENCHMARK_NOTBASE(std_op_wrapper_fn_ebd);
 BENCHMARK_NOTBASE(std_op_wrapper_fn_view_fu2);
 BENCHMARK_NOTBASE(std_op_wrapper_fn_ref_ebd);
+BENCHMARK_NOTBASE(std_op_wrapper_fn_pro);

--- a/benchmark/runtime/proxy/proxy.h
+++ b/benchmark/runtime/proxy/proxy.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_PROXY_H_
+#define MSFT_PROXY_PROXY_H_
+
+#include "v4/proxy.h" // IWYU pragma: export
+
+#endif // MSFT_PROXY_PROXY_H_

--- a/benchmark/runtime/proxy/proxy_fmt.h
+++ b/benchmark/runtime/proxy/proxy_fmt.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_PROXY_FMT_H_
+#define MSFT_PROXY_PROXY_FMT_H_
+
+#include "v4/proxy_fmt.h" // IWYU pragma: export
+
+#endif // MSFT_PROXY_PROXY_FMT_H_

--- a/benchmark/runtime/proxy/proxy_macros.h
+++ b/benchmark/runtime/proxy/proxy_macros.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_PROXY_MACROS_H_
+#define MSFT_PROXY_PROXY_MACROS_H_
+
+#include "v4/proxy_macros.h" // IWYU pragma: export
+
+#endif // MSFT_PROXY_PROXY_MACROS_H_

--- a/benchmark/runtime/proxy/v4/detail/compatibility_check.h
+++ b/benchmark/runtime/proxy/v4/detail/compatibility_check.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_COMPATIBILITY_CHECK_H_
+#define MSFT_PROXY_V4_DETAIL_COMPATIBILITY_CHECK_H_
+
+#if (defined(_MSVC_LANG) ? _MSVC_LANG : __cplusplus) < 202002L
+#error "Proxy requires C++20 or later."
+#endif
+
+// clang-cl miscalculates the layout of an empty [[msvc::no_unique_address]]
+// member in a base class (llvm/llvm-project#143245), corrupting pro::proxy.
+#if __has_cpp_attribute(msvc::no_unique_address)
+namespace pro::inline v4::detail::compatibility_check {
+struct empty {};
+struct base {
+  [[msvc::no_unique_address]] empty value;
+};
+struct derived : base {
+  char dummy;
+};
+static_assert(sizeof(derived) == sizeof(char),
+              "[[msvc::no_unique_address]] is broken");
+} // namespace pro::inline v4::detail::compatibility_check
+#endif
+
+#endif // MSFT_PROXY_V4_DETAIL_COMPATIBILITY_CHECK_H_

--- a/benchmark/runtime/proxy/v4/detail/core.h
+++ b/benchmark/runtime/proxy/v4/detail/core.h
@@ -1,0 +1,1548 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_CORE_H_
+#define MSFT_PROXY_V4_DETAIL_CORE_H_
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <initializer_list>
+#include <memory>
+#include <new>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "../proxy_macros.h"
+
+#if __has_cpp_attribute(msvc::no_unique_address)
+#define PRO4D_NO_UNIQUE_ADDRESS_ATTRIBUTE msvc::no_unique_address
+#elif __has_cpp_attribute(no_unique_address)
+#define PRO4D_NO_UNIQUE_ADDRESS_ATTRIBUTE no_unique_address
+#else
+#error Proxy requires C++20 attribute no_unique_address.
+#endif // __has_cpp_attribute(msvc::no_unique_address)
+
+#if __cpp_lib_unreachable >= 202202L
+#define PRO4D_UNREACHABLE() std::unreachable()
+#else
+#define PRO4D_UNREACHABLE() std::abort()
+#endif // __cpp_lib_unreachable >= 202202L
+
+namespace pro::inline v4 {
+
+namespace detail {
+
+template <class F>
+struct basic_facade_traits;
+
+} // namespace detail
+
+enum class constraint_level { none, nontrivial, nothrow, trivial };
+
+template <template <class> class O>
+struct facade_aware_overload_t {
+  facade_aware_overload_t() = delete;
+};
+
+template <class F>
+concept facade = detail::basic_facade_traits<F>::applicable;
+
+template <facade F>
+class proxy_indirect_accessor;
+template <facade F>
+class PRO4D_ENFORCE_EBO proxy;
+
+template <class T>
+struct is_bitwise_trivially_relocatable
+    : std::bool_constant<std::is_trivially_move_constructible_v<T> &&
+                         std::is_trivially_destructible_v<T>> {};
+template <class T>
+constexpr bool is_bitwise_trivially_relocatable_v =
+    is_bitwise_trivially_relocatable<T>::value;
+
+namespace detail {
+
+struct applicable_traits {
+  static constexpr bool applicable = true;
+};
+struct inapplicable_traits {
+  static constexpr bool applicable = false;
+};
+
+template <template <class, class> class R, class O, class... Is>
+struct recursive_reduction : std::type_identity<O> {};
+template <template <class, class> class R, class O, class I, class... Is>
+struct recursive_reduction<R, O, I, Is...>
+    : recursive_reduction<R, R<O, I>, Is...> {};
+template <template <class, class> class R, class O, class... Is>
+using recursive_reduction_t = typename recursive_reduction<R, O, Is...>::type;
+
+template <template <class...> class R, class... Args>
+struct reduction_traits {
+  template <class O, class I>
+  using type = typename R<Args..., O, I>::type;
+};
+
+template <class O, class I>
+struct composition_reduction : std::type_identity<O> {};
+template <template <class...> class T, class... Os, class I>
+  requires(!std::is_void_v<I>)
+struct composition_reduction<T<Os...>, I> : std::type_identity<T<Os..., I>> {};
+template <template <class...> class T, class... Os, class... Is>
+struct composition_reduction<T<Os...>, T<Is...>>
+    : std::type_identity<T<Os..., Is...>> {};
+template <class T, class... Us>
+using composite_t = recursive_reduction_t<
+    reduction_traits<composition_reduction>::template type, T, Us...>;
+
+template <class Expr>
+consteval bool is_consteval(Expr) {
+  return requires { typename std::bool_constant<(Expr{}(), false)>; };
+}
+template <class T, class U>
+concept static_prop = std::is_same_v<T, const U&>;
+
+template <class T, std::size_t I>
+concept has_tuple_element = requires { typename std::tuple_element_t<I, T>; };
+template <class T>
+consteval bool is_tuple_like_well_formed() {
+  if constexpr (requires {
+                  { std::tuple_size<T>::value } -> static_prop<std::size_t>;
+                }) {
+    if constexpr (is_consteval([] { return std::tuple_size<T>::value; })) {
+      return []<std::size_t... I>(std::index_sequence<I...>) {
+        return (has_tuple_element<T, I> && ...);
+      }(std::make_index_sequence<std::tuple_size_v<T>>{});
+    }
+  }
+  return false;
+}
+
+template <template <class...> class T, class TL, class Is, class... Args>
+struct specialization_type_traits_impl;
+template <template <class...> class T, class TL, std::size_t... Is,
+          class... Args>
+struct specialization_type_traits_impl<T, TL, std::index_sequence<Is...>,
+                                       Args...>
+    : std::type_identity<T<Args..., std::tuple_element_t<Is, TL>...>> {};
+template <template <class...> class T, class TL, class... Args>
+struct specialization_type_traits
+    : specialization_type_traits_impl<
+          T, TL, std::make_index_sequence<std::tuple_size_v<TL>>, Args...> {};
+template <template <class...> class T, class... Ts, class... Args>
+struct specialization_type_traits<T, std::tuple<Ts...>, Args...>
+    : std::type_identity<T<Args..., Ts...>> {};
+template <template <class...> class T, class TL, class... Args>
+using specialization_t =
+    typename specialization_type_traits<T, TL, Args...>::type;
+
+enum class qualifier_type { lv, const_lv, rv, const_rv };
+template <class T, qualifier_type Q>
+struct add_qualifier_traits;
+template <class T>
+struct add_qualifier_traits<T, qualifier_type::lv> : std::type_identity<T&> {};
+template <class T>
+struct add_qualifier_traits<T, qualifier_type::const_lv>
+    : std::type_identity<const T&> {};
+template <class T>
+struct add_qualifier_traits<T, qualifier_type::rv> : std::type_identity<T&&> {};
+template <class T>
+struct add_qualifier_traits<T, qualifier_type::const_rv>
+    : std::type_identity<const T&&> {};
+template <class T, qualifier_type Q>
+using add_qualifier_t = typename add_qualifier_traits<T, Q>::type;
+template <class T, qualifier_type Q>
+using add_qualifier_ptr_t = std::remove_reference_t<add_qualifier_t<T, Q>>*;
+
+template <class T, constraint_level CL>
+struct copyability_traits : inapplicable_traits {};
+template <class T>
+struct copyability_traits<T, constraint_level::none> : applicable_traits {};
+template <class T>
+  requires(std::is_copy_constructible_v<T>)
+struct copyability_traits<T, constraint_level::nontrivial> : applicable_traits {
+};
+template <class T>
+  requires(std::is_nothrow_copy_constructible_v<T>)
+struct copyability_traits<T, constraint_level::nothrow> : applicable_traits {};
+template <class T>
+  requires(std::is_trivially_copy_constructible_v<T>)
+struct copyability_traits<T, constraint_level::trivial> : applicable_traits {};
+
+template <class T, constraint_level CL>
+struct relocatability_traits : inapplicable_traits {};
+template <class T>
+struct relocatability_traits<T, constraint_level::none> : applicable_traits {};
+template <class T>
+  requires((std::is_move_constructible_v<T> && std::is_destructible_v<T>) ||
+           is_bitwise_trivially_relocatable_v<T>)
+struct relocatability_traits<T, constraint_level::nontrivial>
+    : applicable_traits {};
+template <class T>
+  requires((std::is_nothrow_move_constructible_v<T> &&
+            std::is_nothrow_destructible_v<T>) ||
+           is_bitwise_trivially_relocatable_v<T>)
+struct relocatability_traits<T, constraint_level::nothrow> : applicable_traits {
+};
+template <class T>
+  requires(is_bitwise_trivially_relocatable_v<T>)
+struct relocatability_traits<T, constraint_level::trivial> : applicable_traits {
+};
+
+template <class T, constraint_level CL>
+struct destructibility_traits : inapplicable_traits {};
+template <class T>
+struct destructibility_traits<T, constraint_level::none> : applicable_traits {};
+template <class T>
+  requires(std::is_destructible_v<T>)
+struct destructibility_traits<T, constraint_level::nontrivial>
+    : applicable_traits {};
+template <class T>
+  requires(std::is_nothrow_destructible_v<T>)
+struct destructibility_traits<T, constraint_level::nothrow>
+    : applicable_traits {};
+template <class T>
+  requires(std::is_trivially_destructible_v<T>)
+struct destructibility_traits<T, constraint_level::trivial>
+    : applicable_traits {};
+
+template <class F, bool IsDirect, qualifier_type Q>
+using proxy_accessor = add_qualifier_t<
+    std::conditional_t<IsDirect, proxy<F>, proxy_indirect_accessor<F>>, Q>;
+template <class F, qualifier_type Q>
+add_qualifier_t<proxy<F>, Q>
+    as_proxy(add_qualifier_t<proxy_indirect_accessor<F>, Q> p);
+
+struct proxy_helper {
+  template <class P, class F>
+  struct resetting_guard {
+    explicit resetting_guard(proxy<F>& p) noexcept : p_(p) {}
+    explicit resetting_guard(proxy_indirect_accessor<F>& p) noexcept
+        : p_(as_proxy<F, qualifier_type::lv>(p)) {}
+    ~resetting_guard() noexcept(std::is_nothrow_destructible_v<P>) {
+      std::destroy_at(std::addressof(get_ptr<P, F, qualifier_type::lv>(p_)));
+      p_.meta_.reset();
+    }
+
+  private:
+    proxy<F>& p_;
+  };
+
+  template <class M, class F>
+  static const M& get_meta(const proxy<F>& p) noexcept {
+    assert(p.has_value());
+    return static_cast<const M&>(*p.meta_.operator->());
+  }
+  template <class M, class F>
+  static const M& get_meta(const proxy_indirect_accessor<F>& p) noexcept {
+    return get_meta<M>(as_proxy<F, qualifier_type::const_lv>(p));
+  }
+  template <class P, class F, qualifier_type Q>
+  static add_qualifier_t<P, Q> get_ptr(add_qualifier_t<proxy<F>, Q> p) {
+    return static_cast<add_qualifier_t<P, Q>>(
+        *std::launder(reinterpret_cast<add_qualifier_ptr_t<P, Q>>(p.ptr_)));
+  }
+  template <class P, class F1, class F2>
+  static void trivially_relocate(proxy<F1>& from, proxy<F2>& to) noexcept {
+    std::uninitialized_copy_n(from.ptr_, sizeof(P), to.ptr_);
+    to.meta_ = decltype(proxy<F2>::meta_){std::in_place_type<P>};
+    from.meta_.reset();
+  }
+};
+
+template <class P, bool IsDirect, qualifier_type Q>
+struct operand_traits : add_qualifier_traits<P, Q> {};
+template <class P, qualifier_type Q>
+struct operand_traits<P, false, Q>
+    : std::type_identity<decltype(*std::declval<add_qualifier_t<P, Q>>())> {};
+template <class P, bool IsDirect, qualifier_type Q>
+using operand_t = typename operand_traits<P, IsDirect, Q>::type;
+template <class P, bool IsDirect, class D, qualifier_type Q, bool NE, class R,
+          class... Args>
+concept invocable_dispatch =
+    (IsDirect || (requires { *std::declval<add_qualifier_t<P, Q>>(); } &&
+                  (!NE || noexcept(*std::declval<add_qualifier_t<P, Q>>())))) &&
+    ((NE && std::is_nothrow_invocable_r_v<R, D, operand_t<P, IsDirect, Q>,
+                                          Args...>) ||
+     (!NE &&
+      std::is_invocable_r_v<R, D, operand_t<P, IsDirect, Q>, Args...>)) &&
+    (Q != qualifier_type::rv || (NE && std::is_nothrow_destructible_v<P>) ||
+     (!NE && std::is_destructible_v<P>));
+
+struct internal_dispatch {};
+
+template <class O>
+struct overload_traits : inapplicable_traits {};
+template <qualifier_type Q, bool NE, class R, class... Args>
+struct overload_traits_impl : applicable_traits {
+  using return_type = R;
+
+  template <class P, bool IsDirect, class D>
+  static constexpr bool applicable_ptr =
+      invocable_dispatch<P, IsDirect, D, Q, NE, R, Args...>;
+};
+template <class R, class... Args>
+struct overload_traits<R(Args...)>
+    : overload_traits_impl<qualifier_type::lv, false, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) noexcept>
+    : overload_traits_impl<qualifier_type::lv, true, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) &>
+    : overload_traits_impl<qualifier_type::lv, false, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) & noexcept>
+    : overload_traits_impl<qualifier_type::lv, true, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) &&>
+    : overload_traits_impl<qualifier_type::rv, false, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) && noexcept>
+    : overload_traits_impl<qualifier_type::rv, true, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) const>
+    : overload_traits_impl<qualifier_type::const_lv, false, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) const noexcept>
+    : overload_traits_impl<qualifier_type::const_lv, true, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) const&>
+    : overload_traits_impl<qualifier_type::const_lv, false, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) const & noexcept>
+    : overload_traits_impl<qualifier_type::const_lv, true, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) const&&>
+    : overload_traits_impl<qualifier_type::const_rv, false, R, Args...> {};
+template <class R, class... Args>
+struct overload_traits<R(Args...) const && noexcept>
+    : overload_traits_impl<qualifier_type::const_rv, true, R, Args...> {};
+template <class O>
+using ret_t = typename overload_traits<O>::return_type;
+
+template <class O>
+struct overload_substitution_traits : inapplicable_traits {
+  template <class>
+  using type = O;
+};
+template <template <class> class O>
+struct overload_substitution_traits<facade_aware_overload_t<O>>
+    : applicable_traits {
+  template <class F>
+  using type = O<F>;
+};
+template <class O, class F>
+using substituted_overload_t =
+    typename overload_substitution_traits<O>::template type<F>;
+template <class O>
+concept extended_overload = overload_traits<O>::applicable ||
+                            overload_substitution_traits<O>::applicable;
+template <class P, class F, bool IsDirect, class D, class O>
+consteval void diagnose_proxiable_required_convention_not_implemented() {
+  static_assert(overload_traits<O>::applicable &&
+                    overload_traits<O>::template applicable_ptr<P, IsDirect, D>,
+                "not proxiable due to a required convention not implemented");
+}
+
+template <class ProP, class D, class O>
+struct conv_meta;
+#define PRO4D_DEF_CONV_META(oq, pq, ne, ...)                                   \
+  template <class ProP, class D, class R, class... Args>                       \
+  struct conv_meta<ProP, D, R(Args...) oq ne> {                                \
+    conv_meta() = default;                                                     \
+    template <class P>                                                         \
+    constexpr explicit conv_meta(std::in_place_type_t<P>)                      \
+        : invoke([](ProP pq self, Args... args) ne -> R {                      \
+            return reinterpret_invoke<P, D, R>(static_cast<ProP pq>(self),     \
+                                               std::forward<Args>(args)...);   \
+          }) {}                                                                \
+                                                                               \
+    R (*invoke)(ProP pq, Args...) ne;                                          \
+  }
+PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(PRO4D_DEF_CONV_META)
+#undef PRO4D_DEF_CONV_META
+
+template <class... Ms>
+struct PRO4D_ENFORCE_EBO composite_meta : Ms... {
+  composite_meta() = default;
+  template <class P>
+  constexpr explicit composite_meta(std::in_place_type_t<P>)
+      : Ms(std::in_place_type<P>)... {}
+};
+
+template <class T>
+consteval bool is_is_direct_well_formed() {
+  if constexpr (requires {
+                  { T::is_direct } -> static_prop<bool>;
+                }) {
+    if constexpr (is_consteval([] { return T::is_direct; })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <class C, class... Os>
+struct basic_conv_traits_impl : inapplicable_traits {};
+template <class C, extended_overload... Os>
+  requires(sizeof...(Os) > 0u)
+struct basic_conv_traits_impl<C, Os...> : applicable_traits {};
+template <class C>
+struct basic_conv_traits : inapplicable_traits {};
+template <class C>
+  requires(requires {
+    { typename C::dispatch_type() } noexcept;
+    typename C::overload_types;
+  } && is_is_direct_well_formed<C>() &&
+           is_tuple_like_well_formed<typename C::overload_types>())
+struct basic_conv_traits<C>
+    : specialization_t<basic_conv_traits_impl, typename C::overload_types, C> {
+};
+
+template <class T>
+struct a11y_traits_impl
+    : std::conditional<std::is_nothrow_default_constructible_v<T> &&
+                           std::is_trivially_copyable_v<T> &&
+                           !std::is_final_v<T>,
+                       T, void> {};
+template <class SFINAE, class T, class... Args>
+struct a11y_traits : std::type_identity<void> {};
+template <class T, class... Args>
+struct a11y_traits<std::void_t<typename T::template accessor<Args...>>, T,
+                   Args...>
+    : a11y_traits_impl<typename T::template accessor<Args...>> {};
+template <class T, class... Args>
+using accessor_t = typename a11y_traits<void, T, Args...>::type;
+
+template <class C, class F, class... Os>
+struct conv_traits_impl {
+  static_assert((overload_traits<substituted_overload_t<Os, F>>::applicable &&
+                 ...));
+  using meta = composite_meta<conv_meta<
+      std::conditional_t<C::is_direct, proxy<F>, proxy_indirect_accessor<F>>,
+      typename C::dispatch_type, substituted_overload_t<Os, F>>...>;
+  template <class T>
+  using accessor =
+      accessor_t<typename C::dispatch_type, T, typename C::dispatch_type,
+                 substituted_overload_t<Os, F>...>;
+
+  template <class P>
+  static consteval void diagnose_proxiable() {
+    ((diagnose_proxiable_required_convention_not_implemented<
+         P, F, C::is_direct, typename C::dispatch_type,
+         substituted_overload_t<Os, F>>()),
+     ...);
+  }
+
+  template <class P>
+  static constexpr bool applicable_ptr =
+      (overload_traits<substituted_overload_t<Os, F>>::template applicable_ptr<
+           P, C::is_direct, typename C::dispatch_type> &&
+       ...);
+};
+template <class C, class F>
+struct conv_traits
+    : specialization_t<conv_traits_impl, typename C::overload_types, C, F> {};
+
+template <bool IsDirect, class R>
+struct reflection_meta {
+  reflection_meta() = default;
+  template <class P>
+    requires(IsDirect)
+  constexpr explicit reflection_meta(std::in_place_type_t<P>)
+      : reflector(std::in_place_type<P>) {}
+  template <class P>
+    requires(!IsDirect)
+  constexpr explicit reflection_meta(std::in_place_type_t<P>)
+      : reflector(
+            std::in_place_type<typename std::pointer_traits<P>::element_type>) {
+  }
+
+  [[PRO4D_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
+  R reflector;
+};
+
+template <class T, bool IsDirect, class R>
+consteval bool is_reflector_well_formed() {
+  if constexpr (IsDirect) {
+    if constexpr (std::is_constructible_v<R, std::in_place_type_t<T>>) {
+      return true;
+    }
+  } else {
+    return is_reflector_well_formed<
+        typename std::pointer_traits<T>::element_type, true, R>();
+  }
+  return false;
+}
+template <class P, class F, bool IsDirect, class R>
+consteval void diagnose_proxiable_required_reflection_not_implemented() {
+  static_assert(is_reflector_well_formed<P, IsDirect, R>(),
+                "not proxiable due to a required reflection not implemented");
+}
+
+struct copy_dispatch {
+  template <class T, class F>
+  PRO4D_STATIC_CALL(void, const T& self, proxy<F>& rhs) noexcept(
+      std::is_nothrow_copy_constructible_v<T>) {
+    std::construct_at(std::addressof(rhs), self);
+  }
+};
+struct relocate_dispatch : internal_dispatch {
+  template <class P, class F>
+  PRO4D_STATIC_CALL(void, std::in_place_type_t<P>, proxy<F>&& self,
+                    proxy<F>& rhs) noexcept {
+    proxy_helper::trivially_relocate<P>(self, rhs);
+  }
+  template <class T, class F>
+  PRO4D_STATIC_CALL(void, T&& self, proxy<F>& rhs) noexcept(
+      relocatability_traits<T, constraint_level::nothrow>::applicable) {
+    std::construct_at(std::addressof(rhs), std::forward<T>(self));
+  }
+};
+struct destroy_dispatch {
+  template <class T>
+  PRO4D_STATIC_CALL(void, T& self) noexcept(std::is_nothrow_destructible_v<T>) {
+    std::destroy_at(&self);
+  }
+};
+template <class F, class D, class ONE, class OE, constraint_level C>
+struct lifetime_meta_traits : std::type_identity<void> {};
+template <class F, class D, class ONE, class OE>
+struct lifetime_meta_traits<F, D, ONE, OE, constraint_level::nothrow>
+    : std::type_identity<conv_meta<proxy<F>, D, ONE>> {};
+template <class F, class D, class ONE, class OE>
+struct lifetime_meta_traits<F, D, ONE, OE, constraint_level::nontrivial>
+    : std::type_identity<conv_meta<proxy<F>, D, OE>> {};
+template <class F, class D, class ONE, class OE, constraint_level C>
+using lifetime_meta_t = typename lifetime_meta_traits<F, D, ONE, OE, C>::type;
+
+template <class... As>
+struct PRO4D_ENFORCE_EBO composite_accessor : As... {};
+
+template <class C, class F, bool IsDirect>
+struct conv_accessor_traits : std::type_identity<void> {};
+template <class C, class F>
+  requires(!C::is_direct)
+struct conv_accessor_traits<C, F, false>
+    : std::type_identity<typename conv_traits<C, F>::template accessor<
+          proxy_indirect_accessor<F>>> {};
+template <class C, class F>
+  requires(C::is_direct)
+struct conv_accessor_traits<C, F, true>
+    : std::type_identity<
+          typename conv_traits<C, F>::template accessor<proxy<F>>> {};
+template <class C, class F, bool IsDirect>
+using conv_accessor_t = typename conv_accessor_traits<C, F, IsDirect>::type;
+
+template <class R, class F, bool IsDirect>
+struct refl_accessor_traits : std::type_identity<void> {};
+template <class R, class F>
+  requires(!R::is_direct)
+struct refl_accessor_traits<R, F, false>
+    : std::type_identity<
+          accessor_t<typename R::reflector_type, proxy_indirect_accessor<F>,
+                     typename R::reflector_type>> {};
+template <class R, class F>
+  requires(R::is_direct)
+struct refl_accessor_traits<R, F, true>
+    : std::type_identity<accessor_t<typename R::reflector_type, proxy<F>,
+                                    typename R::reflector_type>> {};
+template <class R, class F, bool IsDirect>
+using refl_accessor_t = typename refl_accessor_traits<R, F, IsDirect>::type;
+
+template <class T>
+concept pointer_like = (std::is_pointer_v<T> ||
+    requires { typename T::element_type; } || requires(T val) { *val; }) &&
+    requires { typename std::pointer_traits<T>::element_type; };
+
+template <class T, template <class...> class TT>
+struct specialization_traits : inapplicable_traits {};
+template <template <class...> class TT, class... Args>
+struct specialization_traits<TT<Args...>, TT> : applicable_traits {};
+template <class T, template <class...> class TT>
+concept specialization_of = specialization_traits<T, TT>::applicable;
+
+template <class P, class F, std::size_t ActualSize, std::size_t MaxSize>
+consteval void diagnose_proxiable_size_too_large() {
+  static_assert(ActualSize <= MaxSize, "not proxiable due to size too large");
+}
+template <class P, class F, std::size_t ActualAlign, std::size_t MaxAlign>
+consteval void diagnose_proxiable_align_too_large() {
+  static_assert(ActualAlign <= MaxAlign,
+                "not proxiable due to alignment too large");
+}
+template <class P, class F, constraint_level RequiredCopyability>
+consteval void diagnose_proxiable_insufficient_copyability() {
+  static_assert(copyability_traits<P, RequiredCopyability>::applicable,
+                "not proxiable due to insufficient copyability");
+}
+template <class P, class F, constraint_level RequiredRelocatability>
+consteval void diagnose_proxiable_insufficient_relocatability() {
+  static_assert(relocatability_traits<P, RequiredRelocatability>::applicable,
+                "not proxiable due to insufficient relocatability");
+}
+template <class P, class F, constraint_level RequiredDestructibility>
+consteval void diagnose_proxiable_insufficient_destructibility() {
+  static_assert(destructibility_traits<P, RequiredDestructibility>::applicable,
+                "not proxiable due to insufficient destructibility");
+}
+
+consteval bool is_layout_well_formed(std::size_t size, std::size_t align) {
+  return size > 0u && std::has_single_bit(align) && size % align == 0u;
+}
+consteval bool is_cl_well_formed(constraint_level cl) {
+  return cl >= constraint_level::none && cl <= constraint_level::trivial;
+}
+template <class F>
+consteval bool is_facade_constraints_well_formed() {
+  if constexpr (requires {
+                  { F::max_size } -> static_prop<std::size_t>;
+                  { F::max_align } -> static_prop<std::size_t>;
+                  { F::copyability } -> static_prop<constraint_level>;
+                  { F::relocatability } -> static_prop<constraint_level>;
+                  { F::destructibility } -> static_prop<constraint_level>;
+                }) {
+    if constexpr (is_consteval([] {
+                    return std::tuple{F::max_size, F::max_align, F::copyability,
+                                      F::relocatability, F::destructibility};
+                  })) {
+      return is_layout_well_formed(F::max_size, F::max_align) &&
+             is_cl_well_formed(F::copyability) &&
+             is_cl_well_formed(F::relocatability) &&
+             is_cl_well_formed(F::destructibility);
+    }
+  }
+  return false;
+}
+template <class... Cs>
+struct basic_facade_conv_traits_impl : inapplicable_traits {};
+template <class... Cs>
+  requires(basic_conv_traits<Cs>::applicable && ...)
+struct basic_facade_conv_traits_impl<Cs...> : applicable_traits {};
+template <class... Rs>
+struct basic_facade_refl_traits_impl : inapplicable_traits {};
+template <class... Rs>
+  requires((requires {
+             typename Rs::reflector_type;
+           } && is_is_direct_well_formed<Rs>()) && ...)
+struct basic_facade_refl_traits_impl<Rs...> : applicable_traits {};
+template <class F>
+struct basic_facade_traits : inapplicable_traits {};
+template <class F>
+  requires(requires {
+    typename F::convention_types;
+    typename F::reflection_types;
+  } && is_facade_constraints_well_formed<F>() &&
+           is_tuple_like_well_formed<typename F::convention_types>() &&
+           specialization_t<basic_facade_conv_traits_impl,
+                            typename F::convention_types>::applicable &&
+           is_tuple_like_well_formed<typename F::reflection_types>() &&
+           specialization_t<basic_facade_refl_traits_impl,
+                            typename F::reflection_types>::applicable)
+struct basic_facade_traits<F> : applicable_traits {};
+
+template <class F, class... Cs>
+struct facade_conv_traits_impl {
+  using conv_meta =
+      composite_t<composite_meta<>, typename conv_traits<Cs, F>::meta...>;
+  using conv_indirect_accessor =
+      composite_t<composite_accessor<>, conv_accessor_t<Cs, F, false>...>;
+  using conv_direct_accessor =
+      composite_t<composite_accessor<>, conv_accessor_t<Cs, F, true>...>;
+
+  template <class P>
+  static consteval void diagnose_proxiable_conv() {
+    (conv_traits<Cs, F>::template diagnose_proxiable<P>(), ...);
+  }
+
+  template <class P>
+  static constexpr bool conv_applicable_ptr =
+      (conv_traits<Cs, F>::template applicable_ptr<P> && ...);
+};
+template <class F, class... Rs>
+struct facade_refl_traits_impl {
+  using refl_meta = composite_meta<
+      reflection_meta<Rs::is_direct, typename Rs::reflector_type>...>;
+  using refl_indirect_accessor =
+      composite_t<composite_accessor<>, refl_accessor_t<Rs, F, false>...>;
+  using refl_direct_accessor =
+      composite_t<composite_accessor<>, refl_accessor_t<Rs, F, true>...>;
+
+  template <class P>
+  static consteval void diagnose_proxiable_refl() {
+    (diagnose_proxiable_required_reflection_not_implemented<
+         P, F, Rs::is_direct, typename Rs::reflector_type>(),
+     ...);
+  }
+
+  template <class P>
+  static constexpr bool refl_applicable_ptr =
+      (is_reflector_well_formed<P, Rs::is_direct,
+                                typename Rs::reflector_type>() &&
+       ...);
+};
+template <class F>
+struct facade_traits : specialization_t<facade_conv_traits_impl,
+                                        typename F::convention_types, F>,
+                       specialization_t<facade_refl_traits_impl,
+                                        typename F::reflection_types, F> {
+  using meta = composite_t<
+      composite_meta<>,
+      lifetime_meta_t<F, copy_dispatch, void(proxy<F>&) const noexcept,
+                      void(proxy<F>&) const, F::copyability>,
+      lifetime_meta_t<F, relocate_dispatch, void(proxy<F>&) && noexcept,
+                      void(proxy<F>&) &&, F::relocatability>,
+      lifetime_meta_t<F, destroy_dispatch, void() noexcept, void(),
+                      F::destructibility>,
+      typename facade_traits::conv_meta, typename facade_traits::refl_meta>;
+  using indirect_accessor =
+      composite_t<typename facade_traits::conv_indirect_accessor,
+                  typename facade_traits::refl_indirect_accessor>;
+  using direct_accessor =
+      composite_t<typename facade_traits::conv_direct_accessor,
+                  typename facade_traits::refl_direct_accessor>;
+
+  template <class P>
+  [[noreturn]] static consteval void diagnose_proxiable_noreturn() {
+    diagnose_proxiable_size_too_large<P, F, sizeof(P), F::max_size>();
+    diagnose_proxiable_align_too_large<P, F, alignof(P), F::max_align>();
+    diagnose_proxiable_insufficient_copyability<P, F, F::copyability>();
+    diagnose_proxiable_insufficient_relocatability<P, F, F::relocatability>();
+    diagnose_proxiable_insufficient_destructibility<P, F, F::destructibility>();
+    facade_traits::template diagnose_proxiable_conv<P>();
+    facade_traits::template diagnose_proxiable_refl<P>();
+    PRO4D_UNREACHABLE(); // Propagate the error to the caller side
+  }
+
+  template <class P>
+  static constexpr bool applicable_ptr =
+      sizeof(P) <= F::max_size && alignof(P) <= F::max_align &&
+      copyability_traits<P, F::copyability>::applicable &&
+      relocatability_traits<P, F::relocatability>::applicable &&
+      destructibility_traits<P, F::destructibility>::applicable &&
+      facade_traits::template conv_applicable_ptr<P> &&
+      facade_traits::template refl_applicable_ptr<P>;
+};
+
+using ptr_prototype = void* [2];
+
+template <class M>
+struct meta_ptr_indirect_impl {
+  meta_ptr_indirect_impl() = default;
+  template <class P>
+  explicit meta_ptr_indirect_impl(std::in_place_type_t<P>)
+      : ptr_(&storage<P>) {}
+  bool has_value() const noexcept { return ptr_ != nullptr; }
+  void reset() noexcept { ptr_ = nullptr; }
+  const M* operator->() const noexcept { return ptr_; }
+
+private:
+  const M* ptr_;
+  template <class P>
+  static inline const M storage{std::in_place_type<P>};
+};
+template <class M, class DM>
+struct meta_ptr_direct_impl : private M {
+  using M::M;
+  bool has_value() const noexcept { return this->DM::invoke != nullptr; }
+  void reset() noexcept { this->DM::invoke = nullptr; }
+  const M* operator->() const noexcept { return this; }
+};
+template <class M>
+struct meta_ptr_traits_impl : std::type_identity<meta_ptr_indirect_impl<M>> {};
+template <class ProP, class D, class O, class... Ms>
+struct meta_ptr_traits_impl<composite_meta<conv_meta<ProP, D, O>, Ms...>>
+    : std::type_identity<
+          meta_ptr_direct_impl<composite_meta<conv_meta<ProP, D, O>, Ms...>,
+                               conv_meta<ProP, D, O>>> {};
+template <class M>
+struct meta_ptr_traits : std::type_identity<meta_ptr_indirect_impl<M>> {};
+template <class M>
+  requires(sizeof(M) <= sizeof(ptr_prototype) &&
+           alignof(M) <= alignof(ptr_prototype) &&
+           std::is_nothrow_default_constructible_v<M> &&
+           std::is_trivially_copyable_v<M>)
+struct meta_ptr_traits<M> : meta_ptr_traits_impl<M> {};
+template <class M>
+using meta_ptr = typename meta_ptr_traits<M>::type;
+
+template <class T>
+class inplace_ptr {
+public:
+  template <class... Args>
+  explicit inplace_ptr(std::in_place_t, Args&&... args)
+      : value_(std::forward<Args>(args)...) {}
+  inplace_ptr() = default;
+  inplace_ptr(const inplace_ptr&) = default;
+  inplace_ptr(inplace_ptr&&) = default;
+  inplace_ptr& operator=(const inplace_ptr&) = default;
+  inplace_ptr& operator=(inplace_ptr&&) = default;
+
+  T* operator->() noexcept { return std::addressof(value_); }
+  const T* operator->() const noexcept { return std::addressof(value_); }
+  T& operator*() & noexcept { return value_; }
+  const T& operator*() const& noexcept { return value_; }
+  T&& operator*() && noexcept { return std::move(value_); }
+  const T&& operator*() const&& noexcept { return std::move(value_); }
+
+private:
+  [[PRO4D_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
+  T value_;
+};
+
+template <class D, class O, class P, class... Args>
+ret_t<O> invoke_impl(P&& p, Args&&... args) {
+  return proxy_helper::get_meta<conv_meta<std::remove_cvref_t<P>, D, O>>(p)
+      .invoke(std::forward<P>(p), std::forward<Args>(args)...);
+}
+template <class F, qualifier_type Q>
+add_qualifier_t<proxy<F>, Q>
+    as_proxy(add_qualifier_t<proxy_indirect_accessor<F>, Q> p) {
+  return static_cast<add_qualifier_t<proxy<F>, Q>>(
+      *reinterpret_cast<
+          add_qualifier_ptr_t<inplace_ptr<proxy_indirect_accessor<F>>, Q>>(
+          std::addressof(p)));
+}
+template <class P, class F, bool IsDirect, qualifier_type Q>
+operand_t<P, IsDirect, Q> get_operand(proxy_accessor<F, IsDirect, Q> p) {
+  if constexpr (IsDirect) {
+    return proxy_helper::get_ptr<P, F, Q>(
+        std::forward<proxy_accessor<F, IsDirect, Q>>(p));
+  } else {
+    add_qualifier_t<P, Q> ptr = proxy_helper::get_ptr<P, F, Q>(
+        as_proxy<F, Q>(std::forward<proxy_accessor<F, IsDirect, Q>>(p)));
+    if constexpr (std::is_constructible_v<bool, P&>) {
+      assert(ptr);
+    }
+    return *std::forward<add_qualifier_t<P, Q>>(ptr);
+  }
+}
+
+// When a dispatch always throws, MSVC may incorrectly warn about unreachable
+// code (C4702). Disable the warning for invoke_dispatch().
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif // defined(_MSC_VER) && !defined(__clang__)
+template <class D, class R, class... Args>
+R invoke_dispatch(Args&&... args) {
+  if constexpr (std::is_void_v<R>) {
+    D()(std::forward<Args>(args)...);
+  } else {
+    return D()(std::forward<Args>(args)...);
+  }
+}
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif // defined(_MSC_VER) && !defined(__clang__)
+template <class P, class F, bool IsDirect, qualifier_type Q, class D, class R,
+          class... Args>
+R reinterpret_invoke(proxy_accessor<F, IsDirect, Q> self, Args&&... args) {
+  if constexpr (Q == qualifier_type::rv) {
+    if constexpr (std::is_base_of_v<internal_dispatch, D> &&
+                  is_bitwise_trivially_relocatable_v<P>) {
+      return D()(std::in_place_type<P>, std::move(self),
+                 std::forward<Args>(args)...);
+    } else {
+      proxy_helper::resetting_guard<P, F> guard{self};
+      return invoke_dispatch<D, R>(
+          get_operand<P, F, IsDirect, Q>(std::move(self)),
+          std::forward<Args>(args)...);
+    }
+  } else {
+    return invoke_dispatch<D, R>(
+        get_operand<P, F, IsDirect, Q>(
+            std::forward<proxy_accessor<F, IsDirect, Q>>(self)),
+        std::forward<Args>(args)...);
+  }
+}
+
+} // namespace detail
+
+template <class P, class F>
+concept proxiable = facade<F> && detail::pointer_like<P> &&
+                    detail::facade_traits<F>::template applicable_ptr<P>;
+
+template <facade F>
+class proxy_indirect_accessor
+    : public detail::facade_traits<F>::indirect_accessor {
+  friend class detail::inplace_ptr<proxy_indirect_accessor>;
+  proxy_indirect_accessor() = default;
+  proxy_indirect_accessor(const proxy_indirect_accessor&) = default;
+  proxy_indirect_accessor& operator=(const proxy_indirect_accessor&) = default;
+
+public:
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(proxy_indirect_accessor& p, Args&&... args) {
+    return detail::invoke_impl<D, O>(p, std::forward<Args>(args)...);
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(const proxy_indirect_accessor& p,
+                                 Args&&... args) {
+    return detail::invoke_impl<D, O>(p, std::forward<Args>(args)...);
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(proxy_indirect_accessor&& p, Args&&... args) {
+    return detail::invoke_impl<D, O>(std::move(p), std::forward<Args>(args)...);
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(const proxy_indirect_accessor&& p,
+                                 Args&&... args) {
+    return detail::invoke_impl<D, O>(std::move(p), std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(proxy_indirect_accessor& p, Args&&... args) {
+    return detail::reinterpret_invoke<P, F, false, detail::qualifier_type::lv,
+                                      D, R>(p, std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(const proxy_indirect_accessor& p,
+                              Args&&... args) {
+    return detail::reinterpret_invoke<P, F, false,
+                                      detail::qualifier_type::const_lv, D, R>(
+        p, std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(proxy_indirect_accessor&& p, Args&&... args) {
+    return detail::reinterpret_invoke<P, F, false, detail::qualifier_type::rv,
+                                      D, R>(std::move(p),
+                                            std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(const proxy_indirect_accessor&& p,
+                              Args&&... args) {
+    return detail::reinterpret_invoke<P, F, false,
+                                      detail::qualifier_type::const_rv, D, R>(
+        std::move(p), std::forward<Args>(args)...);
+  }
+  template <class R>
+  friend const R& reflect(const proxy_indirect_accessor& p) noexcept {
+    return detail::proxy_helper::get_meta<detail::reflection_meta<false, R>>(p)
+        .reflector;
+  }
+};
+
+template <facade F>
+class proxy : public detail::facade_traits<F>::direct_accessor,
+              public detail::inplace_ptr<proxy_indirect_accessor<F>> {
+  friend struct detail::proxy_helper;
+
+public:
+  using facade_type = F;
+
+  proxy() noexcept { initialize(); }
+  proxy(std::nullptr_t) noexcept : proxy() {}
+  proxy(const proxy&) noexcept
+    requires(F::copyability == constraint_level::trivial)
+  = default;
+  proxy(const proxy& rhs) noexcept(F::copyability == constraint_level::nothrow)
+    requires(F::copyability == constraint_level::nontrivial ||
+             F::copyability == constraint_level::nothrow)
+      : detail::inplace_ptr<proxy_indirect_accessor<F>>() /* Make GCC happy */ {
+    initialize(rhs);
+  }
+  proxy(proxy&& rhs) noexcept(F::relocatability >= constraint_level::nothrow)
+    requires(F::relocatability >= constraint_level::nontrivial &&
+             F::copyability != constraint_level::trivial)
+  {
+    initialize(std::move(rhs));
+  }
+  template <class P>
+  constexpr proxy(P&& ptr) noexcept(
+      std::is_nothrow_constructible_v<std::decay_t<P>, P>)
+    requires(!detail::specialization_of<std::decay_t<P>, proxy> &&
+             detail::pointer_like<std::decay_t<P>> &&
+             std::is_constructible_v<std::decay_t<P>, P>)
+  {
+    initialize<std::decay_t<P>>(std::forward<P>(ptr));
+  }
+  template <class P, class... Args>
+  constexpr explicit proxy(std::in_place_type_t<P>, Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<P, Args...>)
+    requires(detail::pointer_like<P> && std::is_constructible_v<P, Args...>)
+  {
+    initialize<P>(std::forward<Args>(args)...);
+  }
+  template <class P, class U, class... Args>
+  constexpr explicit proxy(
+      std::in_place_type_t<P>, std::initializer_list<U> il,
+      Args&&... args) noexcept(std::
+                                   is_nothrow_constructible_v<
+                                       P, std::initializer_list<U>&, Args...>)
+    requires(detail::pointer_like<P> &&
+             std::is_constructible_v<P, std::initializer_list<U>&, Args...>)
+  {
+    initialize<P>(il, std::forward<Args>(args)...);
+  }
+  proxy& operator=(std::nullptr_t) noexcept(F::destructibility >=
+                                            constraint_level::nothrow)
+    requires(F::destructibility >= constraint_level::nontrivial)
+  {
+    reset();
+    return *this;
+  }
+  proxy& operator=(const proxy&) noexcept
+    requires(F::copyability == constraint_level::trivial)
+  = default;
+  proxy& operator=(const proxy& rhs) noexcept(F::copyability >=
+                                                  constraint_level::nothrow &&
+                                              F::destructibility >=
+                                                  constraint_level::nothrow)
+    requires((F::copyability == constraint_level::nontrivial ||
+              F::copyability == constraint_level::nothrow) &&
+             F::destructibility >= constraint_level::nontrivial)
+  {
+    if (this != std::addressof(rhs)) [[likely]] {
+      if constexpr (F::copyability == constraint_level::nothrow) {
+        destroy();
+        initialize(rhs);
+      } else {
+        *this = proxy{rhs};
+      }
+    }
+    return *this;
+  }
+  proxy& operator=(proxy&& rhs) noexcept(F::relocatability >=
+                                             constraint_level::nothrow &&
+                                         F::destructibility >=
+                                             constraint_level::nothrow)
+    requires(F::relocatability >= constraint_level::nontrivial &&
+             F::destructibility >= constraint_level::nontrivial &&
+             F::copyability != constraint_level::trivial)
+  {
+    if (this != std::addressof(rhs)) [[likely]] {
+      reset();
+      initialize(std::move(rhs));
+    }
+    return *this;
+  }
+  template <class P>
+  constexpr proxy& operator=(P&& ptr) noexcept(
+      std::is_nothrow_constructible_v<std::decay_t<P>, P> &&
+      F::destructibility >= constraint_level::nothrow)
+    requires(!detail::specialization_of<std::decay_t<P>, proxy> &&
+             detail::pointer_like<std::decay_t<P>> &&
+             std::is_constructible_v<std::decay_t<P>, P> &&
+             F::destructibility >= constraint_level::nontrivial)
+  {
+    if constexpr (std::is_nothrow_constructible_v<std::decay_t<P>, P>) {
+      destroy();
+      initialize<std::decay_t<P>>(std::forward<P>(ptr));
+    } else {
+      *this = proxy{std::forward<P>(ptr)};
+    }
+    return *this;
+  }
+  ~proxy()
+    requires(F::destructibility == constraint_level::trivial)
+  = default;
+  ~proxy() noexcept(F::destructibility == constraint_level::nothrow)
+    requires(F::destructibility == constraint_level::nontrivial ||
+             F::destructibility == constraint_level::nothrow)
+  {
+    destroy();
+  }
+
+  bool has_value() const noexcept { return meta_.has_value(); }
+  explicit operator bool() const noexcept { return meta_.has_value(); }
+  void reset() noexcept(F::destructibility >= constraint_level::nothrow)
+    requires(F::destructibility >= constraint_level::nontrivial)
+  {
+    destroy();
+    initialize();
+  }
+  void swap(proxy& rhs) noexcept(F::relocatability >=
+                                     constraint_level::nothrow ||
+                                 F::copyability == constraint_level::trivial)
+    requires(F::relocatability >= constraint_level::nontrivial ||
+             F::copyability == constraint_level::trivial)
+  {
+    if constexpr (F::relocatability == constraint_level::trivial ||
+                  F::copyability == constraint_level::trivial) {
+      std::swap(meta_, rhs.meta_);
+#ifdef __INTEL_LLVM_COMPILER
+      // Workaround: Intel oneAPI compiler (as of 2025.2.0) may over-optimize
+      // the swap below, causing unit tests failure
+      std::byte temp[F::max_size];
+      std::ranges::uninitialized_copy(ptr_, temp);
+      std::ranges::uninitialized_copy(rhs.ptr_, ptr_);
+      std::ranges::uninitialized_copy(temp, rhs.ptr_);
+#else
+      std::swap(ptr_, rhs.ptr_);
+#endif // __INTEL_LLVM_COMPILER
+    } else {
+      if (meta_.has_value()) {
+        if (rhs.meta_.has_value()) {
+          proxy temp = std::move(*this);
+          initialize(std::move(rhs));
+          rhs.initialize(std::move(temp));
+        } else {
+          rhs.initialize(std::move(*this));
+        }
+      } else if (rhs.meta_.has_value()) {
+        initialize(std::move(rhs));
+      }
+    }
+  }
+  template <class P, class... Args>
+  constexpr P& emplace(Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<P, Args...> &&
+      F::destructibility >= constraint_level::nothrow)
+    requires(detail::pointer_like<P> && std::is_constructible_v<P, Args...> &&
+             F::destructibility >= constraint_level::nontrivial)
+  {
+    reset();
+    return initialize<P>(std::forward<Args>(args)...);
+  }
+  template <class P, class U, class... Args>
+  constexpr P& emplace(std::initializer_list<U> il, Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<P, std::initializer_list<U>&, Args...> &&
+      F::destructibility >= constraint_level::nothrow)
+    requires(detail::pointer_like<P> &&
+             std::is_constructible_v<P, std::initializer_list<U>&, Args...> &&
+             F::destructibility >= constraint_level::nontrivial)
+  {
+    reset();
+    return initialize<P>(il, std::forward<Args>(args)...);
+  }
+
+  friend void swap(proxy& lhs, proxy& rhs) noexcept(noexcept(lhs.swap(rhs)))
+    requires(requires { lhs.swap(rhs); })
+  {
+    lhs.swap(rhs);
+  }
+  friend bool operator==(const proxy& lhs, std::nullptr_t) noexcept {
+    return !lhs.has_value();
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(proxy& p, Args&&... args) {
+    return detail::invoke_impl<D, O>(p, std::forward<Args>(args)...);
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(const proxy& p, Args&&... args) {
+    return detail::invoke_impl<D, O>(p, std::forward<Args>(args)...);
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(proxy&& p, Args&&... args) {
+    return detail::invoke_impl<D, O>(std::move(p), std::forward<Args>(args)...);
+  }
+  template <class D, class O, class... Args>
+  friend detail::ret_t<O> invoke(const proxy&& p, Args&&... args) {
+    return detail::invoke_impl<D, O>(std::move(p), std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(proxy& p, Args&&... args) {
+    return detail::reinterpret_invoke<P, F, true, detail::qualifier_type::lv, D,
+                                      R>(p, std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(const proxy& p, Args&&... args) {
+    return detail::reinterpret_invoke<P, F, true,
+                                      detail::qualifier_type::const_lv, D, R>(
+        p, std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(proxy&& p, Args&&... args) {
+    return detail::reinterpret_invoke<P, F, true, detail::qualifier_type::rv, D,
+                                      R>(std::move(p),
+                                         std::forward<Args>(args)...);
+  }
+  template <class P, class D, class R, class... Args>
+  friend R reinterpret_invoke(const proxy&& p, Args&&... args) {
+    return detail::reinterpret_invoke<P, F, true,
+                                      detail::qualifier_type::const_rv, D, R>(
+        std::move(p), std::forward<Args>(args)...);
+  }
+  template <class R>
+  friend const R& reflect(const proxy& p) noexcept {
+    return detail::proxy_helper::get_meta<detail::reflection_meta<true, R>>(p)
+        .reflector;
+  }
+
+private:
+  void initialize() {
+    PRO4D_DEBUG(std::ignore = &pro_symbol_guard;)
+    meta_.reset();
+  }
+  void initialize(const proxy& rhs)
+    requires(F::copyability != constraint_level::none)
+  {
+    PRO4D_DEBUG(std::ignore = &pro_symbol_guard;)
+    if (rhs.meta_.has_value()) {
+      if constexpr (F::copyability == constraint_level::trivial) {
+        std::ranges::uninitialized_copy(rhs.ptr_, ptr_);
+        meta_ = rhs.meta_;
+      } else {
+        invoke<detail::copy_dispatch,
+               void(proxy&) const noexcept(
+                   F::copyability == constraint_level::nothrow)>(rhs, *this);
+      }
+    } else {
+      meta_.reset();
+    }
+  }
+  void initialize(proxy&& rhs)
+    requires(F::relocatability != constraint_level::none)
+  {
+    PRO4D_DEBUG(std::ignore = &pro_symbol_guard;)
+    if (rhs.meta_.has_value()) {
+      if constexpr (F::relocatability == constraint_level::trivial) {
+        std::ranges::uninitialized_copy(rhs.ptr_, ptr_);
+        meta_ = rhs.meta_;
+        rhs.meta_.reset();
+      } else {
+        invoke<detail::relocate_dispatch,
+               void(proxy&) &&
+                   noexcept(F::relocatability == constraint_level::nothrow)>(
+            std::move(rhs), *this);
+      }
+    } else {
+      meta_.reset();
+    }
+  }
+  template <class P, class... Args>
+  constexpr P& initialize(Args&&... args) {
+    PRO4D_DEBUG(std::ignore = &pro_symbol_guard;)
+    P& result = *std::construct_at(reinterpret_cast<P*>(ptr_),
+                                   std::forward<Args>(args)...);
+    if constexpr (proxiable<P, F>) {
+      meta_ = detail::meta_ptr<typename detail::facade_traits<F>::meta>{
+          std::in_place_type<P>};
+    } else {
+      detail::facade_traits<F>::template diagnose_proxiable_noreturn<P>();
+    }
+    return result;
+  }
+  void destroy()
+    requires(F::destructibility != constraint_level::none)
+  {
+    if constexpr (F::destructibility != constraint_level::trivial) {
+      if (meta_.has_value()) {
+        invoke<detail::destroy_dispatch,
+               void() noexcept(F::destructibility ==
+                               constraint_level::nothrow)>(*this);
+      }
+    }
+  }
+  PRO4D_DEBUG(static inline void pro_symbol_guard(proxy& self,
+                                                  const proxy& cself) {
+    self.operator->();
+    *self;
+    *std::move(self);
+    cself.operator->();
+    *cself;
+    *std::move(cself);
+  })
+
+  detail::meta_ptr<typename detail::facade_traits<F>::meta> meta_;
+  alignas(F::max_align) std::byte ptr_[F::max_size];
+};
+
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(proxy_indirect_accessor<F>& p, Args&&... args) {
+  return invoke<D, O>(p, std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(const proxy_indirect_accessor<F>& p, Args&&... args) {
+  return invoke<D, O>(p, std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(proxy_indirect_accessor<F>&& p, Args&&... args) {
+  return invoke<D, O>(std::move(p), std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(const proxy_indirect_accessor<F>&& p, Args&&... args) {
+  return invoke<D, O>(std::move(p), std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(proxy<F>& p, Args&&... args) {
+  return invoke<D, O>(p, std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(const proxy<F>& p, Args&&... args) {
+  return invoke<D, O>(p, std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(proxy<F>&& p, Args&&... args) {
+  return invoke<D, O>(std::move(p), std::forward<Args>(args)...);
+}
+template <class D, class O, facade F, class... Args>
+[[deprecated("Use unqualified invoke instead")]] detail::ret_t<O>
+    proxy_invoke(const proxy<F>&& p, Args&&... args) {
+  return invoke<D, O>(std::move(p), std::forward<Args>(args)...);
+}
+
+template <class R, facade F>
+[[deprecated("Use unqualified reflect instead")]] const R&
+    proxy_reflect(const proxy_indirect_accessor<F>& p) noexcept {
+  return reflect<R>(p);
+}
+template <class R, facade F>
+[[deprecated("Use unqualified reflect instead")]] const R&
+    proxy_reflect(const proxy<F>& p) noexcept {
+  return reflect<R>(p);
+}
+
+struct substitution_dispatch;
+
+template <facade F>
+struct observer_facade;
+template <facade F>
+using proxy_view = proxy<observer_facade<F>>;
+
+template <facade F>
+struct weak_facade;
+template <facade F>
+using weak_proxy = proxy<weak_facade<F>>;
+
+namespace detail {
+
+template <class F>
+struct converter {
+  explicit converter(F f) noexcept : f_(std::move(f)) {}
+  converter(const converter&) = delete;
+  template <class T>
+  operator T() && noexcept(
+      std::is_nothrow_invocable_r_v<T, F, std::in_place_type_t<T>>)
+    requires(std::is_invocable_r_v<T, F, std::in_place_type_t<T>> &&
+             !std::is_invocable_r_v<T, F, std::in_place_type_t<T&>> &&
+             !std::is_invocable_r_v<T, F, std::in_place_type_t<T &&>>)
+  {
+    return std::move(f_)(std::in_place_type<T>);
+  }
+  template <class T>
+  operator T&() && noexcept(
+      std::is_nothrow_invocable_r_v<T&, F, std::in_place_type_t<T&>>)
+    requires(std::is_invocable_r_v<T&, F, std::in_place_type_t<T&>>)
+  {
+    return std::move(f_)(std::in_place_type<T&>);
+  }
+  template <class T>
+  operator T&&() && noexcept(
+      std::is_nothrow_invocable_r_v<T&&, F, std::in_place_type_t<T&&>>)
+    requires(std::is_invocable_r_v<T &&, F, std::in_place_type_t<T &&>>)
+  {
+    return std::move(f_)(std::in_place_type<T&&>);
+  }
+
+private:
+  F f_;
+};
+
+#define PRO4D_DEF_CAST_ACCESSOR(oq, pq, ne, ...)                               \
+  template <class P, class D, class T>                                         \
+  struct accessor<P, D, T() oq ne> {                                           \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(operator T)                        \
+    explicit(Expl) operator T() oq ne {                                        \
+      if constexpr (Nullable) {                                                \
+        if (!static_cast<const P&>(*this).has_value()) {                       \
+          return nullptr;                                                      \
+        }                                                                      \
+      }                                                                        \
+      return invoke<D, T() oq ne>(static_cast<P pq>(*this));                   \
+    }                                                                          \
+  }
+template <bool Expl, bool Nullable>
+struct cast_dispatch_base {
+  PRO4D_DEF_ACCESSOR_TEMPLATE(
+      MEM, PRO4D_DEF_CAST_ACCESSOR,
+      operator typename overload_traits<ProOs>::return_type)
+};
+#undef PRO4D_DEF_CAST_ACCESSOR
+
+template <bool IsDirect, class D, class... Os>
+struct conv_impl {
+  static constexpr bool is_direct = IsDirect;
+  using dispatch_type = D;
+  using overload_types = std::tuple<Os...>;
+};
+template <bool IsDirect, class R>
+struct refl_impl {
+  static constexpr bool is_direct = IsDirect;
+  using reflector_type = R;
+};
+template <class Cs, class Rs, std::size_t MaxSize, std::size_t MaxAlign,
+          constraint_level Copyability, constraint_level Relocatability,
+          constraint_level Destructibility>
+struct facade_impl {
+  using convention_types = Cs;
+  using reflection_types = Rs;
+  static constexpr std::size_t max_size = MaxSize;
+  static constexpr std::size_t max_align = MaxAlign;
+  static constexpr constraint_level copyability = Copyability;
+  static constexpr constraint_level relocatability = Relocatability;
+  static constexpr constraint_level destructibility = Destructibility;
+};
+
+template <class O, class I>
+struct add_tuple_reduction : std::type_identity<O> {};
+template <class... Os, class I>
+  requires(!std::is_same_v<I, Os> && ...)
+struct add_tuple_reduction<std::tuple<Os...>, I>
+    : std::type_identity<std::tuple<Os..., I>> {};
+template <class O, class... Is>
+using add_tuple_t =
+    recursive_reduction_t<reduction_traits<add_tuple_reduction>::template type,
+                          O, Is...>;
+
+template <bool IsDirect, class D>
+struct conv_specialization_helper {
+  template <class... Os>
+  using type = conv_impl<IsDirect, D, Os...>;
+};
+template <bool IsDirect, class D, class Os>
+using conv_specialization_t =
+    specialization_t<conv_specialization_helper<IsDirect, D>::template type,
+                     Os>;
+
+template <class LR, class CLR, class RR, class CRR>
+class observer_ptr {
+public:
+  explicit observer_ptr(LR lr) : lr_(lr) {}
+  observer_ptr(const observer_ptr&) = default;
+  auto operator->() noexcept { return std::addressof(lr_); }
+  auto operator->() const noexcept {
+    return std::addressof(static_cast<CLR>(lr_));
+  }
+  LR operator*() & noexcept { return static_cast<LR>(lr_); }
+  CLR operator*() const& noexcept { return static_cast<CLR>(lr_); }
+  RR operator*() && noexcept { return static_cast<RR>(lr_); }
+  CRR operator*() const&& noexcept { return static_cast<CRR>(lr_); }
+
+private:
+  LR lr_;
+};
+
+template <class O>
+using observer_substitution_overload =
+    proxy_view<typename ret_t<O>::facade_type>() const noexcept;
+template <class... Os>
+using observer_substitution_conv = conv_specialization_t<
+    true, substitution_dispatch,
+    add_tuple_t<std::tuple<>, observer_substitution_overload<Os>...>>;
+
+template <class C>
+struct observer_conv_traits : std::type_identity<void> {};
+template <class C>
+  requires(C::is_direct &&
+           std::is_same_v<typename C::dispatch_type, substitution_dispatch>)
+struct observer_conv_traits<C>
+    : std::type_identity<specialization_t<observer_substitution_conv,
+                                          typename C::overload_types>> {};
+template <class C>
+  requires(!C::is_direct)
+struct observer_conv_traits<C> : std::type_identity<C> {};
+template <class... Cs>
+using observer_conv_types =
+    composite_t<std::tuple<>, typename observer_conv_traits<Cs>::type...>;
+template <class... Rs>
+using observer_refl_types =
+    composite_t<std::tuple<>, std::conditional_t<Rs::is_direct, void, Rs>...>;
+
+template <class P>
+auto weak_lock_impl(const P& self) noexcept
+  requires(requires { self.lock(); })
+{
+  if constexpr (std::is_constructible_v<bool, decltype(self.lock())>) {
+    return converter{
+        [&self]<class F>(std::in_place_type_t<proxy<F>>) noexcept -> proxy<F> {
+          auto strong = self.lock();
+          return strong ? proxy<F>{std::move(strong)} : proxy<F>{};
+        }};
+  } else {
+    return self.lock();
+  }
+}
+PRO4_DEF_FREE_AS_MEM_DISPATCH(weak_mem_lock, weak_lock_impl, lock);
+
+template <class O>
+struct weak_substitution_overload_traits;
+#define PRO4D_DEF_WEAK_SUBSTITUTION_OVERLOAD_TRAITS(oq, pq, ne, ...)           \
+  template <class F>                                                           \
+  struct weak_substitution_overload_traits<proxy<F>() oq ne>                   \
+      : std::type_identity<weak_proxy<F>() oq ne> {};
+PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(PRO4D_DEF_WEAK_SUBSTITUTION_OVERLOAD_TRAITS)
+#undef PRO4D_DEF_WEAK_SUBSTITUTION_OVERLOAD_TRAITS
+template <class... Os>
+using weak_substitution_conv =
+    conv_impl<true, substitution_dispatch,
+              typename weak_substitution_overload_traits<Os>::type...>;
+
+template <class C>
+struct weak_conv_traits : std::type_identity<void> {};
+template <class C>
+  requires(C::is_direct &&
+           std::is_same_v<typename C::dispatch_type, substitution_dispatch>)
+struct weak_conv_traits<C>
+    : std::type_identity<specialization_t<weak_substitution_conv,
+                                          typename C::overload_types>> {};
+template <class F, class... Cs>
+using weak_conv_types = composite_t<
+    std::tuple<conv_impl<true, weak_mem_lock, proxy<F>() const noexcept>>,
+    typename weak_conv_traits<Cs>::type...>;
+
+} // namespace detail
+
+struct PRO4D_ENFORCE_EBO substitution_dispatch
+    : detail::cast_dispatch_base<false, true>,
+      detail::internal_dispatch {
+  template <class P, class F1>
+  PRO4D_STATIC_CALL(auto, std::in_place_type_t<P>, proxy<F1>&& self) noexcept {
+    return detail::converter{
+        [&self]<class F2>(std::in_place_type_t<proxy<F2>>) noexcept {
+          proxy<F2> ret;
+          detail::proxy_helper::trivially_relocate<P>(self, ret);
+          return ret;
+        }};
+  }
+  template <class T>
+  PRO4D_STATIC_CALL(T&&, T&& self) noexcept {
+    return std::forward<T>(self);
+  }
+
+  // This overload is not reachable at runtime, but is necessary to ensure
+  // substitution_dispatch is SFINAE-friendly.
+  template <class T>
+  PRO4D_STATIC_CALL(auto, T&&) noexcept
+    requires(std::is_same_v<T, std::remove_cvref_t<T>> &&
+             is_bitwise_trivially_relocatable_v<T>)
+  {
+    return detail::converter{
+        []<class F2>(std::in_place_type_t<proxy<F2>>) noexcept -> proxy<F2>
+          requires(proxiable<T, F2>)
+        { PRO4D_UNREACHABLE(); }};
+  }
+};
+
+template <facade F>
+struct observer_facade
+    : detail::facade_impl<
+          detail::specialization_t<detail::observer_conv_types,
+                                   typename F::convention_types>,
+          detail::specialization_t<detail::observer_refl_types,
+                                   typename F::reflection_types>,
+          sizeof(void*), alignof(void*), constraint_level::trivial,
+          constraint_level::trivial, constraint_level::trivial> {};
+
+template <facade F>
+struct weak_facade
+    : detail::facade_impl<
+          detail::specialization_t<detail::weak_conv_types,
+                                   typename F::convention_types, F>,
+          std::tuple<>, F::max_size, F::max_align, F::copyability,
+          F::relocatability, F::destructibility> {};
+
+} // namespace pro::inline v4
+
+#endif // MSFT_PROXY_V4_DETAIL_CORE_H_

--- a/benchmark/runtime/proxy/v4/detail/dispatch.h
+++ b/benchmark/runtime/proxy/v4/detail/dispatch.h
@@ -1,0 +1,305 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_DISPATCH_H_
+#define MSFT_PROXY_V4_DETAIL_DISPATCH_H_
+
+#include <exception>
+
+#include "core.h"
+
+namespace pro::inline v4 {
+
+namespace detail {
+
+template <std::size_t N>
+struct sign {
+  consteval sign(const char (&str)[N + 1]) {
+    if (str[N] != '\0') {
+      PRO4D_UNREACHABLE();
+    }
+    for (std::size_t i = 0; i < N; ++i) {
+      value[i] = str[i];
+    }
+  }
+
+  char value[N];
+};
+template <std::size_t N>
+sign(const char (&str)[N]) -> sign<N - 1u>;
+
+// When std::reference_constructs_from_temporary_v (C++23) is not available, we
+// fall back to a conservative approximation that disallows binding a temporary
+// to a reference type if the source type is not a reference or if the source
+// and target reference types are not compatible.
+template <class T, class U>
+concept explicitly_convertible =
+    std::is_constructible_v<U, T> &&
+#if __cpp_lib_reference_from_temporary >= 202202L
+    !std::reference_constructs_from_temporary_v<U, T>;
+#else
+    (!std::is_reference_v<U> ||
+     (std::is_reference_v<T> &&
+      std::is_convertible_v<std::add_pointer_t<std::remove_reference_t<T>>,
+                            std::add_pointer_t<std::remove_reference_t<U>>>));
+#endif // __cpp_lib_reference_from_temporary >= 202202L
+
+struct noreturn_conversion {
+  template <class T>
+  [[noreturn]] PRO4D_STATIC_CALL(T, std::in_place_type_t<T>) {
+    PRO4D_UNREACHABLE();
+  }
+};
+using wildcard = converter<noreturn_conversion>;
+
+} // namespace detail
+
+template <detail::sign Sign, bool Rhs = false>
+struct operator_dispatch;
+
+#define PRO4D_DEF_LHS_LEFT_OP_ACCESSOR(oq, pq, ne, ...)                        \
+  template <class P, class D, class R>                                         \
+  struct accessor<P, D, R() oq ne> {                                           \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    R __VA_ARGS__() oq ne {                                                    \
+      return invoke<D, R() oq ne>(static_cast<P pq>(*this));                   \
+    }                                                                          \
+  }
+#define PRO4D_DEF_LHS_UNARY_OP_ACCESSOR(oq, pq, ne, ...)                       \
+  template <class P, class D, class R>                                         \
+  struct accessor<P, D, R() oq ne> {                                           \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    decltype(auto) __VA_ARGS__() oq ne {                                       \
+      invoke<D, R() oq ne>(static_cast<P pq>(*this));                          \
+      return static_cast<P pq>(*this);                                         \
+    }                                                                          \
+  };                                                                           \
+  template <class P, class D, class R>                                         \
+  struct accessor<P, D, R(int) oq ne> {                                        \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    R __VA_ARGS__(int) oq ne {                                                 \
+      return invoke<D, R(int) oq ne>(static_cast<P pq>(*this), 0);             \
+    }                                                                          \
+  }
+#define PRO4D_DEF_LHS_BINARY_OP_ACCESSOR PRO4D_DEF_MEM_ACCESSOR
+#define PRO4D_DEF_LHS_ALL_OP_ACCESSOR PRO4D_DEF_MEM_ACCESSOR
+#define PRO4D_LHS_LEFT_OP_DISPATCH_BODY_IMPL(...)                              \
+  template <class T>                                                           \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self)                                  \
+  PRO4D_DIRECT_FUNC_IMPL(__VA_ARGS__ std::forward<T>(self))
+#define PRO4D_LHS_UNARY_OP_DISPATCH_BODY_IMPL(...)                             \
+  template <class T>                                                           \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self)                                  \
+  PRO4D_DIRECT_FUNC_IMPL(__VA_ARGS__ std::forward<T>(self)) template <class T> \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, int)                             \
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self) __VA_ARGS__)
+#define PRO4D_LHS_BINARY_OP_DISPATCH_BODY_IMPL(...)                            \
+  template <class T, class Arg>                                                \
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                       \
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)                                 \
+                             __VA_ARGS__ std::forward<Arg>(arg))
+#define PRO4D_LHS_ALL_OP_DISPATCH_BODY_IMPL(...)                               \
+  PRO4D_LHS_LEFT_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)                            \
+  PRO4D_LHS_BINARY_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)
+#define PRO4D_LHS_OP_DISPATCH_IMPL(type, ...)                                  \
+  template <>                                                                  \
+  struct operator_dispatch<#__VA_ARGS__, false> {                              \
+    PRO4D_LHS_##type##_OP_DISPATCH_BODY_IMPL(__VA_ARGS__)                      \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(                                           \
+            MEM, PRO4D_DEF_LHS_##type##_OP_ACCESSOR, operator __VA_ARGS__)     \
+  };
+
+#define PRO4D_DEF_RHS_OP_ACCESSOR(oq, pq, ne, ...)                             \
+  template <class P, class D, class R, class Arg>                              \
+  struct accessor<P, D, R(Arg) oq ne> {                                        \
+    friend R operator __VA_ARGS__(Arg arg, P pq self) ne {                     \
+      return invoke<D, R(Arg) oq ne>(static_cast<P pq>(self),                  \
+                                     std::forward<Arg>(arg));                  \
+    }                                                                          \
+    PRO4D_DEBUG(                                                             \
+      accessor() noexcept { std::ignore = &pro_symbol_guard; }               \
+                                                                             \
+    private:                                                                 \
+      static inline R pro_symbol_guard(Arg arg, P pq self) {                 \
+        return std::forward<Arg>(arg) __VA_ARGS__ static_cast<P pq>(self);   \
+      }                                                                      \
+    ) \
+  }
+#define PRO4D_RHS_OP_DISPATCH_IMPL(...)                                        \
+  template <>                                                                  \
+  struct operator_dispatch<#__VA_ARGS__, true> {                               \
+    template <class T, class Arg>                                              \
+    PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
+    PRO4D_DIRECT_FUNC_IMPL(std::forward<Arg>(arg)                              \
+                               __VA_ARGS__ std::forward<T>(self))              \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(FREE, PRO4D_DEF_RHS_OP_ACCESSOR,           \
+                                    __VA_ARGS__)                               \
+  };
+
+#define PRO4D_EXTENDED_BINARY_OP_DISPATCH_IMPL(...)                            \
+  PRO4D_LHS_OP_DISPATCH_IMPL(ALL, __VA_ARGS__)                                 \
+  PRO4D_RHS_OP_DISPATCH_IMPL(__VA_ARGS__)
+
+#define PRO4D_BINARY_OP_DISPATCH_IMPL(...)                                     \
+  PRO4D_LHS_OP_DISPATCH_IMPL(BINARY, __VA_ARGS__)                              \
+  PRO4D_RHS_OP_DISPATCH_IMPL(__VA_ARGS__)
+
+#define PRO4D_DEF_LHS_ASSIGNMENT_OP_ACCESSOR(oq, pq, ne, ...)                  \
+  template <class P, class D, class R, class Arg>                              \
+  struct accessor<P, D, R(Arg) oq ne> {                                        \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    decltype(auto) __VA_ARGS__(Arg arg) oq ne {                                \
+      invoke<D, R(Arg) oq ne>(static_cast<P pq>(*this),                        \
+                              std::forward<Arg>(arg));                         \
+      return static_cast<P pq>(*this);                                         \
+    }                                                                          \
+  }
+#define PRO4D_DEF_RHS_ASSIGNMENT_OP_ACCESSOR(oq, pq, ne, ...)                  \
+  template <class P, class D, class R, class Arg>                              \
+  struct accessor<P, D, R(Arg&) oq ne> {                                       \
+    friend Arg& operator __VA_ARGS__(Arg& arg, P pq self) ne {                 \
+      invoke<D, R(Arg&) oq ne>(static_cast<P pq>(self), arg);                  \
+      return arg;                                                              \
+    }                                                                          \
+    PRO4D_DEBUG(                                                               \
+        accessor() noexcept { std::ignore = &pro_symbol_guard; }               \
+                                                                               \
+        private : static inline Arg& pro_symbol_guard(                         \
+            Arg& arg,                                                          \
+            P pq self) { return arg __VA_ARGS__ static_cast<P pq>(self); })    \
+  }
+#define PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(...)                                 \
+  template <>                                                                  \
+  struct operator_dispatch<#__VA_ARGS__, false> {                              \
+    template <class T, class Arg>                                              \
+    PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
+    PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)                               \
+                               __VA_ARGS__ std::forward<Arg>(arg))             \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(                                           \
+            MEM, PRO4D_DEF_LHS_ASSIGNMENT_OP_ACCESSOR, operator __VA_ARGS__)   \
+  };                                                                           \
+  template <>                                                                  \
+  struct operator_dispatch<#__VA_ARGS__, true> {                               \
+    template <class T, class Arg>                                              \
+    PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)                     \
+    PRO4D_DIRECT_FUNC_IMPL(std::forward<Arg>(arg)                              \
+                               __VA_ARGS__ std::forward<T>(self))              \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(FREE,                                      \
+                                    PRO4D_DEF_RHS_ASSIGNMENT_OP_ACCESSOR,      \
+                                    __VA_ARGS__)                               \
+  };
+
+PRO4D_EXTENDED_BINARY_OP_DISPATCH_IMPL(+)
+PRO4D_EXTENDED_BINARY_OP_DISPATCH_IMPL(-)
+PRO4D_EXTENDED_BINARY_OP_DISPATCH_IMPL(*)
+PRO4D_BINARY_OP_DISPATCH_IMPL(/)
+PRO4D_BINARY_OP_DISPATCH_IMPL(%)
+PRO4D_LHS_OP_DISPATCH_IMPL(UNARY, ++)
+PRO4D_LHS_OP_DISPATCH_IMPL(UNARY, --)
+PRO4D_BINARY_OP_DISPATCH_IMPL(==)
+PRO4D_BINARY_OP_DISPATCH_IMPL(!=)
+PRO4D_BINARY_OP_DISPATCH_IMPL(>)
+PRO4D_BINARY_OP_DISPATCH_IMPL(<)
+PRO4D_BINARY_OP_DISPATCH_IMPL(>=)
+PRO4D_BINARY_OP_DISPATCH_IMPL(<=)
+PRO4D_BINARY_OP_DISPATCH_IMPL(<=>)
+PRO4D_LHS_OP_DISPATCH_IMPL(LEFT, !)
+PRO4D_BINARY_OP_DISPATCH_IMPL(&&)
+PRO4D_BINARY_OP_DISPATCH_IMPL(||)
+PRO4D_LHS_OP_DISPATCH_IMPL(LEFT, ~)
+PRO4D_EXTENDED_BINARY_OP_DISPATCH_IMPL(&)
+PRO4D_BINARY_OP_DISPATCH_IMPL(|)
+PRO4D_BINARY_OP_DISPATCH_IMPL(^)
+PRO4D_BINARY_OP_DISPATCH_IMPL(<<)
+PRO4D_BINARY_OP_DISPATCH_IMPL(>>)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(+=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(-=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(*=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(/=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(%=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(&=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(|=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(^=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(<<=)
+PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL(>>=)
+PRO4D_BINARY_OP_DISPATCH_IMPL(, )
+PRO4D_BINARY_OP_DISPATCH_IMPL(->*)
+
+template <>
+struct operator_dispatch<"()", false> {
+  template <class T, class... Args>
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Args&&... args)
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)(std::forward<Args>(args)...))
+      PRO4D_DEF_ACCESSOR_TEMPLATE(MEM, PRO4D_DEF_MEM_ACCESSOR, operator())
+};
+template <>
+struct operator_dispatch<"[]", false> {
+#if __cpp_multidimensional_subscript >= 202110L
+  template <class T, class... Args>
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Args&&... args)
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)[std::forward<Args>(args)...])
+#else
+  template <class T, class Arg>
+  PRO4D_STATIC_CALL(decltype(auto), T&& self, Arg&& arg)
+  PRO4D_DIRECT_FUNC_IMPL(std::forward<T>(self)[std::forward<Arg>(arg)])
+#endif // __cpp_multidimensional_subscript >= 202110L
+      PRO4D_DEF_ACCESSOR_TEMPLATE(MEM, PRO4D_DEF_MEM_ACCESSOR, operator[])
+};
+
+#undef PRO4D_ASSIGNMENT_OP_DISPATCH_IMPL
+#undef PRO4D_DEF_RHS_ASSIGNMENT_OP_ACCESSOR
+#undef PRO4D_DEF_LHS_ASSIGNMENT_OP_ACCESSOR
+#undef PRO4D_BINARY_OP_DISPATCH_IMPL
+#undef PRO4D_EXTENDED_BINARY_OP_DISPATCH_IMPL
+#undef PRO4D_RHS_OP_DISPATCH_IMPL
+#undef PRO4D_DEF_RHS_OP_ACCESSOR
+#undef PRO4D_LHS_OP_DISPATCH_IMPL
+#undef PRO4D_LHS_ALL_OP_DISPATCH_BODY_IMPL
+#undef PRO4D_LHS_BINARY_OP_DISPATCH_BODY_IMPL
+#undef PRO4D_LHS_UNARY_OP_DISPATCH_BODY_IMPL
+#undef PRO4D_LHS_LEFT_OP_DISPATCH_BODY_IMPL
+#undef PRO4D_DEF_LHS_ALL_OP_ACCESSOR
+#undef PRO4D_DEF_LHS_BINARY_OP_ACCESSOR
+#undef PRO4D_DEF_LHS_UNARY_OP_ACCESSOR
+#undef PRO4D_DEF_LHS_LEFT_OP_ACCESSOR
+
+struct implicit_conversion_dispatch : detail::cast_dispatch_base<false, false> {
+  template <class T>
+  PRO4D_STATIC_CALL(T&&, T&& self) noexcept {
+    return std::forward<T>(self);
+  }
+};
+struct explicit_conversion_dispatch : detail::cast_dispatch_base<true, false> {
+  template <class T>
+  PRO4D_STATIC_CALL(auto, T&& self) noexcept {
+    return detail::converter{
+        [&self]<class U>(std::in_place_type_t<U>) noexcept(
+            std::is_nothrow_constructible_v<U, T>) -> U
+          requires(detail::explicitly_convertible < T &&, U >)
+        { return static_cast<U>(std::forward<T>(self)); }};
+  }
+};
+using conversion_dispatch = explicit_conversion_dispatch;
+
+class not_implemented : public std::exception {
+public:
+  char const* what() const noexcept override {
+    return "pro::v4::not_implemented";
+  }
+};
+
+template <class D>
+struct weak_dispatch : D {
+  using D::operator();
+  template <class... Args>
+  [[noreturn]] PRO4D_STATIC_CALL(detail::wildcard, Args&&...)
+    requires(!std::is_invocable_v<D, Args...>)
+  {
+    PRO4D_THROW(not_implemented{});
+  }
+};
+
+} // namespace pro::inline v4
+
+#endif // MSFT_PROXY_V4_DETAIL_DISPATCH_H_

--- a/benchmark/runtime/proxy/v4/detail/facade_creation.h
+++ b/benchmark/runtime/proxy/v4/detail/facade_creation.h
@@ -1,0 +1,195 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_FACADE_CREATION_H_
+#define MSFT_PROXY_V4_DETAIL_FACADE_CREATION_H_
+
+#include <limits>
+
+#include "core.h"
+
+namespace pro::inline v4 {
+
+namespace detail {
+
+inline constexpr std::size_t invalid_size =
+    std::numeric_limits<std::size_t>::max();
+inline constexpr constraint_level invalid_cl = static_cast<constraint_level>(
+    std::numeric_limits<std::underlying_type_t<constraint_level>>::min());
+consteval std::size_t merge_size(std::size_t a, std::size_t b) {
+  return a < b ? a : b;
+}
+consteval constraint_level merge_constraint(constraint_level a,
+                                            constraint_level b) {
+  return a < b ? b : a;
+}
+consteval std::size_t max_align_of(std::size_t value) {
+  value &= ~value + 1u;
+  return value < alignof(std::max_align_t) ? value : alignof(std::max_align_t);
+}
+
+template <class T, class U>
+using merge_tuple_t = specialization_t<add_tuple_t, U, T>;
+template <class C1, class C2>
+using merge_conv_t = conv_specialization_t<
+    C1::is_direct, typename C1::dispatch_type,
+    merge_tuple_t<typename C1::overload_types, typename C2::overload_types>>;
+
+template <class Cs1, class C2, class C>
+struct add_conv_reduction;
+template <class... Cs1, class C2, class... Cs3, class C>
+struct add_conv_reduction<std::tuple<Cs1...>, std::tuple<C2, Cs3...>, C>
+    : add_conv_reduction<std::tuple<Cs1..., C2>, std::tuple<Cs3...>, C> {};
+template <class... Cs1, class C2, class... Cs3, class C>
+  requires(
+      C::is_direct == C2::is_direct &&
+      std::is_same_v<typename C::dispatch_type, typename C2::dispatch_type>)
+struct add_conv_reduction<std::tuple<Cs1...>, std::tuple<C2, Cs3...>, C>
+    : std::type_identity<std::tuple<Cs1..., merge_conv_t<C2, C>, Cs3...>> {};
+template <class... Cs, class C>
+struct add_conv_reduction<std::tuple<Cs...>, std::tuple<>, C>
+    : std::type_identity<std::tuple<
+          Cs..., merge_conv_t<
+                     conv_impl<C::is_direct, typename C::dispatch_type>, C>>> {
+};
+template <class Cs, class C>
+using add_conv_t = typename add_conv_reduction<std::tuple<>, Cs, C>::type;
+
+template <class F, constraint_level CL>
+using copy_conversion_overload =
+    proxy<F>() const& noexcept(CL >= constraint_level::nothrow);
+template <class F, constraint_level CL>
+using move_conversion_overload =
+    proxy<F>() && noexcept(CL >= constraint_level::nothrow);
+template <class Cs, class F, constraint_level CCL, constraint_level RCL>
+struct add_substitution_conv
+    : std::type_identity<add_conv_t<
+          Cs, conv_specialization_t<
+                  true, substitution_dispatch,
+                  composite_t<
+                      std::tuple<>,
+                      std::conditional_t<CCL == constraint_level::none, void,
+                                         copy_conversion_overload<F, CCL>>,
+                      std::conditional_t<RCL == constraint_level::none, void,
+                                         move_conversion_overload<F, RCL>>>>>> {
+};
+template <class Cs, class F>
+struct add_substitution_conv<Cs, F, constraint_level::none,
+                             constraint_level::none> : std::type_identity<Cs> {
+};
+
+template <class Cs1, class... Cs2>
+using merge_conv_tuple_t = recursive_reduction_t<add_conv_t, Cs1, Cs2...>;
+template <class Cs, class F, bool WithSubstitution>
+using merge_facade_conv_t = typename add_substitution_conv<
+    specialization_t<merge_conv_tuple_t, typename F::convention_types, Cs>, F,
+    WithSubstitution ? F::copyability : constraint_level::none,
+    (WithSubstitution && F::copyability != constraint_level::trivial)
+        ? F::relocatability
+        : constraint_level::none>::type;
+
+template <bool WithSubstitution>
+struct add_facade_deprecation_traits : std::bool_constant<WithSubstitution> {};
+template <>
+struct [[deprecated(
+    "basic_facade_builder::add_facade<F, true> is deprecated; use "
+    "basic_facade_builder::add_facade_with_substitution<F> instead.")]]
+add_facade_deprecation_traits<true> : std::bool_constant<true> {};
+
+} // namespace detail
+
+template <class Cs, class Rs, std::size_t MaxSize, std::size_t MaxAlign,
+          constraint_level Copyability, constraint_level Relocatability,
+          constraint_level Destructibility>
+struct basic_facade_builder {
+  template <class D, detail::extended_overload... Os>
+    requires(sizeof...(Os) > 0u)
+  using add_indirect_convention = basic_facade_builder<
+      detail::add_conv_t<Cs, detail::conv_impl<false, D, Os...>>, Rs, MaxSize,
+      MaxAlign, Copyability, Relocatability, Destructibility>;
+  template <class D, detail::extended_overload... Os>
+    requires(sizeof...(Os) > 0u)
+  using add_direct_convention = basic_facade_builder<
+      detail::add_conv_t<Cs, detail::conv_impl<true, D, Os...>>, Rs, MaxSize,
+      MaxAlign, Copyability, Relocatability, Destructibility>;
+  template <class D, detail::extended_overload... Os>
+    requires(sizeof...(Os) > 0u)
+  using add_convention = add_indirect_convention<D, Os...>;
+  template <class R>
+  using add_indirect_reflection = basic_facade_builder<
+      Cs, detail::add_tuple_t<Rs, detail::refl_impl<false, R>>, MaxSize,
+      MaxAlign, Copyability, Relocatability, Destructibility>;
+  template <class R>
+  using add_direct_reflection = basic_facade_builder<
+      Cs, detail::add_tuple_t<Rs, detail::refl_impl<true, R>>, MaxSize,
+      MaxAlign, Copyability, Relocatability, Destructibility>;
+  template <class R>
+  using add_reflection = add_indirect_reflection<R>;
+  template <facade F, bool WithSubstitution = false>
+  using add_facade = basic_facade_builder<
+      detail::merge_facade_conv_t<
+          Cs, F,
+          detail::add_facade_deprecation_traits<WithSubstitution>::value>,
+      detail::merge_tuple_t<Rs, typename F::reflection_types>,
+      detail::merge_size(MaxSize, F::max_size),
+      detail::merge_size(MaxAlign, F::max_align),
+      detail::merge_constraint(Copyability, F::copyability),
+      detail::merge_constraint(Relocatability, F::relocatability),
+      detail::merge_constraint(Destructibility, F::destructibility)>;
+  template <facade F>
+  using add_facade_with_substitution = basic_facade_builder<
+      detail::merge_facade_conv_t<Cs, F, true>,
+      detail::merge_tuple_t<Rs, typename F::reflection_types>,
+      detail::merge_size(MaxSize, F::max_size),
+      detail::merge_size(MaxAlign, F::max_align),
+      detail::merge_constraint(Copyability, F::copyability),
+      detail::merge_constraint(Relocatability, F::relocatability),
+      detail::merge_constraint(Destructibility, F::destructibility)>;
+  template <std::size_t PtrSize,
+            std::size_t PtrAlign = detail::max_align_of(PtrSize)>
+    requires(detail::is_layout_well_formed(PtrSize, PtrAlign))
+  using restrict_layout =
+      basic_facade_builder<Cs, Rs, detail::merge_size(MaxSize, PtrSize),
+                           detail::merge_size(MaxAlign, PtrAlign), Copyability,
+                           Relocatability, Destructibility>;
+  template <constraint_level CL>
+    requires(detail::is_cl_well_formed(CL))
+  using support_copy =
+      basic_facade_builder<Cs, Rs, MaxSize, MaxAlign,
+                           detail::merge_constraint(Copyability, CL),
+                           Relocatability, Destructibility>;
+  template <constraint_level CL>
+    requires(detail::is_cl_well_formed(CL))
+  using support_relocation =
+      basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability,
+                           detail::merge_constraint(Relocatability, CL),
+                           Destructibility>;
+  template <constraint_level CL>
+    requires(detail::is_cl_well_formed(CL))
+  using support_destruction =
+      basic_facade_builder<Cs, Rs, MaxSize, MaxAlign, Copyability,
+                           Relocatability,
+                           detail::merge_constraint(Destructibility, CL)>;
+  template <template <class> class Skill>
+  using add_skill = Skill<basic_facade_builder>;
+  using build = detail::facade_impl<
+      Cs, Rs,
+      MaxSize == detail::invalid_size ? sizeof(detail::ptr_prototype) : MaxSize,
+      MaxAlign == detail::invalid_size ? alignof(detail::ptr_prototype)
+                                       : MaxAlign,
+      Copyability == detail::invalid_cl ? constraint_level::none : Copyability,
+      Relocatability == detail::invalid_cl ? constraint_level::trivial
+                                           : Relocatability,
+      Destructibility == detail::invalid_cl ? constraint_level::nothrow
+                                            : Destructibility>;
+  basic_facade_builder() = delete;
+};
+using facade_builder =
+    basic_facade_builder<std::tuple<>, std::tuple<>, detail::invalid_size,
+                         detail::invalid_size, detail::invalid_cl,
+                         detail::invalid_cl, detail::invalid_cl>;
+
+} // namespace pro::inline v4
+
+#endif // MSFT_PROXY_V4_DETAIL_FACADE_CREATION_H_

--- a/benchmark/runtime/proxy/v4/detail/proxy_creation.h
+++ b/benchmark/runtime/proxy/v4/detail/proxy_creation.h
@@ -1,0 +1,433 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_PROXY_CREATION_H_
+#define MSFT_PROXY_V4_DETAIL_PROXY_CREATION_H_
+
+#include <initializer_list>
+#include <memory>
+#include <new>
+
+#if __STDC_HOSTED__
+#include <atomic>
+#endif // __STDC_HOSTED__
+
+#include "core.h"
+
+namespace pro::inline v4 {
+
+template <class T, class F>
+concept inplace_proxiable_target = proxiable<detail::inplace_ptr<T>, F>;
+
+template <class T, class F>
+concept proxiable_target =
+    proxiable<detail::observer_ptr<T&, const T&, T&&, const T&&>,
+              observer_facade<F>>;
+
+template <class T>
+  requires(is_bitwise_trivially_relocatable_v<T>)
+struct is_bitwise_trivially_relocatable<detail::inplace_ptr<T>>
+    : std::true_type {};
+
+template <facade F, class T, class... Args>
+constexpr proxy<F> make_proxy_inplace(Args&&... args) noexcept(
+    std::is_nothrow_constructible_v<T, Args...>)
+  requires(std::is_constructible_v<T, Args...>)
+{
+  return proxy<F>{std::in_place_type<detail::inplace_ptr<T>>, std::in_place,
+                  std::forward<Args>(args)...};
+}
+template <facade F, class T, class U, class... Args>
+constexpr proxy<F>
+    make_proxy_inplace(std::initializer_list<U> il, Args&&... args) noexcept(
+        std::is_nothrow_constructible_v<T, std::initializer_list<U>&, Args...>)
+  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
+{
+  return proxy<F>{std::in_place_type<detail::inplace_ptr<T>>, std::in_place, il,
+                  std::forward<Args>(args)...};
+}
+template <facade F, class T>
+constexpr proxy<F> make_proxy_inplace(T&& value) noexcept(
+    std::is_nothrow_constructible_v<std::decay_t<T>, T>)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return proxy<F>{std::in_place_type<detail::inplace_ptr<std::decay_t<T>>>,
+                  std::in_place, std::forward<T>(value)};
+}
+
+template <facade F, class T>
+constexpr proxy_view<F> make_proxy_view(T& value) noexcept {
+  return proxy_view<F>{
+      detail::observer_ptr<T&, const T&, T&&, const T&&>{value}};
+}
+
+#if __STDC_HOSTED__
+namespace detail {
+
+template <class T, class Alloc, class... Args>
+T* allocate(const Alloc& alloc, Args&&... args) {
+  auto al =
+      typename std::allocator_traits<Alloc>::template rebind_alloc<T>(alloc);
+  auto deleter = [&](T* ptr) { al.deallocate(ptr, 1); };
+  std::unique_ptr<T, decltype(deleter)> result{al.allocate(1), deleter};
+  std::construct_at(result.get(), std::forward<Args>(args)...);
+  return result.release();
+}
+template <class Alloc, class T>
+void deallocate(const Alloc& alloc, T* ptr) {
+  auto al =
+      typename std::allocator_traits<Alloc>::template rebind_alloc<T>(alloc);
+  std::destroy_at(ptr);
+  al.deallocate(ptr, 1);
+}
+template <class Alloc>
+struct alloc_aware {
+  explicit alloc_aware(const Alloc& alloc) noexcept : alloc(alloc) {}
+  alloc_aware(const alloc_aware&) noexcept = default;
+
+  [[PRO4D_NO_UNIQUE_ADDRESS_ATTRIBUTE]]
+  Alloc alloc;
+};
+template <class T>
+class indirect_ptr {
+public:
+  explicit indirect_ptr(T* ptr) noexcept : ptr_(ptr) {}
+  auto operator->() noexcept { return std::addressof(**ptr_); }
+  auto operator->() const noexcept { return std::addressof(**ptr_); }
+  decltype(auto) operator*() & noexcept { return **ptr_; }
+  decltype(auto) operator*() const& noexcept { return *std::as_const(*ptr_); }
+  decltype(auto) operator*() && noexcept { return *std::move(*ptr_); }
+  decltype(auto) operator*() const&& noexcept {
+    return *std::move(std::as_const(*ptr_));
+  }
+
+protected:
+  T* ptr_;
+};
+
+template <class T, class Alloc>
+class PRO4D_ENFORCE_EBO allocated_ptr : private alloc_aware<Alloc>,
+                                        public indirect_ptr<inplace_ptr<T>> {
+public:
+  template <class... Args>
+  allocated_ptr(const Alloc& alloc, Args&&... args)
+      : alloc_aware<Alloc>(alloc),
+        indirect_ptr<inplace_ptr<T>>(allocate<inplace_ptr<T>>(
+            this->alloc, std::in_place, std::forward<Args>(args)...)) {}
+  allocated_ptr(const allocated_ptr& rhs)
+    requires(std::is_copy_constructible_v<T>)
+      : alloc_aware<Alloc>(rhs),
+        indirect_ptr<inplace_ptr<T>>(
+            allocate<inplace_ptr<T>>(this->alloc, std::in_place, *rhs)) {}
+  allocated_ptr(allocated_ptr&& rhs) = delete;
+  ~allocated_ptr() noexcept(std::is_nothrow_destructible_v<T>) {
+    deallocate(this->alloc, this->ptr_);
+  }
+};
+
+template <class T, class Alloc>
+struct PRO4D_ENFORCE_EBO compact_ptr_storage : alloc_aware<Alloc>,
+                                               inplace_ptr<T> {
+  template <class... Args>
+  explicit compact_ptr_storage(const Alloc& alloc, Args&&... args)
+      : alloc_aware<Alloc>(alloc),
+        inplace_ptr<T>(std::in_place, std::forward<Args>(args)...) {}
+};
+template <class T, class Alloc>
+class compact_ptr : public indirect_ptr<compact_ptr_storage<T, Alloc>> {
+  using Storage = compact_ptr_storage<T, Alloc>;
+
+public:
+  template <class... Args>
+  compact_ptr(const Alloc& alloc, Args&&... args)
+      : indirect_ptr<Storage>(
+            allocate<Storage>(alloc, alloc, std::forward<Args>(args)...)) {}
+  compact_ptr(const compact_ptr& rhs)
+    requires(std::is_copy_constructible_v<T>)
+      : indirect_ptr<Storage>(
+            allocate<Storage>(rhs.ptr_->alloc, rhs.ptr_->alloc, *rhs)) {}
+  compact_ptr(compact_ptr&& rhs) = delete;
+  ~compact_ptr() noexcept(std::is_nothrow_destructible_v<T>) {
+    deallocate(this->ptr_->alloc, this->ptr_);
+  }
+};
+
+struct shared_compact_ptr_storage_base {
+  std::atomic_long ref_count = 1;
+};
+template <class T, class Alloc>
+struct PRO4D_ENFORCE_EBO shared_compact_ptr_storage
+    : shared_compact_ptr_storage_base,
+      alloc_aware<Alloc>,
+      inplace_ptr<T> {
+  template <class... Args>
+  explicit shared_compact_ptr_storage(const Alloc& alloc, Args&&... args)
+      : alloc_aware<Alloc>(alloc),
+        inplace_ptr<T>(std::in_place, std::forward<Args>(args)...) {}
+};
+template <class T, class Alloc>
+class shared_compact_ptr
+    : public indirect_ptr<shared_compact_ptr_storage<T, Alloc>> {
+  using Storage = shared_compact_ptr_storage<T, Alloc>;
+
+public:
+  template <class... Args>
+  shared_compact_ptr(const Alloc& alloc, Args&&... args)
+      : indirect_ptr<Storage>(
+            allocate<Storage>(alloc, alloc, std::forward<Args>(args)...)) {}
+  shared_compact_ptr(const shared_compact_ptr& rhs) noexcept
+      : indirect_ptr<Storage>(rhs.ptr_) {
+    this->ptr_->ref_count.fetch_add(1, std::memory_order::relaxed);
+  }
+  shared_compact_ptr(shared_compact_ptr&& rhs) = delete;
+  ~shared_compact_ptr() noexcept(std::is_nothrow_destructible_v<T>) {
+    if (this->ptr_->ref_count.fetch_sub(1, std::memory_order::acq_rel) == 1) {
+      deallocate(this->ptr_->alloc, this->ptr_);
+    }
+  }
+};
+
+struct strong_weak_compact_ptr_storage_base {
+  std::atomic_long strong_count = 1, weak_count = 1;
+};
+template <class T, class Alloc>
+struct strong_weak_compact_ptr_storage : strong_weak_compact_ptr_storage_base,
+                                         alloc_aware<Alloc> {
+  template <class... Args>
+  explicit strong_weak_compact_ptr_storage(const Alloc& alloc, Args&&... args)
+      : alloc_aware<Alloc>(alloc) {
+    std::construct_at(reinterpret_cast<T*>(&value),
+                      std::forward<Args>(args)...);
+  }
+
+  alignas(alignof(T)) std::byte value[sizeof(T)];
+};
+template <class T, class Alloc>
+class weak_compact_ptr;
+template <class T, class Alloc>
+class strong_compact_ptr {
+  using Storage = strong_weak_compact_ptr_storage<T, Alloc>;
+  friend class weak_compact_ptr<T, Alloc>;
+
+public:
+  using weak_type = weak_compact_ptr<T, Alloc>;
+
+  explicit strong_compact_ptr(Storage* ptr) noexcept : ptr_(ptr) {}
+  template <class... Args>
+  strong_compact_ptr(const Alloc& alloc, Args&&... args)
+      : ptr_(allocate<Storage>(alloc, alloc, std::forward<Args>(args)...)) {}
+  strong_compact_ptr(const strong_compact_ptr& rhs) noexcept : ptr_(rhs.ptr_) {
+    ptr_->strong_count.fetch_add(1, std::memory_order::relaxed);
+  }
+  strong_compact_ptr(strong_compact_ptr&& rhs) = delete;
+  ~strong_compact_ptr() noexcept(std::is_nothrow_destructible_v<T>) {
+    if (ptr_->strong_count.fetch_sub(1, std::memory_order::acq_rel) == 1) {
+      std::destroy_at(operator->());
+      if (ptr_->weak_count.fetch_sub(1u, std::memory_order::release) == 1) {
+        deallocate(ptr_->alloc, ptr_);
+      }
+    }
+  }
+  T* operator->() noexcept {
+    return std::launder(reinterpret_cast<T*>(&ptr_->value));
+  }
+  const T* operator->() const noexcept {
+    return std::launder(reinterpret_cast<const T*>(&ptr_->value));
+  }
+  T& operator*() & noexcept { return *operator->(); }
+  const T& operator*() const& noexcept { return *operator->(); }
+  T&& operator*() && noexcept { return std::move(*operator->()); }
+  const T&& operator*() const&& noexcept { return std::move(*operator->()); }
+
+private:
+  strong_weak_compact_ptr_storage<T, Alloc>* ptr_;
+};
+template <class T, class Alloc>
+class weak_compact_ptr {
+public:
+  using element_type = T;
+
+  weak_compact_ptr(const strong_compact_ptr<T, Alloc>& rhs) noexcept
+      : ptr_(rhs.ptr_) {
+    ptr_->weak_count.fetch_add(1, std::memory_order::relaxed);
+  }
+  weak_compact_ptr(const weak_compact_ptr& rhs) noexcept : ptr_(rhs.ptr_) {
+    ptr_->weak_count.fetch_add(1, std::memory_order::relaxed);
+  }
+  weak_compact_ptr(weak_compact_ptr&& rhs) = delete;
+  ~weak_compact_ptr() noexcept {
+    if (ptr_->weak_count.fetch_sub(1u, std::memory_order::acq_rel) == 1) {
+      deallocate(ptr_->alloc, ptr_);
+    }
+  }
+  auto lock() const noexcept {
+    return converter{[ptr = this->ptr_]<class F>(
+                         std::in_place_type_t<proxy<F>>) noexcept -> proxy<F> {
+      long ref_count = ptr->strong_count.load(std::memory_order::relaxed);
+      do {
+        if (ref_count == 0) {
+          return proxy<F>{};
+        }
+      } while (!ptr->strong_count.compare_exchange_weak(
+          ref_count, ref_count + 1, std::memory_order::relaxed));
+      return proxy<F>{std::in_place_type<strong_compact_ptr<T, Alloc>>, ptr};
+    }};
+  }
+
+private:
+  strong_weak_compact_ptr_storage<T, Alloc>* ptr_;
+};
+
+template <class F, class T, class Alloc, class... Args>
+constexpr proxy<F> allocate_proxy_impl(const Alloc& alloc, Args&&... args) {
+  if constexpr (proxiable<allocated_ptr<T, Alloc>, F>) {
+    return proxy<F>{std::in_place_type<allocated_ptr<T, Alloc>>, alloc,
+                    std::forward<Args>(args)...};
+  } else {
+    return proxy<F>{std::in_place_type<compact_ptr<T, Alloc>>, alloc,
+                    std::forward<Args>(args)...};
+  }
+}
+template <class F, class T, class... Args>
+constexpr proxy<F> make_proxy_impl(Args&&... args) {
+  if constexpr (proxiable<inplace_ptr<T>, F>) {
+    return proxy<F>{std::in_place_type<inplace_ptr<T>>, std::in_place,
+                    std::forward<Args>(args)...};
+  } else {
+    return allocate_proxy_impl<F, T>(std::allocator<void>{},
+                                     std::forward<Args>(args)...);
+  }
+}
+template <class F, class T, class Alloc, class... Args>
+constexpr proxy<F> allocate_proxy_shared_impl(const Alloc& alloc,
+                                              Args&&... args) {
+  if constexpr (std::is_convertible_v<proxy<F>, weak_proxy<F>>) {
+    return proxy<F>{std::in_place_type<strong_compact_ptr<T, Alloc>>, alloc,
+                    std::forward<Args>(args)...};
+  } else {
+    return proxy<F>{std::in_place_type<shared_compact_ptr<T, Alloc>>, alloc,
+                    std::forward<Args>(args)...};
+  }
+}
+template <class F, class T, class... Args>
+constexpr proxy<F> make_proxy_shared_impl(Args&&... args) {
+  return allocate_proxy_shared_impl<F, T>(std::allocator<void>{},
+                                          std::forward<Args>(args)...);
+}
+
+} // namespace detail
+
+template <class T, class D>
+  requires(is_bitwise_trivially_relocatable_v<D>)
+struct is_bitwise_trivially_relocatable<std::unique_ptr<T, D>>
+    : std::true_type {};
+template <class T>
+struct is_bitwise_trivially_relocatable<std::shared_ptr<T>> : std::true_type {};
+template <class T>
+struct is_bitwise_trivially_relocatable<std::weak_ptr<T>> : std::true_type {};
+template <class T, class Alloc>
+  requires(is_bitwise_trivially_relocatable_v<Alloc>)
+struct is_bitwise_trivially_relocatable<detail::allocated_ptr<T, Alloc>>
+    : std::true_type {};
+template <class T, class Alloc>
+struct is_bitwise_trivially_relocatable<detail::compact_ptr<T, Alloc>>
+    : std::true_type {};
+template <class T, class Alloc>
+struct is_bitwise_trivially_relocatable<detail::shared_compact_ptr<T, Alloc>>
+    : std::true_type {};
+template <class T, class Alloc>
+struct is_bitwise_trivially_relocatable<detail::strong_compact_ptr<T, Alloc>>
+    : std::true_type {};
+template <class T, class Alloc>
+struct is_bitwise_trivially_relocatable<detail::weak_compact_ptr<T, Alloc>>
+    : std::true_type {};
+
+template <facade F, class T, class Alloc, class... Args>
+constexpr proxy<F> allocate_proxy(const Alloc& alloc, Args&&... args)
+  requires(std::is_constructible_v<T, Args...>)
+{
+  return detail::allocate_proxy_impl<F, T>(alloc, std::forward<Args>(args)...);
+}
+template <facade F, class T, class Alloc, class U, class... Args>
+constexpr proxy<F> allocate_proxy(const Alloc& alloc,
+                                  std::initializer_list<U> il, Args&&... args)
+  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
+{
+  return detail::allocate_proxy_impl<F, T>(alloc, il,
+                                           std::forward<Args>(args)...);
+}
+template <facade F, class Alloc, class T>
+constexpr proxy<F> allocate_proxy(const Alloc& alloc, T&& value)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return detail::allocate_proxy_impl<F, std::decay_t<T>>(
+      alloc, std::forward<T>(value));
+}
+template <facade F, class T, class... Args>
+constexpr proxy<F> make_proxy(Args&&... args)
+  requires(std::is_constructible_v<T, Args...>)
+{
+  return detail::make_proxy_impl<F, T>(std::forward<Args>(args)...);
+}
+template <facade F, class T, class U, class... Args>
+constexpr proxy<F> make_proxy(std::initializer_list<U> il, Args&&... args)
+  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
+{
+  return detail::make_proxy_impl<F, T>(il, std::forward<Args>(args)...);
+}
+template <facade F, class T>
+constexpr proxy<F> make_proxy(T&& value)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return detail::make_proxy_impl<F, std::decay_t<T>>(std::forward<T>(value));
+}
+
+template <facade F, class T, class Alloc, class... Args>
+constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc, Args&&... args)
+  requires(std::is_constructible_v<T, Args...>)
+{
+  return detail::allocate_proxy_shared_impl<F, T>(alloc,
+                                                  std::forward<Args>(args)...);
+}
+template <facade F, class T, class Alloc, class U, class... Args>
+constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc,
+                                         std::initializer_list<U> il,
+                                         Args&&... args)
+  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
+{
+  return detail::allocate_proxy_shared_impl<F, T>(alloc, il,
+                                                  std::forward<Args>(args)...);
+}
+template <facade F, class Alloc, class T>
+constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc, T&& value)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return detail::allocate_proxy_shared_impl<F, std::decay_t<T>>(
+      alloc, std::forward<T>(value));
+}
+template <facade F, class T, class... Args>
+constexpr proxy<F> make_proxy_shared(Args&&... args)
+  requires(std::is_constructible_v<T, Args...>)
+{
+  return detail::make_proxy_shared_impl<F, T>(std::forward<Args>(args)...);
+}
+template <facade F, class T, class U, class... Args>
+constexpr proxy<F> make_proxy_shared(std::initializer_list<U> il,
+                                     Args&&... args)
+  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
+{
+  return detail::make_proxy_shared_impl<F, T>(il, std::forward<Args>(args)...);
+}
+template <facade F, class T>
+constexpr proxy<F> make_proxy_shared(T&& value)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return detail::make_proxy_shared_impl<F, std::decay_t<T>>(
+      std::forward<T>(value));
+}
+#endif // __STDC_HOSTED__
+
+} // namespace pro::inline v4
+
+#endif // MSFT_PROXY_V4_DETAIL_PROXY_CREATION_H_

--- a/benchmark/runtime/proxy/v4/detail/skills.h
+++ b/benchmark/runtime/proxy/v4/detail/skills.h
@@ -1,0 +1,311 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_SKILLS_H_
+#define MSFT_PROXY_V4_DETAIL_SKILLS_H_
+
+#include <memory>
+#include <version>
+
+#if __STDC_HOSTED__
+// LLVM libc++ 17 has usable <format> despite lacking __cpp_lib_format until 19.
+#if __cpp_lib_format >= 201907L || _LIBCPP_VERSION >= 170000
+#include <format>
+#include <string_view>
+#define PRO4D_HAS_FORMAT
+#endif // __cpp_lib_format || _LIBCPP_VERSION >= 170000
+#endif // __STDC_HOSTED__
+
+#if __cpp_rtti >= 199711L
+#include <optional>
+#include <typeinfo>
+#endif // __cpp_rtti >= 199711L
+
+#include "core.h"
+
+namespace pro::inline v4 {
+
+#if __cpp_rtti >= 199711L
+class bad_proxy_cast : public std::bad_cast {
+public:
+  char const* what() const noexcept override {
+    return "pro::v4::bad_proxy_cast";
+  }
+};
+#endif // __cpp_rtti >= 199711L
+
+namespace detail {
+
+template <template <class...> class TT, class... Ctx>
+struct enabled_t {};
+template <class T, template <class...> class TT, class... Ctx>
+concept enabled_for = std::is_base_of_v<enabled_t<TT, Ctx...>, T>;
+
+struct view_conversion_dispatch : cast_dispatch_base<false, true> {
+  template <class T>
+  PRO4D_STATIC_CALL(auto, T& value) noexcept
+    requires(requires {
+      { std::addressof(*value) } noexcept;
+    })
+  {
+    return observer_ptr<decltype(*value), decltype(*std::as_const(value)),
+                        decltype(*std::move(value)),
+                        decltype(*std::move(std::as_const(value)))>{*value};
+  }
+};
+template <class F>
+using view_conversion_overload = proxy_view<F>() & noexcept;
+
+struct weak_conversion_dispatch : cast_dispatch_base<false, true> {
+  template <class P>
+  PRO4D_STATIC_CALL(auto, const P& self) noexcept
+    requires(requires(const typename P::weak_type& w) {
+      { w.lock() } noexcept;
+    } && std::is_convertible_v<const P&, typename P::weak_type>)
+  {
+    return converter{
+        [&self]<class F>(std::in_place_type_t<proxy<F>>) noexcept
+          requires(proxiable<typename P::weak_type, F>)
+        { return proxy<F>{std::in_place_type<typename P::weak_type>, self}; }};
+  }
+};
+template <class F>
+using weak_conversion_overload = weak_proxy<F>() const noexcept;
+
+template <template <class...> class Formatter,
+          template <class...> class StringView,
+          template <class...> class ParseContext,
+          template <class...> class FormatContext>
+struct format_traits {
+  template <class CharT>
+  using overload = typename FormatContext<CharT>::iterator(
+      StringView<CharT> spec, FormatContext<CharT>& fc) const;
+
+  struct dispatch {
+    template <class T, class CharT>
+    PRO4D_STATIC_CALL(auto, const T& self, StringView<CharT> spec,
+                      FormatContext<CharT>& fc)
+      requires(std::is_default_constructible_v<Formatter<T, CharT>>)
+    {
+      Formatter<T, CharT> impl;
+      {
+        ParseContext<CharT> pc{spec};
+        impl.parse(pc);
+      }
+      return impl.format(self, fc);
+    }
+
+    template <class P, class D, class... Os>
+    struct PRO4D_ENFORCE_EBO accessor : accessor<P, D, Os>... {};
+    template <class P, class D>
+    struct accessor<P, D, overload<char>> : enabled_t<Formatter, char> {};
+    template <class P, class D>
+    struct accessor<P, D, overload<wchar_t>> : enabled_t<Formatter, wchar_t> {};
+  };
+
+  template <class CharT>
+  struct formatter {
+    constexpr auto parse(ParseContext<CharT>& pc) {
+      for (auto it = pc.begin(); it != pc.end(); ++it) {
+        if (*it == '}') {
+          spec_ = StringView<CharT>{pc.begin(), it + 1};
+          return it;
+        }
+      }
+      return pc.end();
+    }
+
+    template <class P, class CompatibleFormatContext>
+    auto format(const P& p, CompatibleFormatContext& fc) const ->
+        typename CompatibleFormatContext::iterator {
+      return invoke<dispatch, overload<CharT>>(p, spec_, fc);
+    }
+
+  private:
+    StringView<CharT> spec_;
+  };
+};
+
+#ifdef PRO4D_HAS_FORMAT
+template <class CharT>
+struct std_format_context_traits;
+template <>
+struct std_format_context_traits<char>
+    : std::type_identity<std::format_context> {};
+template <>
+struct std_format_context_traits<wchar_t>
+    : std::type_identity<std::wformat_context> {};
+template <class CharT>
+using std_format_context = typename std_format_context_traits<CharT>::type;
+struct std_format_traits
+    : format_traits<std::formatter, std::basic_string_view,
+                    std::basic_format_parse_context, std_format_context> {};
+#endif // PRO4D_HAS_FORMAT
+
+#if __cpp_rtti >= 199711L
+struct proxy_cast_context {
+  const std::type_info* type_ptr;
+  bool is_ref;
+  bool is_const;
+  void* result_ptr;
+};
+
+template <class Self, class D, class O>
+struct proxy_cast_accessor_impl {
+  template <class T>
+  friend T proxy_cast(Self self) {
+    static_assert(!std::is_rvalue_reference_v<T>);
+    if constexpr (std::is_lvalue_reference_v<T>) {
+      using U = std::remove_reference_t<T>;
+      void* result = nullptr;
+      proxy_cast_context ctx{.type_ptr = &typeid(T),
+                             .is_ref = true,
+                             .is_const = std::is_const_v<U>,
+                             .result_ptr = &result};
+      invoke<D, O>(static_cast<Self>(self), ctx);
+      if (result == nullptr) [[unlikely]] {
+        PRO4D_THROW(bad_proxy_cast{});
+      }
+      return *static_cast<U*>(result);
+    } else {
+      std::optional<std::remove_const_t<T>> result;
+      proxy_cast_context ctx{.type_ptr = &typeid(T),
+                             .is_ref = false,
+                             .is_const = false,
+                             .result_ptr = &result};
+      invoke<D, O>(static_cast<Self>(self), ctx);
+      if (!result.has_value()) [[unlikely]] {
+        PRO4D_THROW(bad_proxy_cast{});
+      }
+      return std::move(*result);
+    }
+  }
+  template <class T>
+  friend T* proxy_cast(std::remove_reference_t<Self>* self) noexcept
+    requires(std::is_lvalue_reference<Self>::value)
+  {
+    void* result = nullptr;
+    proxy_cast_context ctx{.type_ptr = &typeid(T),
+                           .is_ref = true,
+                           .is_const = std::is_const_v<T>,
+                           .result_ptr = &result};
+    invoke<D, O>(*self, ctx);
+    return static_cast<T*>(result);
+  }
+};
+
+#define PRO4D_DEF_PROXY_CAST_ACCESSOR(oq, pq, ne, ...)                         \
+  template <class P, class D>                                                  \
+  struct accessor<P, D, void(proxy_cast_context) oq ne>                        \
+      : proxy_cast_accessor_impl<P pq, D, void(proxy_cast_context) oq ne> {}
+struct proxy_cast_dispatch {
+  template <class T>
+  PRO4D_STATIC_CALL(void, T&& self, proxy_cast_context ctx) {
+    if (typeid(T) == *ctx.type_ptr) [[likely]] {
+      if (ctx.is_ref) {
+        if constexpr (std::is_lvalue_reference_v<T>) {
+          if (ctx.is_const || !std::is_const_v<T>) [[likely]] {
+            *static_cast<void**>(ctx.result_ptr) = static_cast<void*>(std::addressof(self));
+          }
+        }
+      } else {
+        if constexpr (std::is_constructible_v<std::decay_t<T>, T>) {
+          static_cast<std::optional<std::decay_t<T>>*>(ctx.result_ptr)
+              ->emplace(std::forward<T>(self));
+        }
+      }
+    }
+  }
+  PRO4D_DEF_ACCESSOR_TEMPLATE(FREE, PRO4D_DEF_PROXY_CAST_ACCESSOR)
+};
+#undef PRO4D_DEF_PROXY_CAST_ACCESSOR
+
+struct proxy_typeid_reflector {
+  proxy_typeid_reflector() = default;
+  template <class T>
+  constexpr explicit proxy_typeid_reflector(std::in_place_type_t<T>)
+      : info(&typeid(T)) {}
+
+  template <class Self, class R>
+  struct accessor {
+    friend const std::type_info& proxy_typeid(const Self& self) noexcept {
+      const proxy_typeid_reflector& refl = reflect<R>(self);
+      return *refl.info;
+    }
+    PRO4D_DEBUG(
+        accessor() noexcept { std::ignore = &pro_symbol_guard; }
+
+        private : static inline const std::type_info& pro_symbol_guard(
+            const Self& self) { return proxy_typeid(self); })
+  };
+
+  const std::type_info* info;
+};
+#endif // __cpp_rtti >= 199711L
+
+} // namespace detail
+
+namespace skills {
+
+#ifdef PRO4D_HAS_FORMAT
+template <class FB>
+using format = typename FB::template add_convention<
+    detail::std_format_traits::dispatch,
+    detail::std_format_traits::overload<char>>;
+
+template <class FB>
+using wformat = typename FB::template add_convention<
+    detail::std_format_traits::dispatch,
+    detail::std_format_traits::overload<wchar_t>>;
+#endif // PRO4D_HAS_FORMAT
+
+#if __cpp_rtti >= 199711L
+template <class FB>
+using indirect_rtti = typename FB::template add_indirect_convention<
+    detail::proxy_cast_dispatch, void(detail::proxy_cast_context) &,
+    void(detail::proxy_cast_context) const&,
+    void(detail::proxy_cast_context) &&>::
+    template add_indirect_reflection<detail::proxy_typeid_reflector>;
+
+template <class FB>
+using direct_rtti = typename FB::template add_direct_convention<
+    detail::proxy_cast_dispatch, void(detail::proxy_cast_context) &,
+    void(detail::proxy_cast_context) const&,
+    void(detail::proxy_cast_context) &&>::
+    template add_direct_reflection<detail::proxy_typeid_reflector>;
+
+template <class FB>
+using rtti = indirect_rtti<FB>;
+#endif // __cpp_rtti >= 199711L
+
+template <class FB>
+using slim =
+    typename FB::template restrict_layout<sizeof(void*), alignof(void*)>;
+
+template <class FB>
+using as_view = typename FB::template add_direct_convention<
+    detail::view_conversion_dispatch,
+    facade_aware_overload_t<detail::view_conversion_overload>>;
+
+template <class FB>
+using as_weak = typename FB::template add_direct_convention<
+    detail::weak_conversion_dispatch,
+    facade_aware_overload_t<detail::weak_conversion_overload>>;
+
+} // namespace skills
+
+} // namespace pro::inline v4
+
+#ifdef PRO4D_HAS_FORMAT
+namespace std {
+
+template <class T, class CharT>
+  requires(pro::v4::detail::enabled_for<T, std::formatter, CharT>)
+struct formatter<T, CharT>
+    : pro::v4::detail::std_format_traits::formatter<CharT> {};
+
+} // namespace std
+#endif // PRO4D_HAS_FORMAT
+
+#endif // MSFT_PROXY_V4_DETAIL_SKILLS_H_

--- a/benchmark/runtime/proxy/v4/proxy.h
+++ b/benchmark/runtime/proxy/v4/proxy.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_PROXY_H_
+#define MSFT_PROXY_V4_PROXY_H_
+
+#include "detail/compatibility_check.h" // IWYU pragma: keep
+#include "detail/core.h"                // IWYU pragma: export
+#include "detail/dispatch.h"            // IWYU pragma: export
+#include "detail/facade_creation.h"     // IWYU pragma: export
+#include "detail/proxy_creation.h"      // IWYU pragma: export
+#include "detail/skills.h"              // IWYU pragma: export
+
+#endif // MSFT_PROXY_V4_PROXY_H_

--- a/benchmark/runtime/proxy/v4/proxy.ixx
+++ b/benchmark/runtime/proxy/v4/proxy.ixx
@@ -1,0 +1,75 @@
+module;
+
+#include <proxy/v4/proxy.h>
+
+export module proxy.v4;
+
+export namespace pro::inline v4 {
+
+#if __STDC_HOSTED__
+using v4::allocate_proxy;
+using v4::allocate_proxy_shared;
+using v4::make_proxy;
+using v4::make_proxy_shared;
+#endif // __STDC_HOSTED__
+
+#if __cpp_rtti >= 199711L
+using v4::bad_proxy_cast;
+#endif // __cpp_rtti >= 199711L
+
+using v4::basic_facade_builder;
+using v4::constraint_level;
+using v4::conversion_dispatch;
+using v4::explicit_conversion_dispatch;
+using v4::facade;
+using v4::facade_aware_overload_t;
+using v4::facade_builder;
+using v4::implicit_conversion_dispatch;
+using v4::inplace_proxiable_target;
+using v4::is_bitwise_trivially_relocatable;
+using v4::is_bitwise_trivially_relocatable_v;
+using v4::make_proxy_inplace;
+using v4::make_proxy_view;
+using v4::not_implemented;
+using v4::observer_facade;
+using v4::operator_dispatch;
+using v4::proxiable;
+using v4::proxiable_target;
+using v4::proxy;
+using v4::proxy_indirect_accessor;
+using v4::proxy_invoke;
+using v4::proxy_reflect;
+using v4::proxy_view;
+using v4::substitution_dispatch;
+using v4::weak_dispatch;
+using v4::weak_facade;
+using v4::weak_proxy;
+
+namespace skills {
+
+#ifdef PRO4D_HAS_FORMAT
+using skills::format;
+using skills::wformat;
+#endif // PRO4D_HAS_FORMAT
+
+#if __cpp_rtti >= 199711L
+using skills::direct_rtti;
+using skills::indirect_rtti;
+using skills::rtti;
+#endif // __cpp_rtti >= 199711L
+
+using skills::as_view;
+using skills::as_weak;
+using skills::slim;
+
+} // namespace skills
+
+} // namespace pro::inline v4
+
+#ifdef PRO4D_HAS_FORMAT
+export namespace std {
+
+using std::formatter;
+
+} // namespace std
+#endif // PRO4D_HAS_FORMAT

--- a/benchmark/runtime/proxy/v4/proxy_fmt.h
+++ b/benchmark/runtime/proxy/v4/proxy_fmt.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_PROXY_FMT_H_
+#define MSFT_PROXY_V4_PROXY_FMT_H_
+
+#include <string_view>
+#include <type_traits>
+
+#ifndef __msft_lib_proxy4
+#error Please ensure that proxy.h is included before proxy_fmt.h.
+#endif // __msft_lib_proxy4
+
+#if FMT_VERSION < 60100
+#error Please ensure that the appropriate {fmt} headers (version 6.1.0 or \
+later) are included before proxy_fmt.h.
+#endif // FMT_VERSION < 60100
+
+namespace pro::inline v4 {
+
+namespace detail {
+
+template <class CharT>
+#if FMT_VERSION >= 110000
+using fmt_buffered_context = fmt::buffered_context<CharT>;
+#else
+using fmt_buffered_context = fmt::buffer_context<CharT>;
+#endif // FMT_VERSION
+
+struct fmt_format_traits
+    : format_traits<fmt::formatter, std::basic_string_view,
+                    fmt::basic_format_parse_context, fmt_buffered_context> {};
+
+} // namespace detail
+
+namespace skills {
+
+template <class FB>
+using fmt_format = typename FB::template add_convention<
+    detail::fmt_format_traits::dispatch,
+    detail::fmt_format_traits::overload<char>>;
+
+template <class FB>
+using fmt_wformat = typename FB::template add_convention<
+    detail::fmt_format_traits::dispatch,
+    detail::fmt_format_traits::overload<wchar_t>>;
+
+} // namespace skills
+
+} // namespace pro::inline v4
+
+namespace fmt {
+
+template <class T, class CharT>
+  requires(pro::v4::detail::enabled_for<T, fmt::formatter, CharT>)
+struct formatter<T, CharT>
+    : pro::v4::detail::fmt_format_traits::formatter<CharT> {};
+
+} // namespace fmt
+
+#endif // MSFT_PROXY_V4_PROXY_FMT_H_

--- a/benchmark/runtime/proxy/v4/proxy_macros.h
+++ b/benchmark/runtime/proxy/v4/proxy_macros.h
@@ -1,0 +1,205 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_PROXY_MACROS_H_
+#define MSFT_PROXY_V4_PROXY_MACROS_H_
+
+#if __cpp_static_call_operator >= 202207L
+#define PRO4D_STATIC_CALL(ret, ...) static ret operator()(__VA_ARGS__)
+#else
+#define PRO4D_STATIC_CALL(ret, ...) ret operator()(__VA_ARGS__) const
+#endif // __cpp_static_call_operator >= 202207L
+
+#if __cpp_exceptions >= 199711L
+#define PRO4D_THROW(...) throw __VA_ARGS__
+#else
+#define PRO4D_THROW(...) std::abort()
+#endif // __cpp_exceptions >= 199711L
+
+#ifdef _MSC_VER
+#define PRO4D_ENFORCE_EBO __declspec(empty_bases)
+#else
+#define PRO4D_ENFORCE_EBO
+#endif // _MSC_VER
+
+#ifdef NDEBUG
+#define PRO4D_DEBUG(...)
+#else
+#define PRO4D_DEBUG(...) __VA_ARGS__
+#endif // NDEBUG
+
+#define __msft_lib_proxy4 202606L
+
+#define PRO4D_DIRECT_FUNC_IMPL(...)                                            \
+  noexcept(noexcept(__VA_ARGS__))                                              \
+    requires(requires { __VA_ARGS__; })                                        \
+  {                                                                            \
+    return __VA_ARGS__;                                                        \
+  }
+
+#define PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(macro, ...)                         \
+  macro(, &, , __VA_ARGS__);                                                   \
+  macro(, &, noexcept, __VA_ARGS__);                                           \
+  macro(&, &, , __VA_ARGS__);                                                  \
+  macro(&, &, noexcept, __VA_ARGS__);                                          \
+  macro(&&, &&, , __VA_ARGS__);                                                \
+  macro(&&, &&, noexcept, __VA_ARGS__);                                        \
+  macro(const, const&, , __VA_ARGS__);                                         \
+  macro(const, const&, noexcept, __VA_ARGS__);                                 \
+  macro(const&, const&, , __VA_ARGS__);                                        \
+  macro(const&, const&, noexcept, __VA_ARGS__);                                \
+  macro(const&&, const&&, , __VA_ARGS__);                                      \
+  macro(const&&, const&&, noexcept, __VA_ARGS__);
+
+#define PRO4D_DEF_AGGREGATE_MEM_ACCESSOR_BODY(...)                             \
+  using accessor<ProP, ProD, ProOs>::__VA_ARGS__...;
+#define PRO4D_DEF_AGGREGATE_FREE_ACCESSOR_BODY(...)
+#define PRO4D_DEF_ACCESSOR_TEMPLATE(type, macro, ...)                          \
+  template <class ProP, class ProD, class... ProOs>                            \
+  struct PRO4D_ENFORCE_EBO accessor {                                          \
+    accessor() = delete;                                                       \
+  };                                                                           \
+  template <class ProP, class ProD, class... ProOs>                            \
+    requires(sizeof...(ProOs) > 1u &&                                          \
+             (::std::is_constructible_v<accessor<ProP, ProD, ProOs>> && ...))  \
+  struct accessor<ProP, ProD, ProOs...> : accessor<ProP, ProD, ProOs>... {     \
+    PRO4D_DEF_AGGREGATE_##type##_ACCESSOR_BODY(__VA_ARGS__)                    \
+  };                                                                           \
+  PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(macro, __VA_ARGS__)
+
+#define PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(...)                           \
+  PRO4D_DEBUG(accessor() noexcept { ::std::ignore = &accessor::__VA_ARGS__; })
+
+#define PRO4D_EXPAND_IMPL(x) x
+
+#define PRO4D_EXPAND_MACRO_IMPL(macro, _1, _2, _3, name, ...) macro##_##name
+#define PRO4D_EXPAND_MACRO(macro, ...)                                         \
+  PRO4D_EXPAND_IMPL(                                                           \
+      PRO4D_EXPAND_MACRO_IMPL(macro, __VA_ARGS__, 3, 2)(__VA_ARGS__))
+
+#define PRO4D_DEF_MEM_ACCESSOR(oq, pq, ne, ...)                                \
+  template <class ProP, class ProD, class ProR, class... ProArgs>              \
+  struct accessor<ProP, ProD, ProR(ProArgs...) oq ne> {                        \
+    PRO4D_GEN_DEBUG_SYMBOL_FOR_MEM_ACCESSOR(__VA_ARGS__)                       \
+    ProR __VA_ARGS__(ProArgs... pro_args) oq ne {                              \
+      return invoke<ProD, ProR(ProArgs...) oq ne>(                             \
+          static_cast<ProP pq>(*this), ::std::forward<ProArgs>(pro_args)...);  \
+    }                                                                          \
+  }
+#define PRO4D_DEF_MEM_DISPATCH_IMPL(name, impl, func)                          \
+  struct name {                                                                \
+    template <class ProT, class... ProArgs>                                    \
+    PRO4D_STATIC_CALL(decltype(auto), ProT&& pro_self, ProArgs&&... pro_args)  \
+    PRO4D_DIRECT_FUNC_IMPL(::std::forward<ProT>(pro_self).impl(                \
+        ::std::forward<ProArgs>(pro_args)...))                                 \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(MEM, PRO4D_DEF_MEM_ACCESSOR, func)         \
+  }
+#define PRO4D_DEF_MEM_DISPATCH_2(name, impl)                                   \
+  PRO4D_DEF_MEM_DISPATCH_IMPL(name, impl, impl)
+#define PRO4D_DEF_MEM_DISPATCH_3(name, impl, func)                             \
+  PRO4D_DEF_MEM_DISPATCH_IMPL(name, impl, func)
+#define PRO4_DEF_MEM_DISPATCH(name, ...)                                       \
+  PRO4D_EXPAND_MACRO(PRO4D_DEF_MEM_DISPATCH, name, __VA_ARGS__)
+
+#define PRO4D_DEF_FREE_ACCESSOR(oq, pq, ne, ...)                               \
+  template <class ProP, class ProD, class ProR, class... ProArgs>              \
+  struct accessor<ProP, ProD, ProR(ProArgs...) oq ne> {                        \
+    friend ProR __VA_ARGS__(ProP pq pro_self, ProArgs... pro_args) ne {        \
+      return invoke<ProD, ProR(ProArgs...) oq ne>(                             \
+          static_cast<ProP pq>(pro_self),                                      \
+          ::std::forward<ProArgs>(pro_args)...);                               \
+    }                                                                          \
+    PRO4D_DEBUG(                                                             \
+      accessor() noexcept { ::std::ignore = &pro_symbol_guard; }             \
+                                                                             \
+    private:                                                                 \
+      static inline ProR pro_symbol_guard(ProP pq pro_self,                  \
+                                          ProArgs... pro_args) {             \
+        return __VA_ARGS__(static_cast<ProP pq>(pro_self),                   \
+            ::std::forward<ProArgs>(pro_args)...);                           \
+      }                                                                      \
+    ) \
+  }
+#define PRO4D_DEF_FREE_DISPATCH_IMPL(name, impl, func)                         \
+  struct name {                                                                \
+    template <class ProT, class... ProArgs>                                    \
+    PRO4D_STATIC_CALL(decltype(auto), ProT&& pro_self, ProArgs&&... pro_args)  \
+    PRO4D_DIRECT_FUNC_IMPL(impl(::std::forward<ProT>(pro_self),                \
+                                ::std::forward<ProArgs>(pro_args)...))         \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(FREE, PRO4D_DEF_FREE_ACCESSOR, func)       \
+  }
+#define PRO4D_DEF_FREE_DISPATCH_2(name, impl)                                  \
+  PRO4D_DEF_FREE_DISPATCH_IMPL(name, impl, impl)
+#define PRO4D_DEF_FREE_DISPATCH_3(name, impl, func)                            \
+  PRO4D_DEF_FREE_DISPATCH_IMPL(name, impl, func)
+#define PRO4_DEF_FREE_DISPATCH(name, ...)                                      \
+  PRO4D_EXPAND_MACRO(PRO4D_DEF_FREE_DISPATCH, name, __VA_ARGS__)
+
+#define PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(name, impl, func)                  \
+  struct name {                                                                \
+    template <class ProT, class... ProArgs>                                    \
+    PRO4D_STATIC_CALL(decltype(auto), ProT&& pro_self, ProArgs&&... pro_args)  \
+    PRO4D_DIRECT_FUNC_IMPL(impl(::std::forward<ProT>(pro_self),                \
+                                ::std::forward<ProArgs>(pro_args)...))         \
+        PRO4D_DEF_ACCESSOR_TEMPLATE(MEM, PRO4D_DEF_MEM_ACCESSOR, func)         \
+  }
+#define PRO4D_DEF_FREE_AS_MEM_DISPATCH_2(name, impl)                           \
+  PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(name, impl, impl)
+#define PRO4D_DEF_FREE_AS_MEM_DISPATCH_3(name, impl, func)                     \
+  PRO4D_DEF_FREE_AS_MEM_DISPATCH_IMPL(name, impl, func)
+#define PRO4_DEF_FREE_AS_MEM_DISPATCH(name, ...)                               \
+  PRO4D_EXPAND_MACRO(PRO4D_DEF_FREE_AS_MEM_DISPATCH, name, __VA_ARGS__)
+
+// Version-less macro aliases
+
+#define PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(name, qualified_name)          \
+  static_assert(false, "The use of macro `" #name "` is ambiguous. \
+Are multiple different versions of Proxy library included at the same time?\n\
+Note: To resolve this error: \n\
+- Either make sure that only one version of Proxy library is included within this file.\n\
+- Or use the `" #qualified_name "` macro (note the `4` suffix) to explicitly \
+stick to a specific major version of the Proxy library.")
+
+#ifdef __msft_lib_proxy
+#undef __msft_lib_proxy
+#define __msft_lib_proxy                                                       \
+  [] {                                                                         \
+    PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(__msft_lib_proxy,                  \
+                                            __msft_lib_proxy4);                \
+    return 0L;                                                                 \
+  }()
+#else
+#define __msft_lib_proxy __msft_lib_proxy4
+#endif // __msft_lib_proxy
+
+#ifdef PRO_DEF_MEM_DISPATCH
+#undef PRO_DEF_MEM_DISPATCH
+#define PRO_DEF_MEM_DISPATCH(...)                                              \
+  PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_MEM_DISPATCH,                \
+                                          PRO4_DEF_MEM_DISPATCH)
+#else
+#define PRO_DEF_MEM_DISPATCH(name, ...) PRO4_DEF_MEM_DISPATCH(name, __VA_ARGS__)
+#endif // PRO_DEF_MEM_DISPATCH
+
+#ifdef PRO_DEF_FREE_DISPATCH
+#undef PRO_DEF_FREE_DISPATCH
+#define PRO_DEF_FREE_DISPATCH(...)                                             \
+  PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_FREE_DISPATCH,               \
+                                          PRO4_DEF_FREE_DISPATCH)
+#else
+#define PRO_DEF_FREE_DISPATCH(name, ...)                                       \
+  PRO4_DEF_FREE_DISPATCH(name, __VA_ARGS__)
+#endif // PRO_DEF_FREE_DISPATCH
+
+#ifdef PRO_DEF_FREE_AS_MEM_DISPATCH
+#undef PRO_DEF_FREE_AS_MEM_DISPATCH
+#define PRO_DEF_FREE_AS_MEM_DISPATCH(...)                                      \
+  PRO4D_AMBIGUOUS_MACRO_DIAGNOSTIC_ASSERT(PRO_DEF_FREE_AS_MEM_DISPATCH,        \
+                                          PRO4_DEF_FREE_AS_MEM_DISPATCH)
+#else
+#define PRO_DEF_FREE_AS_MEM_DISPATCH(name, ...)                                \
+  PRO4_DEF_FREE_AS_MEM_DISPATCH(name, __VA_ARGS__)
+#endif // PRO_DEF_FREE_AS_MEM_DISPATCH
+
+#endif // MSFT_PROXY_V4_PROXY_MACROS_H_

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -2,16 +2,19 @@
 - Fixed freestanding support: `throw_or_terminate()` now uses `std::terminate()` and the `std::function` overload of `not_empty()` is skipped when `__STDC_HOSTED__` is not defined.
 - Fixed GCC 16 ipa-cp devirtualization failure by adding `gcc_ipa_cp_friendly_cast()` so indirect calls via `m_invoker` are tracked correctly (see issue #133).
 - Fixed `-Wuninitialized` warning by explicitly initializing `Base_MemberVariable` in the default/`nullptr_t`/functor constructors.
+- Fixed the benchmark bug in `MoveOnlyFunction.Params.SmallTrivial` (wrong `volatile void*` usage).
 
 **⚠️ Breaking Changes**
 - None.
 
 **✨ New Features**
-- None.
+- Added [ngcpp/proxy](https://github.com/ngcpp/proxy) as a benchmark target, with `proxy` cases added to all runtime benchmark suites (headers vendored in `benchmark/runtime/proxy/`).
 
 **🛠️ Optimizations and Improvements**
 - Constructed `ErasurePass` directly with const pointers, adding dedicated constructors for const/volatile-qualified erased pointers.
 - Simplified `operator()` by inlining the invoker call and dropping the `invoke()` helper from the command tables and removing unnecessary `const_cast`.
+- Benchmarks now build with `-O2` (was `-Os`) to avoid the trange bug in MinGW, and benchmark parameters were adjusted (`BENCHMARK_TIMES {1000, 1000000}`, `BENCHMARK_REPEAT 15`).
+- Updated benchmark CI to GCC-16 on Ubuntu 26.04, and README benchmark results (GCC-16, C++23, `-O2`).
 
 **📌 Notes**
-- None.
+- Benchmark now requires C++20 because of the `proxy` dependency.

--- a/test/README.md
+++ b/test/README.md
@@ -19,5 +19,5 @@ cd ./test # Go to test directory: <repo_root>/test
 
 cmake -B build -S . -DCMAKE_CXX_STANDARD=11 # Generate build files
 
-cmake --build build --config Debug --target test # Build and run tests. Add '-j 100' if slow.
+cmake --build build --config Debug --target test --parallel
 ```


### PR DESCRIPTION
## Summary
Add [ngcpp/proxy](https://github.com/ngcpp/proxy) (a C++20 pointer-semantics based polymorphic wrapper) as a new comparison target across the runtime benchmarks, and refresh the benchmark build configuration and related docs/CI.

## Changes
### Benchmark (new proxy comparisons)
- Add proxy (pro) to benchmark.hpp include and benchmark/CMakeLists.txt as a benchmark target.
- Add pro cases to existing benchmark suites:
- benchmark_lambda.cpp: scalar / trivial / call-trivial lambda calls.
- benchmark_move_only_function.cpp: scalar, small-trivial, multi-trivial parameter forwarding.
- benchmark_assignment.cpp: copy/move assignment for small-trivial, large-capture, stateless, function-pointer and same-type cases.
- benchmark_create.cpp: capture-lambda and non-trivial-functor creation.
- benchmark_std_op.cpp, benchmark_free_function.cpp: additional pro cases.
- Vendor proxy v4 source under benchmark/runtime/proxy/.
### Benchmark config
- Switch compile flags from -Os to -O2 (fixes the strange bug on MinGW).
- Adjust BENCHMARK_TIMES to {1000, 1000000} and BENCHMARK_REPEAT to 15.
- Require C++20 (proxy needs C++20; function2 still works).
Fixes
- Add a missing `volatile` in `MoveOnlyFunction.Params.SmallTrivial`
### Docs / CI
- Update README.md benchmark results section (still has TODO here), add references to P2721 (deprecating std::function) and P3086 (proxy).
- Update `benchmark/README.md`, `test/README.md` for the new commands.
- benchmark.yml: drop unused ninja-build install and use --parallel.