### PR TITLE
Version 2.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.2.1 LANGUAGES CXX)
+project(embedded_function VERSION 2.2.2 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 - [Proxy: A Pointer-Semantics-Based Polymorphism Library -P3086](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3086r5.html)
 
+- [SG14: Non-allocating standard functions](https://github.com/WG21-SG14/SG14/blob/master/Docs/Proposals/NonAllocatingStandardFunction.pdf)
+
 ## 📚 Similar implementations
 
 - [std::function](https://cppreference.com/w/cpp/utility/functional/function)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.2.1-yellow?style=for-the-badge&logo=github" alt="Version - 2.2.1">
+  <img src="https://img.shields.io/badge/Version-2.2.2-yellow?style=for-the-badge&logo=github" alt="Version - 2.2.2">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23/26-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23/26">
 </p>
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/test.yml">
     <img src="https://github.com/Kim-J-Smith/Embedded-Function/actions/workflows/test.yml/badge.svg">
-    <img src="https://img.shields.io/badge/GCC_5.1~16.1-support-B46F1B?style=flat&logo=gnu" alt="gcc-5.1~16.1 - support">
+    <img src="https://img.shields.io/badge/GCC_5.1~16.2-support-B46F1B?style=flat&logo=gnu" alt="gcc-5.1~16.2 - support">
     <img src="https://img.shields.io/badge/Clang_3.7~22.1-support-045891?style=flat&logo=llvm" alt="clang-3.7~22.1 - support">
     <img src="https://img.shields.io/badge/MSVC_19.10~19.51-support-5C2D91?style=flat" alt="msvc-19.10~19.51 - support">
   </a>

--- a/docs/api/detail/function.md
+++ b/docs/api/detail/function.md
@@ -160,13 +160,17 @@ constexpr bool is_empty() const noexcept;
 
 Returns `true` if the function wrapper is empty, `false` otherwise.
 
-#### operator bool
+#### operator bool (Deprecated)
 
 ```cpp
+EMBED_DEPRECATED("Use `!f.is_empty()` instead")
 constexpr explicit operator bool() const noexcept;
 ```
 
 Returns `true` if the function wrapper is not empty, `false` otherwise.
+
+> [!WARNING]
+> This operator is deprecated and will be removed in a future release. It usually indicates a bug in user code: e.g., with `ebd::fn<bool()> f`, `f (f())` can be confused with `if (f)`, because the conversion only tests emptiness, not the call result. Use explicit `!f.is_empty()` instead.
 
 #### clear
 

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -2,7 +2,7 @@
 - None.
 
 **⚠️ Breaking Changes**
-- None.
+- Deprecated `operator bool`. Use `!f.is_empty()` instead.
 
 **✨ New Features**
 - None.
@@ -11,4 +11,4 @@
 - None.
 
 **📌 Notes**
-- None.
+- `operator bool` still works but may warn. It will be removed in a future release.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,8 +1,8 @@
 **🔧 Fixed Bugs**
-- None.
+- Fixed incorrect stateless detection in `is_stateless`: functors with copy side effects (non-trivially-copyable) were treated as stateless, causing copies to be elided. (#145)
 
 **⚠️ Breaking Changes**
-- Deprecated `operator bool`. Use `!f.is_empty()` instead.
+- Deprecated `operator bool`. Use `!f.is_empty()` instead. (#143)
 
 **✨ New Features**
 - None.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,24 +1,14 @@
 **🔧 Fixed Bugs**
-- Fixed freestanding support: `throw_or_terminate()` now uses `std::terminate()` and the `std::function` overload of `not_empty()` is skipped when `__STDC_HOSTED__` is not defined. (#132)
-- Fixed GCC 16 ipa-cp devirtualization failure by adding `gcc_ipa_cp_friendly_cast()` so indirect calls via `m_invoker` are tracked correctly (see issue #133). (#134)
-- Fixed `-Wuninitialized` warning by explicitly initializing `Base_MemberVariable` in the default/`nullptr_t`/functor constructors. (#136)
-- Fixed the benchmark bug in `MoveOnlyFunction.Params.SmallTrivial` (wrong `volatile void*` usage). (#137)
+- None.
 
 **⚠️ Breaking Changes**
 - None.
 
 **✨ New Features**
-- Added [ngcpp/proxy](https://github.com/ngcpp/proxy) as a benchmark target, with `proxy` cases added to all runtime benchmark suites (headers vendored in `benchmark/runtime/proxy/`). (#137)
-- Added an ADL swap() free function for exchanging two same-type wrappers. (#128)
+- None.
 
 **🛠️ Optimizations and Improvements**
-- Constructed `ErasurePass` directly with const pointers, adding dedicated constructors for const/volatile-qualified erased pointers. (#134)
-- Simplified `operator()` by inlining the invoker call and dropping the `invoke()` helper from the command tables and removing unnecessary `const_cast`. (#134)
-- Benchmarks now build with `-O2` (was `-Os`) to avoid the strange bug in MinGW, and benchmark parameters were adjusted (`BENCHMARK_TIMES {1000, 1000000}`, `BENCHMARK_REPEAT 15`). (#137)
-- Updated benchmark CI to GCC-16 on Ubuntu 26.04, and README benchmark results (GCC-16, C++23, `-O2`). (#137)
-- Enabled sanitizers in the test suite (non-Windows): GCC tests build with `-fsanitize=address` and Clang tests build with `-fsanitize=address,undefined`. (#130)
-- Defining `DEBUG` now forces the debug diagnostics (assertions and terminate checks) to stay active even when `NDEBUG` or `__OPTIMIZE__` is defined. (#136)
-- Added `[[msvc::intrinsic]]` to `gcc_ipa_cp_friendly_cast()` to help MSVC inline. (#135)
+- None.
 
 **📌 Notes**
-- Benchmark now requires C++20 because of the `proxy` dependency.
+- None.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3,7 +3,7 @@
  *
  * @date        2026-8-6
  *
- * @version     2.2.1
+ * @version     2.2.2
  *
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1622,23 +1622,19 @@ inline namespace fn_traits {
 # endif // ^^^ __cpp_lib_three_way_comparison >= 201907L
 #endif
 
-  // Check empty and normal callable functor.
+  // Check whether the functor is stateless.
   // Lambda has trivially default constructor since C++20.
   // See <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0624r2.pdf>.
-  template <typename Fn>
-  struct is_empty_trivial : bool_constant<
-    std::is_empty<Fn>::value && std::is_trivially_default_constructible<Fn>::value
-    && std::is_trivially_destructible<Fn>::value
+  template <bool IsView/*= false*/, typename Fn, typename... Args>
+  struct is_stateless : bool_constant<
+    std::is_trivially_copyable<Fn>::value
+    && (is_statically_callable<Fn, Args...>::value ||
+       (std::is_empty<Fn>::value && std::is_default_constructible<Fn>::value))
   > {};
 
-  // Check whether the functor is stateless.
-  template <bool IsView, typename Fn, typename... Args>
-  struct is_stateless : bool_constant<
-    is_statically_callable<Fn, Args...>::value
-    || is_std_op_wrapper<Fn>::value
-    || (is_empty_trivial<Fn>::value && !IsView)
-    // ^^^ empty trivial functor may use `this` in operator(). This is
-    // not strict stateless and cannot be used in reference semantic.
+  template <typename Fn, typename... Args>
+  struct is_stateless</*IsView =*/true, Fn, Args...> : bool_constant<
+    is_statically_callable<Fn, Args...>::value || is_std_op_wrapper<Fn>::value
   > {};
 
   // Log error for make_fn.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1199,7 +1199,7 @@ inline namespace fn_traits {
     template <std::size_t Buf, typename Cfg, typename Sig,
       EMBED_DETAIL_REQUIRES(!Cfg::isView) /*OWNING*/> static
     EMBED_CXX14_CONSTEXPR bool not_empty(const function<Buf, Cfg, Sig>& f) noexcept
-    { return static_cast<bool>(f); }
+    { return !f.is_empty(); }
 
 #if __STDC_HOSTED__
 
@@ -2580,7 +2580,8 @@ namespace crtp_mixins {
     EMBED_NODISCARD constexpr bool is_empty() const noexcept
     { return static_cast<const Self&>(*this).m_command.is_empty(); }
 
-    // Return `true` if the object is NOT empty.
+    /// @deprecated This method usually indicates a bug. Use explicit `!f.is_empty()` instead.
+    EMBED_DEPRECATED("Use `!f.is_empty()` instead")
     constexpr explicit operator bool() const noexcept { return !is_empty(); }
 
     // Clear the object.

--- a/test/conformance/fn/side_effects.pass.cpp
+++ b/test/conformance/fn/side_effects.pass.cpp
@@ -1,0 +1,46 @@
+#include "test_fallback_macros.hpp"
+
+#include "embed/embed_function.hpp"
+#include "gtest/gtest.h"
+
+namespace {
+    static int copies = 0;
+
+    struct NonTriviallyCopyable {
+        NonTriviallyCopyable() = default;
+        NonTriviallyCopyable(const NonTriviallyCopyable&) noexcept { copies++; }
+        int operator()(int) { return 42; }
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+        static int operator()(long) { return 43; }
+#endif
+    };
+}
+
+// See <https://lists.isocpp.org/sg14/2026/08/1346.php>.
+TEST(Conformance_fn, side_effects_pass) {
+    int number = 1;
+    ebd::fn<int()> f1 = [number]() mutable { return number++; };
+    ASSERT_EQ(f1(), 1);
+    ASSERT_EQ(f1(), 2);
+    ASSERT_EQ(f1(), 3);
+
+    ebd::fn<int(int)> f2 = NonTriviallyCopyable{};
+    copies = 0;
+    {
+        auto f_ = f2;
+    }
+    ASSERT_EQ(copies, 1);
+    ASSERT_EQ(f2(0), 42);
+    ASSERT_EQ(f2(0L), 42);
+
+#if (EMBED_CXX_VERSION >= 202302L && __cpp_static_call_operator >= 202207L)
+    ebd::fn<int(long)> f3 = NonTriviallyCopyable{};
+    copies = 0;
+    {
+        auto f_ = f3;
+    }
+    ASSERT_EQ(copies, 1);
+    ASSERT_EQ(f3(0), 43);
+    ASSERT_EQ(f3(0L), 43);
+#endif
+}

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -16,12 +16,10 @@ TEST(InitFunction, fn_freeFunction_v) {
     ASSERT_EQ(buf_size, buf_expect);
     ASSERT_EQ(f != nullptr, true);
     ASSERT_EQ(f == nullptr, false);
-    ASSERT_EQ(static_cast<bool>(f), true);
 
     f = nullptr;
     ASSERT_EQ(f != nullptr, false);
     ASSERT_EQ(f == nullptr, true);
-    ASSERT_EQ(static_cast<bool>(f), false);
 
     auto f2 = ebd::make_fn(ebd_test_free_func_v);
     ASSERT_EQ(f2.is_empty(), false);

--- a/test/test_ThrowDeath.cpp
+++ b/test/test_ThrowDeath.cpp
@@ -10,7 +10,6 @@
 TEST(ThrowDeath, throw_bad_function_call) {
     ebd::classic_fn<void()> f1;
     ASSERT_EQ(f1.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(f1), false);
     EBD_EXPECT_THROW(f1(), std::bad_function_call);
 }
 
@@ -18,27 +17,22 @@ TEST(ThrowDeath, throw_bad_function_call) {
 TEST(ThrowDeath, terminate_on_empty_call) {
     ebd::fn<void()> f1;
     ASSERT_EQ(f1.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(f1), false);
     EXPECT_DEATH(f1(), "");
 
     ebd::unique_fn<void()> f2;
     ASSERT_EQ(f2.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(f2), false);
     EXPECT_DEATH(f2(), "");
 
     ebd::__safe_fn<void()> sf;
     ASSERT_EQ(sf.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(sf), false);
     EXPECT_DEATH(sf(), "");
 
     auto f3 = ebd::make_fn<void()>();
     ASSERT_EQ(f3.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(f3), false);
     EXPECT_DEATH(f3(), "");
 
     auto f4 = ebd::make_fn<void()>(nullptr);
     ASSERT_EQ(f4.is_empty(), true);
-    ASSERT_EQ(static_cast<bool>(f4), false);
     EXPECT_DEATH(f4(), "");
 }
 


### PR DESCRIPTION
**🔧 Fixed Bugs**
- Fixed incorrect stateless detection in `is_stateless`: functors with copy side effects (non-trivially-copyable) were treated as stateless, causing copies to be elided. (#145)

**⚠️ Breaking Changes**
- Deprecated `operator bool`. Use `!f.is_empty()` instead. (#143)

**✨ New Features**
- None.

**🛠️ Optimizations and Improvements**
- None.

**📌 Notes**
- `operator bool` still works but may warn. It will be removed in a future release.
