### PR TITLE
Version 2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.2.2 LANGUAGES CXX)
+project(embedded_function VERSION 2.3.0 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.2.2-yellow?style=for-the-badge&logo=github" alt="Version - 2.2.2">
+  <img src="https://img.shields.io/badge/Version-2.3.0-yellow?style=for-the-badge&logo=github" alt="Version - 2.3.0">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23/26-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23/26">
 </p>

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Go to the `<root>/test/` directory, and follow the instructions in [`test/README
 
 ### Stateless elimination
 
-`ebd::fn` / `ebd::unique_fn` / `ebd::classic_fn` / `ebd::fn_ref` do not store the functor or its pointer if the functor is stateless (e.g., empty classes with trivial operations). This reduces memory access operations and improves cache efficiency.
+`ebd::fn` / `ebd::unique_fn` / `ebd::classic_fn` / `ebd::fn_ref` do not store the functor or its pointer if the functor is stateless (e.g., trivially copyable classes with `static operator()`). This reduces memory access operations and improves cache efficiency.
 
 > Click [x64-asm](./docs/perf/x86_64_msvc_asm_analysis.md), [rv32-asm](./docs/perf/riscv_gcc_asm_analysis.md) and [arm32-asm](./docs/perf/arm_gcc_asm_analysis.md) to see more details.
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,21 @@ In a [single header file](./include/embed/embed_function.hpp), **five** function
 
 ```cpp
 namespace ebd {
-template <class Signature, size_t BufferSize = /*DefaultSize*/>
-  class fn; // Wrapper for copyable callable objects.
-template <class Signature, size_t BufferSize = /*DefaultSize*/>
-  class unique_fn; // Wrapper for movable, especially move-only callable objects.
-template <class Signature, size_t BufferSize = /*DefaultSize*/>
-  class classic_fn; // Wrapper for copyable callable objects (throws on empty, like std::function).
-template <class Signature, size_t Unused = 0>
-  class fn_ref; // View (non-owning wrapper) for callable objects.
+// Owning polymorphic copyable function wrapper.
+template <class Signature, size_t BufferSize = /*DefaultSize*/, size_t Alignment = /*DefaultAlignment*/>
+  class fn;
+
+// Owning polymorphic function wrapper.
+template <class Signature, size_t BufferSize = /*DefaultSize*/, size_t Alignment = /*DefaultAlignment*/>
+  class unique_fn;
+
+// Classic owning polymorphic function wrapper. (like `std::function`)
+template <class Signature, size_t BufferSize = /*DefaultSize*/, size_t Alignment = /*DefaultAlignment*/>
+  class classic_fn;
+
+// Non-owning polymorphic function wrapper.
+template <class Signature, size_t /*Unused*/ = 0, size_t /*Unused*/ = 0>
+  class fn_ref;
 }
 ```
 
@@ -78,15 +85,16 @@ auto main() -> int {
 
 ```cpp
 /// The definition of method of a function wrapper is as follows:
-        FnWrapper <void(int, char) const, 3*sizeof(void*)> fn_ = +[](int, char) {};
-//          ^       ^   ^~~~~~~      ^     ^~~~~~                 ^~~~~~~~~~~~~
-//          |       |   |            |     |                      |
-// Function wrapper |   |            |     |                      |
-// Return type ~~~~~|   |            |     |                      |
-// Parameters ~~~~~~~~~~|            |     |                      |
-// Qualifier ~~~~~~~~~~~~~~~~~~~~~~~~|     |                      |
-// Buffer size ~~~~~~~~~~~~~~~~~~~~~~~~~~~~|                      |
-// Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
+        FnWrapper <void(int) const, sizeof(int(*)()), alignof(int(*)())> fn_ = +[](int) {};
+//          ^       ^   ^~~    ^    ^~~~~~~~~~~~      ^~~~~~~~~~~~~            ^~~~~~~~~~~
+//          |       |   |      |    |                 |                        |
+// Function wrapper |   |      |    |                 |                        |
+// Return type ~~~~~|   |      |    |                 |                        |
+// Parameters ~~~~~~~~~~|      |    |                 |                        |
+// Qualifier ~~~~~~~~~~~~~~~~~~|    |                 |                        |
+// Buffer size ~~~~~~~~~~~~~~~~~~~~~|                 |                        |
+// Alignment ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|                        |
+// Callable object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
 ```
 
 - *`Function wrapper`*: One of `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn` and `ebd::fn_ref`.
@@ -98,6 +106,8 @@ auto main() -> int {
 - *`Qualifier`*: Applies to the wrapper's `operator()` (e.g., `const`, `noexcept`, `&`, `&&`), restricting which callable objects can be stored.
 
 - *`Buffer size`*: Size (in bytes) of the internal storage. Triggers `static_assert` if insufficient - no heap allocation.
+
+- *`Alignment`*: Alignment (in bytes) of the internal storage. Triggers `static_assert` if insufficient - no heap allocation.
 
 - *`Callable object`*: Any entity callable with the target signature (function pointer, lambda, function object, `std::reference_wrapper`). Copied or moved into the buffer depending on wrapper type.
 
@@ -174,13 +184,17 @@ auto main() -> int {
 graph TB;
   subgraph "Non-Owning wrapper"
     B2["Buffer (Fixed)"]
-    I2["Invoker"]
+    subgraph CT1["Command Table"]
+      I2["Invoker"]
+    end
   end
 
   subgraph "Owning wrapper"
     B1["Buffer (Configurable)"]
-    M1["Manager"]
-    I1["Invoker"]
+    subgraph CT2["Command Table"]
+      M1["Manager"]
+      I1["Invoker"]
+    end
   end
 ```
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ graph TB;
 
 ### Brief introduction
 
-In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided, which can automatically deduce the signature and buffer size of the callable object and create a `ebd::fn`, `ebd::unique_fn` or `ebd::fn_ref` object. (Return `ebd::unique_fn` only when the callable object is of the move-only type. Return `ebd::fn_ref` only when the callable object is `std::cw`.)
+In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided, which can automatically deduce the signature, buffer size and alignment of the callable object and create a `ebd::fn`, `ebd::unique_fn` or `ebd::fn_ref` object. (Return `ebd::unique_fn` only when the callable object is of the move-only type. Return `ebd::fn_ref` only when the callable object is `std::cw`.)
 
 > __NOTE__: 
 > The [Concepts](https://cppreference.com/w/cpp/language/constraints.html) language feature is available for use provided that the compiler is configured to support the C++20 standard. On platforms that do not support C++20, `enable_if` will be used instead.
@@ -217,8 +217,8 @@ In order to simplify the use of `ebd::fn`, function `ebd::make_fn()` is provided
 ```cpp
 // Create empty ebd::fn with specified signature and buffer size.
 // If the BufferSize is omitted, it will be set by default (usually 2*sizeof(void*)).
-auto f = ebd::make_fn<Signature[, BufferSize]>();
-auto f = ebd::make_fn<Signature[, BufferSize]>(nullptr);
+auto f = ebd::make_fn<Signature[, BufferSize[, Alignment]]>();
+auto f = ebd::make_fn<Signature[, BufferSize[, Alignment]]>(nullptr);
 ```
 
 ```cpp

--- a/benchmark/runtime/benchmark_move_only_function.cpp
+++ b/benchmark/runtime/benchmark_move_only_function.cpp
@@ -696,10 +696,10 @@ static void noexcept_params_std(picobench::state& s) {
 }
 
 static void noexcept_params_ebd(picobench::state& s) {
-    ebd::basic_fn<void(int, double) noexcept, 2*sizeof(void*), false, false, false, false> fn = 
-        [](int a, double b) noexcept { 
+    ebd::unique_fn<void(int, double) noexcept> fn =
+        [](int a, double b) noexcept {
             volatile int res = a + static_cast<int>(b);
-            (void)res; 
+            (void)res;
         };
 
     for (auto _ : s) {

--- a/docs/api/basic_fn.md
+++ b/docs/api/basic_fn.md
@@ -9,7 +9,8 @@
 | Parameter | Description |
 |-----------|-------------|
 | `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `BufferSize` | Size of the internal storage (in bytes). The value will be automatically aligned. |
+| `BufferSize` | Size of the internal storage (in bytes). The value will be automatically aligned to a multiple of `Alignment`. |
+| `Alignment` | Alignment of the internal storage (in bytes). |
 | `IsCopyable` | If `true`, the stored callable object must be copy-constructible; otherwise, move-only is sufficient. |
 | `IsView` | If `true`, the wrapper acts as a non-owning view (no copy/move/destroy of the target). |
 | `IsThrowing` | If `true`, calling an empty wrapper throws `std::bad_function_call` (if exceptions are enabled); otherwise, `std::terminate` is called. |
@@ -27,10 +28,15 @@ All member functions of `ebd::detail::function` are available for `ebd::basic_fn
 #include "embed/embed_function.hpp"
 
 // Define a custom move-only, non-throwing function wrapper
-template <typename Signature, std::size_t BufferSize = ebd::detail::default_buffer_size::value>
+template <
+    typename Signature,
+    std::size_t BufferSize = ebd::detail::default_values::owning::buffer_size,
+    std::size_t Alignment = ebd::detail::default_values::owning::alignment
+>
 using unique_safe_fn = ebd::basic_fn<
     Signature,
     BufferSize,
+    Alignment,
     false, // IsCopyable (move-only)
     false, // IsView (owning)
     false, // IsThrowing (call std::terminate() when empty)
@@ -54,6 +60,7 @@ template <typename Signature>
 using large_fn_view = ebd::basic_fn<
     Signature,
     64,    // Larger buffer size
+    ebd::detail::default_values::non_owning::alignment,
     true,  // IsCopyable (views are copyable)
     true,  // IsView (non-owning)
     false, // IsThrowing (call std::terminate() when empty)
@@ -69,8 +76,8 @@ view(42);
 ## Notes
 
 - Prefer using the predefined aliases (`ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, `ebd::fn_ref`) unless you need a combination not covered by them.
-- The buffer size is automatically aligned to the nearest alignment boundary.
-- If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
+- The buffer size is automatically aligned to a multiple of `Alignment`.
+- If the callable object is too large or requires a larger alignment than the specified `BufferSize`/`Alignment`, a `static_assert` will be triggered at compile time.
 
 ## See Also
 

--- a/docs/api/basic_fn.md
+++ b/docs/api/basic_fn.md
@@ -52,27 +52,6 @@ fn = [value = std::move(value)](int x) noexcept { /* use value */ };
 fn(100);
 ```
 
-### Custom View Wrapper with Larger Buffer
-
-```cpp
-// Define a custom view wrapper with a larger buffer
-template <typename Signature>
-using large_fn_view = ebd::basic_fn<
-    Signature,
-    64,    // Larger buffer size
-    ebd::detail::default_values::non_owning::alignment,
-    true,  // IsCopyable (views are copyable)
-    true,  // IsView (non-owning)
-    false, // IsThrowing (call std::terminate() when empty)
-    false  // AssertObjectNoThrow (no requirement)
->;
-
-// Usage
-void foo(int x) { /* do something */ }
-large_fn_view<void(int)> view = &foo;
-view(42);
-```
-
 ## Notes
 
 - Prefer using the predefined aliases (`ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, `ebd::fn_ref`) unless you need a combination not covered by them.

--- a/docs/api/classic_fn.md
+++ b/docs/api/classic_fn.md
@@ -9,7 +9,8 @@
 | Parameter | Description |
 |-----------|-------------|
 | `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_buffer_size::value` if omitted. |
+| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_values::owning::buffer_size` if omitted. |
+| `Alignment` | Alignment of the internal storage (in bytes). Defaults to `detail::default_values::owning::alignment` if omitted. |
 
 ## Configuration
 
@@ -61,8 +62,8 @@ fn(100);
 ## Notes
 
 - `ebd::classic_fn` is copyable and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest alignment boundary.
-- If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
+- The buffer size is automatically aligned to a multiple of the `Alignment` parameter.
+- If the callable object is too large or has a larger alignment than the specified `BufferSize`/`Alignment`, a `static_assert` will be triggered at compile time.
 - When called in an empty state, `ebd::classic_fn` will throw `std::bad_function_call` (if exceptions are enabled), matching `std::function` behavior.
 
 ## See Also

--- a/docs/api/detail/function.md
+++ b/docs/api/detail/function.md
@@ -9,6 +9,7 @@
 | Parameter | Description |
 |-----------|-------------|
 | `BufferSize` | Specifies the size reserved to store the callable object. Must be at least `sizeof(void*)`. |
+| `Alignment` | Specifies the alignment of the internal storage. |
 | `Config` | Specifies the configuration attributes of the wrapper. Must be a `config_package` type. |
 | `Signature` | The function signature of the wrapper, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
 
@@ -68,14 +69,14 @@ Moves another function wrapper.
 #### Conversion Constructor
 
 ```cpp
-template <std::size_t OtherSize, typename OtherCfg, typename OtherSig>
-function(const function<OtherSize, OtherCfg, OtherSig>& other);
+template <std::size_t OtherSize, std::size_t OtherAlign, typename OtherCfg, typename OtherSig>
+function(const function<OtherSize, OtherAlign, OtherCfg, OtherSig>& other);
 
-template <std::size_t OtherSize, typename OtherCfg, typename OtherSig>
-function(function<OtherSize, OtherCfg, OtherSig>&& other);
+template <std::size_t OtherSize, std::size_t OtherAlign, typename OtherCfg, typename OtherSig>
+function(function<OtherSize, OtherAlign, OtherCfg, OtherSig>&& other);
 ```
 
-Converts from another function wrapper with a different buffer size or configuration, if compatible.
+Converts from another function wrapper with a different buffer size, alignment, or configuration, if compatible. The conversion requires the source buffer size and alignment to be no larger than the target's.
 
 #### Functor Constructor
 
@@ -198,6 +199,14 @@ static constexpr std::size_t get_buffer_size() noexcept;
 
 Returns the buffer size of the function wrapper.
 
+#### get_alignment
+
+```cpp
+static constexpr std::size_t get_alignment() noexcept;
+```
+
+Returns the alignment of the function wrapper.
+
 #### is_copyable
 
 ```cpp
@@ -219,17 +228,17 @@ If the wrapped object is a function pointer, returns that pointer; otherwise, re
 ### Comparison Operators
 
 ```cpp
-template <std::size_t Buf, typename Cfg, typename Sig>
-bool operator==(const function<Buf, Cfg, Sig>& fn, std::nullptr_t) noexcept;
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+bool operator==(const function<Buf, Align, Cfg, Sig>& fn, std::nullptr_t) noexcept;
 
-template <std::size_t Buf, typename Cfg, typename Sig>
-bool operator==(std::nullptr_t, const function<Buf, Cfg, Sig>& fn) noexcept;
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+bool operator==(std::nullptr_t, const function<Buf, Align, Cfg, Sig>& fn) noexcept;
 
-template <std::size_t Buf, typename Cfg, typename Sig>
-bool operator!=(const function<Buf, Cfg, Sig>& fn, std::nullptr_t) noexcept;
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+bool operator!=(const function<Buf, Align, Cfg, Sig>& fn, std::nullptr_t) noexcept;
 
-template <std::size_t Buf, typename Cfg, typename Sig>
-bool operator!=(std::nullptr_t, const function<Buf, Cfg, Sig>& fn) noexcept;
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+bool operator!=(std::nullptr_t, const function<Buf, Align, Cfg, Sig>& fn) noexcept;
 ```
 
 Compare a function wrapper with `nullptr` to check if it is empty.
@@ -237,8 +246,8 @@ Compare a function wrapper with `nullptr` to check if it is empty.
 ### swap
 
 ```cpp
-template <std::size_t Buf, typename Cfg, typename Sig>
-void swap(function<Buf, Cfg, Sig>& a, function<Buf, Cfg, Sig>& b)
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+void swap(function<Buf, Align, Cfg, Sig>& a, function<Buf, Align, Cfg, Sig>& b)
   noexcept(noexcept(a.swap(b)));
 ```
 
@@ -249,7 +258,7 @@ using std::swap;
 swap(f1, f2); // calls the ADL swap of ebd
 ```
 
-Both wrappers must be the same specialization (identical `Buf`, `Cfg`, and `Sig`). The `noexcept` specification is inherited from the member `swap()`: it is `noexcept` for view wrappers (`ebd::fn_ref`) and for wrappers with `Config::assertNoThrow == true`, and potentially throwing otherwise (e.g. `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`).
+Both wrappers must be the same specialization (identical `Buf`, `Align`, `Cfg`, and `Sig`). The `noexcept` specification is inherited from the member `swap()`: it is `noexcept` for view wrappers (`ebd::fn_ref`) and for wrappers with `Config::assertNoThrow == true`, and potentially throwing otherwise (e.g. `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`).
 
 ## Performance Characteristics
 
@@ -268,6 +277,7 @@ Both wrappers must be the same specialization (identical `Buf`, `Cfg`, and `Sig`
 // Create a function wrapper for a void() signature
 ebd::detail::function<
     sizeof(void(*)()),
+    ebd::detail::default_values::owning::alignment,
     ebd::detail::config_package<true, false, true, false>,
     void()
 > fn;
@@ -287,6 +297,7 @@ if (fn) {
 // Create a move-only, non-throwing function wrapper
 typedef ebd::detail::function<
     32, // 32-byte buffer
+    ebd::detail::default_values::owning::alignment,
     ebd::detail::config_package<false, false, false, true>, // move-only, non-throwing, assert no-throw
     int(int, int)
 > custom_fn;
@@ -298,6 +309,7 @@ int result = add(10, 20); // result = 30
 ## Notes
 
 - The `ebd::detail::function` class is not intended for direct use. Instead, use the predefined aliases such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`.
-- The buffer size is automatically aligned to the nearest alignment boundary.
+- The buffer size is automatically aligned to a multiple of the `Alignment` parameter.
+- The stored callable object must fit in the buffer and have an alignment no greater than the `Alignment` parameter; otherwise a `static_assert` is triggered.
 - The function wrapper supports all callable objects, including free functions, lambdas, functors, static member functions, and member functions.
 - When `Config::isView` is `true`, the wrapper acts as a non-owning view, similar to `std::function_ref`.

--- a/docs/api/fn.md
+++ b/docs/api/fn.md
@@ -9,7 +9,8 @@
 | Parameter | Description |
 |-----------|-------------|
 | `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_buffer_size::value` if omitted. |
+| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_values::owning::buffer_size` if omitted. |
+| `Alignment` | Alignment of the internal storage (in bytes). Defaults to `detail::default_values::owning::alignment` if omitted. |
 
 ## Configuration
 
@@ -68,8 +69,8 @@ fn(100);
 ## Notes
 
 - `ebd::fn` is copyable and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest alignment boundary.
-- If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
+- The buffer size is automatically aligned to a multiple of the `Alignment` parameter.
+- If the callable object is too large or has a larger alignment than the specified `BufferSize`/`Alignment`, a `static_assert` will be triggered at compile time.
 - When called in an empty state, `ebd::fn` will call `std::terminate()`.
 
 ## See Also

--- a/docs/api/fn_ref.md
+++ b/docs/api/fn_ref.md
@@ -11,7 +11,8 @@ It is an alias of `ebd::detail::function` with specific configuration parameters
 | Parameter | Description |
 |-----------|-------------|
 | `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `Unused` | Unused parameter. Included for consistency with other function wrapper templates. |
+| `Unused_1` | Unused parameter. Included for consistency with other function wrapper templates. |
+| `Unused_2` | Unused parameter. Included for consistency with other function wrapper templates. |
 
 ## Configuration
 
@@ -99,7 +100,7 @@ process_data(100, &handle_result);
 
 - `ebd::fn_ref` is a non-owning view, so the underlying callable object must outlive the view.
 - `ebd::fn_ref` is trivially copyable and has minimal overhead.
-- The buffer size is fixed to `detail::default_buffer_size::ref_buf`, which is sufficient to store function pointers.
+- The buffer size is fixed to `detail::default_values::non_owning::buffer_size`, which is sufficient to store function pointers.
 - `ebd::fn_ref` now can be initialized with rvalue references, although it may create a dangling reference. (same as `std::function_ref`)
 
 ## Compare `ebd::fn_ref` with `std::function_ref`

--- a/docs/api/fn_ref.md
+++ b/docs/api/fn_ref.md
@@ -11,8 +11,6 @@ It is an alias of `ebd::detail::function` with specific configuration parameters
 | Parameter | Description |
 |-----------|-------------|
 | `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `Unused_1` | Unused parameter. Included for consistency with other function wrapper templates. |
-| `Unused_2` | Unused parameter. Included for consistency with other function wrapper templates. |
 
 ## Configuration
 

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -18,19 +18,21 @@ It can:
 ```cpp
 template <typename Signature, typename Functor,
           typename Class = detail::remove_cvref_t<Functor>,
-          bool NoThrow = detail::is_nothrow_construct_from_functor<Functor&&>::value>
-EMBED_NODISCARD inline fn<Signature, sizeof(Class)>
+          bool NoThrow = detail::is_nothrow_construct_from_functor<Functor&&>::value,
+          std::size_t Alignment = detail::enough_alignment<alignof(Class)>::value>
+EMBED_NODISCARD inline fn<Signature, sizeof(Class), Alignment>
 make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
-Creates an `ebd::fn` for a class-type callable when the signature is specified explicitly. The buffer size is automatically deduced as `sizeof(Class)`.
+Creates an `ebd::fn` for a class-type callable when the signature is specified explicitly. The buffer size is automatically deduced as `sizeof(Class)`, and the alignment as `alignof(Class)` (never less than `detail::default_values::owning::alignment`).
 
 ### 2. Move-only functor with explicit signature
 
 ```cpp
 template <typename Signature, typename Functor,
-          bool NoThrow = std::is_nothrow_move_constructible<Functor>::value>
-EMBED_NODISCARD inline unique_fn<Signature, sizeof(Functor)>
+          bool NoThrow = std::is_nothrow_move_constructible<Functor>::value,
+          std::size_t Alignment = detail::enough_alignment<alignof(Functor)>::value>
+EMBED_NODISCARD inline unique_fn<Signature, sizeof(Functor), Alignment>
 make_fn(Functor&& functor) noexcept(NoThrow);
 ```
 
@@ -40,8 +42,9 @@ Creates an `ebd::unique_fn` for a move-only functor when the signature is specif
 
 ```cpp
 template <typename Signature,
-          std::size_t BufferSize = detail::default_buffer_size::value>
-EMBED_NODISCARD inline fn<Signature, BufferSize>
+          std::size_t BufferSize = detail::default_values::owning::buffer_size,
+          std::size_t Alignment = detail::default_values::owning::alignment>
+EMBED_NODISCARD inline fn<Signature, BufferSize, Alignment>
 make_fn(std::nullptr_t = nullptr) noexcept;
 ```
 
@@ -81,9 +84,9 @@ Creates an `ebd::fn` from a free-function pointer using the specified signature.
 ### 6. Copy from another wrapper
 
 ```cpp
-template <std::size_t Buf, typename Cfg, typename Sig>
-EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
-make_fn(const detail::function<Buf, Cfg, Sig>& fn)
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+EMBED_NODISCARD inline detail::function<Buf, Align, Cfg, Sig>
+make_fn(const detail::function<Buf, Align, Cfg, Sig>& fn)
 noexcept(Cfg::isView || Cfg::assertNoThrow);
 ```
 
@@ -92,9 +95,9 @@ Creates a wrapper by copying another `ebd::detail::function`.
 ### 7. Move from another wrapper
 
 ```cpp
-template <std::size_t Buf, typename Cfg, typename Sig>
-EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
-make_fn(detail::function<Buf, Cfg, Sig>&& fn)
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+EMBED_NODISCARD inline detail::function<Buf, Align, Cfg, Sig>
+make_fn(detail::function<Buf, Align, Cfg, Sig>&& fn)
 noexcept(Cfg::isView || Cfg::assertNoThrow);
 ```
 
@@ -106,16 +109,17 @@ Creates a wrapper by moving another `ebd::detail::function`.
 template <typename Lambda,
           typename Class = detail::remove_cvref_t<Lambda>,
           std::size_t BufferSize = sizeof(Class),
+          std::size_t Alignment = detail::enough_alignment<alignof(Class)>::value,
           typename Signature = detail::get_unique_signature_t<Class>,
           typename Fn = detail::conditional_t<
               std::is_copy_constructible<Class>::value,
-              fn<Signature, BufferSize>,
-              unique_fn<Signature, BufferSize>>,
+              fn<Signature, BufferSize, Alignment>,
+              unique_fn<Signature, BufferSize, Alignment>>,
           bool NoThrow = detail::is_nothrow_construct_from_functor<Lambda&&>::value>
 EMBED_NODISCARD inline Fn make_fn(Lambda&& fn) noexcept(NoThrow);
 ```
 
-Creates a wrapper from a lambda or other functor with exactly one viable `operator()`. The signature is deduced automatically.
+Creates a wrapper from a lambda or other functor with exactly one viable `operator()`. The signature is deduced automatically; the buffer size and alignment are deduced from `sizeof(Class)` and `alignof(Class)` respectively.
 
 ### 9. Pointer to member function
 
@@ -169,7 +173,7 @@ make_fn(std::in_place_type_t<Functor>, std::initializer_list<U> il, CArgs&&... a
 noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs...>::value);
 ```
 
-Constructs the callable directly inside the wrapper buffer. The returned wrapper type is deduced from the functor.
+Constructs the callable directly inside the wrapper buffer. The returned wrapper type is deduced from the functor, and the buffer size and alignment are deduced from `sizeof(Functor)` and `alignof(Functor)` respectively.
 
 ### 13. From `std::constant_wrapper` (C++26+)
 
@@ -192,7 +196,7 @@ Creates an `ebd::fn_ref` from a `std::constant_wrapper` together with an object 
 ### 15. Explicit wrapper type
 
 ```cpp
-template <template <class, std::size_t> class Fn,
+template <template <class, std::size_t, std::size_t> class Fn,
           typename SpecifiedSig = void,
           typename... Args,
           typename Deduction = decltype(make_fn(std::declval<Args>()...)),
@@ -202,13 +206,15 @@ template <template <class, std::size_t> class Fn,
               detail::get_correct_signature_t<Fn, RawSig>,
               SpecifiedSig>,
           std::size_t BufferSize =
-              detail::get_correct_buffer_size<Fn<int(), 0>, Deduction::get_buffer_size(), Args...>::value,
-          typename FnWrapper = Fn<Signature, BufferSize>,
+              detail::get_correct_buffer_size<Fn<int(), 0, alignof(int*)>, Deduction::get_buffer_size(), Args...>::value,
+          std::size_t Alignment = detail::is_ebd_fn<Fn<int(), 0, alignof(int*)>>::config::isView ?
+              detail::default_values::non_owning::alignment : Deduction::get_alignment(),
+          typename FnWrapper = Fn<Signature, BufferSize, Alignment>,
           bool NoThrow = noexcept(FnWrapper(std::declval<Args>()...))>
 EMBED_NODISCARD inline FnWrapper make_fn(Args&&... args) noexcept(NoThrow);
 ```
 
-Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. Accepts multiple arguments: the wrapper type and signature are deduced from `make_fn(args...)`, and the buffer size is taken from the deduced result (when an argument is another ebd wrapper that is not directly config-convertible, the buffer is sized to fit that wrapper object for indirect wrapping). If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(args...)`. This also enables in-place construction with a specific wrapper, e.g. `make_fn<ebd::fn>(std::in_place_type<Functor>, 0)`.
+Creates a wrapper with an explicitly chosen wrapper template such as `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`. Accepts multiple arguments: the wrapper type and signature are deduced from `make_fn(args...)`, and the buffer size is taken from the deduced result (when an argument is another ebd wrapper that is not directly config-convertible, the buffer is sized to fit that wrapper object for indirect wrapping). For owning wrappers the alignment is taken from the deduced result, while view wrappers use the non-owning default alignment. If `SpecifiedSig` is omitted, the signature is deduced from `make_fn(args...)`. This also enables in-place construction with a specific wrapper, e.g. `make_fn<ebd::fn>(std::in_place_type<Functor>, 0)`.
 
 ## Usage Examples
 
@@ -307,6 +313,7 @@ auto cw_mem_obj = ebd::make_fn(std::cw<&MyClass::value>, &obj);
 ## Notes
 
 - `ebd::make_fn` returns `ebd::fn` for copyable deduced callables and `ebd::unique_fn` for move-only deduced callables.
+- The buffer size and alignment of the resulting wrapper are deduced from the functor (`sizeof`/`alignof`). For over-aligned functors (with `alignof` greater than `detail::default_values::owning::alignment`), the alignment is automatically raised so the wrapper can store the object safely.
 - When the callable is ambiguous, such as an overloaded function, specify the signature explicitly.
 - The explicit-wrapper overload accepts multiple arguments and works with `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, and `ebd::fn_ref`. The buffer size is deduced from the `make_fn(args...)` result instead of `sizeof(Functor)`.
 - `ebd::fn_view` is still available as a deprecated alias of `ebd::fn_ref`.

--- a/docs/api/safe_fn.md
+++ b/docs/api/safe_fn.md
@@ -9,9 +9,13 @@ Please use [`ebd::fn`](./fn.md) instead.
 The `safe_fn` alias still works but has been deprecated. If you migrate to `ebd::fn`, note that `AssertObjectNoThrow` changes to `false` — meaning `ebd::fn` no longer requires the callable object to be noexcept-constructible/destructible. If you need the `AssertObjectNoThrow=true` guarantee, use `ebd::basic_fn` directly:
 
 ```cpp
-template <typename Signature, std::size_t BufferSize = ebd::detail::default_buffer_size::value>
+template <
+    typename Signature,
+    std::size_t BufferSize = ebd::detail::default_values::owning::buffer_size,
+    std::size_t Alignment = ebd::detail::default_values::owning::alignment
+>
 using my_safe_fn = ebd::basic_fn<
-    Signature, ebd::detail::get_aligned_size(BufferSize),
+    Signature, BufferSize, Alignment,
     true,  // IsCopyable
     false, // IsView
     false, // IsThrowing

--- a/docs/api/safe_fn.md
+++ b/docs/api/safe_fn.md
@@ -6,7 +6,7 @@ Please use [`ebd::fn`](./fn.md) instead.
 
 ### Migration Note
 
-The `safe_fn` alias still works but has been deprecated. If you migrate to `ebd::fn`, note that `AssertObjectNoThrow` changes to `false` — meaning `ebd::fn` no longer requires the callable object to be noexcept-constructible/destructible. If you need the `AssertObjectNoThrow=true` guarantee, use `ebd::basic_fn` directly:
+The `safe_fn` alias still works but has been deprecated. If you migrate to `ebd::fn`, note that `AssertObjectNoThrow` changes to `false`, which means `ebd::fn` no longer requires the callable object to be noexcept-constructible/destructible. If you need the `AssertObjectNoThrow=true` guarantee, use `ebd::basic_fn` directly:
 
 ```cpp
 template <

--- a/docs/api/unique_fn.md
+++ b/docs/api/unique_fn.md
@@ -9,7 +9,8 @@
 | Parameter | Description |
 |-----------|-------------|
 | `Signature` | Function signature, e.g., `Ret(Args...)` or `Ret(Args...) const`. |
-| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_buffer_size::value` if omitted. |
+| `BufferSize` | Buffer size used for storing the callable object. Defaults to `detail::default_values::owning::buffer_size` if omitted. |
+| `Alignment` | Alignment of the internal storage (in bytes). Defaults to `detail::default_values::owning::alignment` if omitted. |
 
 ## Configuration
 
@@ -74,8 +75,8 @@ fn(100);
 ## Notes
 
 - `ebd::unique_fn` is move-only and owns the callable object it wraps.
-- The buffer size is automatically aligned to the nearest alignment boundary.
-- If the callable object is too large for the specified buffer size, a `static_assert` will be triggered at compile time.
+- The buffer size is automatically aligned to a multiple of the `Alignment` parameter.
+- If the callable object is too large or has a larger alignment than the specified `BufferSize`/`Alignment`, a `static_assert` will be triggered at compile time.
 - When called in an empty state, `ebd::unique_fn` will call `std::terminate()`.
 
 ## See Also

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -12,4 +12,4 @@
 - None.
 
 **📌 Notes**
-- None.
+- `operator bool` still works but may warn. It will be removed in a future release.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -2,11 +2,11 @@
 - None.
 
 **⚠️ Breaking Changes**
-- Added an `Alignment` template parameter to polymorphic function wrappers, which changes its template argument list. Existing code that directly instantiates `basic_fn` is affected; other wrappers (`ebd::fn`, `ebd::unique_fn`, etc.) are unaffected as the new parameter has a default value.
+- Added an `Alignment` template parameter to polymorphic function wrappers, which changes its template argument list. Existing code that directly instantiates `basic_fn` is affected; other wrappers (`ebd::fn`, `ebd::unique_fn`, etc.) are unaffected as the new parameter has a default value. (#147)
 
 **✨ New Features**
-- Added the `Alignment` template parameter to specify the alignment of the internal storage.
-- `make_fn` now automatically deduces the alignment from the callable object.
+- Added the `Alignment` template parameter to specify the alignment of the internal storage. (#147)
+- `make_fn` now automatically deduces the alignment from the callable object. (#147)
 
 **🛠️ Optimizations and Improvements**
 - None.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -1,14 +1,15 @@
 **🔧 Fixed Bugs**
-- Fixed incorrect stateless detection in `is_stateless`: functors with copy side effects (non-trivially-copyable) were treated as stateless, causing copies to be elided. (#145)
+- None.
 
 **⚠️ Breaking Changes**
-- Deprecated `operator bool`. Use `!f.is_empty()` instead. (#143)
+- Added an `Alignment` template parameter to polymorphic function wrappers, which changes its template argument list. Existing code that directly instantiates `basic_fn` is affected; other wrappers (`ebd::fn`, `ebd::unique_fn`, etc.) are unaffected as the new parameter has a default value.
 
 **✨ New Features**
-- None.
+- Added the `Alignment` template parameter to specify the alignment of the internal storage.
+- `make_fn` now automatically deduces the alignment from the callable object.
 
 **🛠️ Optimizations and Improvements**
 - None.
 
 **📌 Notes**
-- `operator bool` still works but may warn. It will be removed in a future release.
+- None.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -2,7 +2,7 @@
 - None.
 
 **⚠️ Breaking Changes**
-- Added an `Alignment` template parameter to polymorphic function wrappers, which changes its template argument list. Existing code that directly instantiates `basic_fn` is affected; other wrappers (`ebd::fn`, `ebd::unique_fn`, etc.) are unaffected as the new parameter has a default value. (#147)
+- Added an `Alignment` template parameter to polymorphic function wrappers, which changes their template argument list. Existing code that directly instantiates `basic_fn` is affected; other wrappers (`ebd::fn`, `ebd::unique_fn`, etc.) are unaffected as the new parameter has a default value. (#147)
 
 **✨ New Features**
 - Added the `Alignment` template parameter to specify the alignment of the internal storage. (#147)

--- a/example/basic_usage.cpp
+++ b/example/basic_usage.cpp
@@ -1,4 +1,4 @@
-/// basic_usage.cpp — four wrapper types: fn, unique_fn, classic_fn, fn_ref
+/// Four wrapper types: fn, unique_fn, classic_fn, fn_ref
 #include <iostream>
 #include <memory>
 #include <embed/embed_function.hpp>

--- a/example/callback_abstraction.cpp
+++ b/example/callback_abstraction.cpp
@@ -1,4 +1,4 @@
-/// callback_abstraction.cpp — fn_ref as zero-overhead callback param, fn as stored callback
+/// `fn_ref` as zero-overhead callback param, fn as stored callback
 #include <iostream>
 #include <vector>
 #include <embed/embed_function.hpp>

--- a/example/make_fn_deduction.cpp
+++ b/example/make_fn_deduction.cpp
@@ -1,4 +1,4 @@
-/// make_fn_deduction.cpp — auto-deduced signature, member function wrapping, operator* fallback
+/// Auto-deduced signature, member function wrapping, operator* fallback
 #include <iostream>
 #include <embed/embed_function.hpp>
 

--- a/example/member_binding.cpp
+++ b/example/member_binding.cpp
@@ -1,4 +1,4 @@
-/// member_binding.cpp — member function wrapping, object binding, wrapper conversions
+/// Member function wrapping, object binding, wrapper conversions
 #include <iostream>
 #include <string>
 #include <embed/embed_function.hpp>

--- a/example/thread_pool.cpp
+++ b/example/thread_pool.cpp
@@ -1,4 +1,4 @@
-/// thread_pool.cpp — simple thread pool using ebd::unique_fn for move-only task storage
+/// Simple thread pool using ebd::unique_fn for move-only task storage
 #include <iostream>
 #include <thread>
 #include <mutex>
@@ -12,7 +12,7 @@
 
 class ThreadPool {
 private:
-    // Task_t = ebd::unique_fn<void(), Auto-Deducing>
+    // Task_t = ebd::unique_fn<void(), Auto-Deduction, Auto-Deduction>
     using Task_t = decltype(ebd::make_fn<void()>(std::packaged_task<void()>{}));
 
     std::vector<std::thread> m_wokers;

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -840,7 +840,7 @@ inline namespace cxx_traits {
 } // end namespace cxx_traits
 
   // Forward declaration.
-  template <std::size_t BufferSize, typename Config, typename Signature>
+  template <std::size_t BufferSize, std::size_t Alignment, typename Config, typename Signature>
   class EMBED_DETAIL_FORCE_EBO function;
 
 /// @brief Here are some self-defined traits.
@@ -956,18 +956,16 @@ inline namespace fn_traits {
   struct is_ebd_fn_impl : public std::false_type {
     using signature = void;
     using config = void;
-    static constexpr std::size_t buffer = 0;
   };
 
-  template <std::size_t Buf, typename Cfg, typename Sig>
-  struct is_ebd_fn_impl<function<Buf, Cfg, Sig>>
+  template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+  struct is_ebd_fn_impl<function<Buf, Align, Cfg, Sig>>
   : public bool_constant<
     unwrap_signature<Sig>::isSignature
     && is_config_package<Cfg>::value
   > {
     using signature = Sig;
     using config = Cfg;
-    static constexpr std::size_t buffer = Buf;
   };
 
   // Check whether the type is `ebd::detail::function` or not.
@@ -1067,10 +1065,10 @@ inline namespace fn_traits {
   template <typename To, typename From>
   struct is_convertible_from_specialization_impl : public std::false_type {};
 
-  template <std::size_t BufTo, typename CfgTo, typename SigTo,
-    std::size_t BufFrom, typename CfgFrom, typename SigFrom>
+  template <std::size_t BufTo, std::size_t AlignTo, typename CfgTo, typename SigTo,
+    std::size_t BufFrom, std::size_t AlignFrom, typename CfgFrom, typename SigFrom>
   struct is_convertible_from_specialization_impl<
-    function<BufTo, CfgTo, SigTo>, function<BufFrom, CfgFrom, SigFrom>
+    function<BufTo, AlignTo, CfgTo, SigTo>, function<BufFrom, AlignFrom, CfgFrom, SigFrom>
   > {
     // Get the unwrap trait.
     using unwrap_to = unwrap_signature<SigTo>;
@@ -1089,6 +1087,9 @@ inline namespace fn_traits {
     // Check the buffer size of `To` is bigger `From` or equals.
     static constexpr bool buf_ok = BufTo >= BufFrom;
 
+    // Check the alignment is ok.
+    static constexpr bool align_ok = AlignTo >= AlignFrom;
+
     // Check the Configuration.
     static constexpr bool cfg_ok = is_config_convertible<CfgTo, CfgFrom>::value;
 
@@ -1100,10 +1101,10 @@ inline namespace fn_traits {
     static constexpr bool qualifier_ok =
       // The `const` and `noexcept` checks in the Non-owning context have certain peculiarities.
       noexcept_qualifier_ok && unwrap_to::hasConst <= unwrap_from::hasConst
-      && is_callable_from_impl<function<BufFrom, CfgFrom, SigFrom>, SigTo>::value;
+      && is_callable_from_impl<function<BufFrom, AlignFrom, CfgFrom, SigFrom>, SigTo>::value;
 
     static constexpr bool value =
-      buf_ok && cfg_ok && sig_ret_ok && sig_args_ok && qualifier_ok;
+      buf_ok && cfg_ok && sig_ret_ok && sig_args_ok && qualifier_ok && align_ok;
   };
 
   // If the `From` type can be converted to the `To` type, then the value is `true`.
@@ -1146,24 +1147,32 @@ inline namespace fn_traits {
   class EMBED_DETAIL_VIRTUAL_INHERITANCE UndefinedClass;
 
   // The default buffer size. Usually is 2 * sizeof(void*).
-  struct default_buffer_size {
-    // The buffer size for ebd::fn_ref. Stop supporting pointer-to-members.
-    static constexpr std::size_t ref_buf = sizeof(void (*) ());
-    static constexpr std::size_t value = sizeof(void (UndefinedClass::*) ());
+  struct default_values {
+    struct owning {
+      static constexpr std::size_t buffer_size = sizeof(void(UndefinedClass::*)());
 
-    // The alignment for owning wrappers (ebd::fn, ebd::unique_fn, ebd::classic_fn).
-    // Using alignof(std::max_align_t) ensures that objects with the maximum
-    // fundamental alignment can be stored in the internal buffer.
-    static constexpr std::size_t align_value = alignof(std::max_align_t);
+      // The alignment for owning wrappers (ebd::fn, ebd::unique_fn, ebd::classic_fn).
+      // Using alignof(std::max_align_t) ensures that objects with the maximum
+      // fundamental alignment can be stored in the internal buffer.
+      static constexpr std::size_t alignment = alignof(std::max_align_t);
+    };
 
-    // The alignment for non-owning wrapper (ebd::fn_ref).
-    static constexpr std::size_t view_align_value = alignof(void (*) ());
+    struct non_owning {
+      // The buffer size for ebd::fn_ref. Stop supporting pointer-to-members.
+      static constexpr std::size_t buffer_size = sizeof(void(*)());
+
+      // The alignment for non-owning wrapper (ebd::fn_ref).
+      static constexpr std::size_t alignment = alignof(void(*)());
+    };
   };
 
-  // Get aligned size. Rounds up to the nearest MinAlign size.
-  template <std::size_t MinAlign = default_buffer_size::align_value>
-  constexpr std::size_t get_aligned_size(std::size_t size)
-  { return size == 0 ? MinAlign : ((size - 1) / MinAlign + 1) * MinAlign; }
+  // Get aligned size. Rounds up to the nearest Alignment size.
+  template <std::size_t Alignment>
+  constexpr std::size_t get_aligned_size(std::size_t size) {
+    static_assert(Alignment >= alignof(void(*)()), "The alignment must be greater than `alignof(void(*)())`.");
+    static_assert((Alignment & (Alignment-1)) == 0, "The alignment must be a power of two.");
+    return size == 0 ? Alignment : ((size - 1) / Alignment + 1) * Alignment;
+  }
 
   // Check whether throwing operations are acceptable.
   template <typename Functor, typename Object, typename Config,
@@ -1196,9 +1205,9 @@ inline namespace fn_traits {
     template <typename T>
     static constexpr bool not_empty(const T&) noexcept { return true; }
 
-    template <std::size_t Buf, typename Cfg, typename Sig,
+    template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig,
       EMBED_DETAIL_REQUIRES(!Cfg::isView) /*OWNING*/> static
-    EMBED_CXX14_CONSTEXPR bool not_empty(const function<Buf, Cfg, Sig>& f) noexcept
+    EMBED_CXX14_CONSTEXPR bool not_empty(const function<Buf, Align, Cfg, Sig>& f) noexcept
     { return !f.is_empty(); }
 
 #if __STDC_HOSTED__
@@ -1563,14 +1572,15 @@ inline namespace fn_traits {
   template <typename Function, typename Signature>
   struct get_correct_signature; // Undefined
 
-#define EMBED_DETAIL_GET_CORRECT_SIGNATURE_DEFINE(C, V, REF, NOEXCEPT)                  \
-  template <std::size_t Buf, typename Cfg, typename Sig, typename Ret, typename... Args>\
-  struct get_correct_signature<function<Buf, Cfg, Sig>, Ret(Args...) C V REF NOEXCEPT> {\
-    /* MSVC 14.36~14.44 regression: noexcept(!Cfg::isThrowing) trigger ICE. */          \
-    using sig_normal = conditional_t<!Cfg::isThrowing,                                  \
-      Ret(Args...) C V REF NOEXCEPT, Ret(Args...) C V REF>;                             \
-    using sig_view = Ret(Args...) C V NOEXCEPT;                                         \
-    using type = conditional_t<Cfg::isView, sig_view, sig_normal>;                      \
+#define EMBED_DETAIL_GET_CORRECT_SIGNATURE_DEFINE(C, V, REF, NOEXCEPT)                          \
+  template <std::size_t Buf, std::size_t Align, typename Cfg,                                   \
+    typename Sig, typename Ret, typename... Args>                                               \
+  struct get_correct_signature<function<Buf, Align, Cfg, Sig>, Ret(Args...) C V REF NOEXCEPT> { \
+    /* MSVC 14.36~14.44 regression: noexcept(!Cfg::isThrowing) trigger ICE. */                  \
+    using sig_normal = conditional_t<!Cfg::isThrowing,                                          \
+      Ret(Args...) C V REF NOEXCEPT, Ret(Args...) C V REF>;                                     \
+    using sig_view = Ret(Args...) C V NOEXCEPT;                                                 \
+    using type = conditional_t<Cfg::isView, sig_view, sig_normal>;                              \
   };
 
   EMBED_DETAIL_FN_EXPAND(EMBED_DETAIL_GET_CORRECT_SIGNATURE_DEFINE)
@@ -1580,9 +1590,9 @@ inline namespace fn_traits {
   // Remove `noexcept` qualifier if the `Fn` is configured to `IsThrowing = true`
   // as well as `IsView = false`, and remove `&` or `&&` qualifier if the `Fn` is
   // configured to `IsView = true`.
-  template <template <class, std::size_t> class Fn, typename Sig>
+  template <template <class, std::size_t, std::size_t> class Fn, typename Sig>
   using get_correct_signature_t =
-    typename get_correct_signature<Fn<Sig, sizeof(void(*)())>, Sig>::type;
+    typename get_correct_signature<Fn<Sig, sizeof(int*), alignof(int*)>, Sig>::type;
 
   // Check if `T` is the stateless standard operator wrapper.
   template <typename T> struct is_std_op_wrapper : std::false_type {};
@@ -1653,10 +1663,11 @@ inline namespace fn_traits {
       "                                         ^^^^^^^^^\n\n"
       "The `Signature` is like `void()`, `float(int,int) const`;\n"
       "The `BufferSize` is the size (in bytes) of the internal storage;\n"
-      "The `FnWrapper` is an alias of `ebd::basic_fn` and has `template <class, std::size_t>` "
-      "as a template argument list, such as `ebd::fn_ref`, `ebd::classic_fn`, etc. If omitted, "
-      "the `FnWrapper` will be inferred to be `ebd::fn` if the `CallableObject` is copyable, "
-      "and `ebd::unique_fn` otherwise."
+      "The `FnWrapper` is an alias of `ebd::basic_fn` and has "
+      "`template <class, std::size_t, std::size_t>` as a template argument "
+      "list, such as `ebd::fn_ref`, `ebd::classic_fn`, etc. If omitted, the "
+      "`FnWrapper` will be inferred to be `ebd::fn` if the `CallableObject` "
+      "is copyable, and `ebd::unique_fn` otherwise."
     );
     return true;
   }
@@ -1715,6 +1726,12 @@ inline namespace fn_traits {
   struct get_correct_buffer_size<FnWrapper, Candidate, Arg>
   : public get_correct_buffer_size_helper<is_ebd_fn<Arg>::value, FnWrapper, Candidate, Arg> {};
 
+  template <std::size_t Alignment>
+  struct enough_alignment {
+    static constexpr std::size_t value =
+      Alignment > default_values::owning::alignment ? Alignment : default_values::owning::alignment;
+  };
+
 } // end namespace fn_traits
 
 // In the namespace "erasure_type", we define a series of
@@ -1745,12 +1762,9 @@ namespace erasure_type {
   // placement new. After that, using `access` to obtain the address or reference
   // (rather than the content) is also in accordance with the C++ standard.
   // See <https://eel.is/c++draft/basic.life#7>.
-  template <bool IsView, std::size_t Size>
+  template <bool IsView, std::size_t Size, std::size_t Align>
   struct EMBED_DETAIL_ALIAS Erasure : public ErasureBase {
-    alignas(IsView
-            ? default_buffer_size::view_align_value
-            : default_buffer_size::align_value)
-    ErasureCore<Size> m_core;
+    alignas(Align) ErasureCore<Size> m_core;
 
     // Access the pointer of erasureCore that qualified with nothing or const.
     EMBED_NODISCARD void* access() noexcept { return &m_core.pod[0]; }
@@ -1841,15 +1855,16 @@ namespace invocation {
 # define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)
 #endif
 
-  template <std::size_t Size, typename Config, typename Signature>
+  template <std::size_t Size, std::size_t Align, typename Config, typename Signature>
   struct InvokerImpl;
 
 #define EMBED_DETAIL_INVOKER_IMPL_DEFINE(C, V, REF, NOEXCEPT)                         \
-  template <std::size_t Size, typename Config, typename Ret, typename... Args>        \
-  struct InvokerImpl<Size, Config, Ret(Args...) C V REF NOEXCEPT> {                   \
+  template <std::size_t Size, std::size_t Align, typename Config,                     \
+    typename Ret, typename... Args>                                                   \
+  struct InvokerImpl<Size, Align, Config, Ret(Args...) C V REF NOEXCEPT> {            \
   public:                                                                             \
     using erasure_base_t = erasure_type::ErasureBase;                                 \
-    using erasure_t = erasure_type::Erasure<Config::isView, Size>;                    \
+    using erasure_t = erasure_type::Erasure<Config::isView, Size, Align>;             \
     using erasure_pass_t = erasure_type::ErasurePass C;                               \
     static constexpr bool is_rvalue_ref =                                             \
       std::is_rvalue_reference<int REF>::value;                                       \
@@ -1933,10 +1948,10 @@ namespace invocation {
 // types for objects that implement the behaviour of management.
 namespace management {
 
-  template <std::size_t Size, typename Config, typename Signature>
+  template <std::size_t Size, std::size_t Align, typename Config, typename Signature>
   struct ManagerImpl {
   private:
-    using invoke_impl_t = invocation::InvokerImpl<Size, Config, Signature>;
+    using invoke_impl_t = invocation::InvokerImpl<Size, Align, Config, Signature>;
     using erasure_base_t  = typename invoke_impl_t::erasure_base_t;
     using erasure_t       = typename invoke_impl_t::erasure_t;
 
@@ -2075,15 +2090,15 @@ namespace management {
 namespace command {
 
   /// @note CommandTable is trivial
-  template <bool IsView, std::size_t Size,
+  template <bool IsView, std::size_t Size, std::size_t Align,
     typename Config, typename Signature, typename ArgsPackage>
   struct CommandTable;
 
   // Command Table for inplace mode.
-  template <std::size_t Size, typename Config, typename Signature, typename... Args>
-  struct CommandTable</* IsView = */ false, Size, Config, Signature, args_package<Args...>> {
-    using invoker_impl_t = invocation::InvokerImpl<Size, Config, Signature>;
-    using manager_impl_t = management::ManagerImpl<Size, Config, Signature>;
+  template <std::size_t Size, std::size_t Align, typename Config, typename Signature, typename... Args>
+  struct CommandTable</* IsView = */ false, Size, Align, Config, Signature, args_package<Args...>> {
+    using invoker_impl_t = invocation::InvokerImpl<Size, Align, Config, Signature>;
+    using manager_impl_t = management::ManagerImpl<Size, Align, Config, Signature>;
     using invoker_t       = typename invoker_impl_t::invoker_type;
     using erasure_base_t  = typename invoker_impl_t::erasure_base_t;
     using erasure_pass_t  = typename invoker_impl_t::erasure_pass_t;
@@ -2157,10 +2172,10 @@ namespace command {
   };
 
   // Command Table for view mode.
-  template <std::size_t Size, typename Config, typename Signature, typename... Args>
-  struct CommandTable</* IsView = */ true, Size, Config, Signature, args_package<Args...>> {
-    using invoker_impl_t = invocation::InvokerImpl<Size, Config, Signature>;
-    using manager_impl_t = management::ManagerImpl<Size, Config, Signature>;
+  template <std::size_t Size, std::size_t Align, typename Config, typename Signature, typename... Args>
+  struct CommandTable</* IsView = */ true, Size, Align, Config, Signature, args_package<Args...>> {
+    using invoker_impl_t = invocation::InvokerImpl<Size, Align, Config, Signature>;
+    using manager_impl_t = management::ManagerImpl<Size, Align, Config, Signature>;
     using invoker_t       = typename invoker_impl_t::invoker_type;
     using erasure_base_t  = typename invoker_impl_t::erasure_base_t;
     using erasure_pass_t  = typename invoker_impl_t::erasure_pass_t;
@@ -2173,7 +2188,7 @@ namespace command {
     const noexcept {
       auto* destination = static_cast<erasure_t*>(dst);
       auto* source = static_cast<erasure_t const*>(src);
-      std::memcpy(destination->access(), source->access(), default_buffer_size::ref_buf);
+      std::memcpy(destination->access(), source->access(), default_values::non_owning::buffer_size);
     }
 
     void move(erasure_base_t*, erasure_base_t*) = delete;
@@ -2502,9 +2517,9 @@ namespace crtp_mixins {
   // to the base class to achieve greater flexibility.
   /// @attention This class must be placed first in the inheritance list; otherwise, there
   /// will be an out-of-order error when it comes to move constructors and move assignments.
-  template <std::size_t BufferSize, typename Config, typename Signature>
+  template <std::size_t Size, std::size_t Align, typename Config, typename Signature>
   struct EMBED_DETAIL_FORCE_EBO member_variable_impl : public assignment_self_clear<
-    /* Self = */ function<BufferSize, Config, Signature>, Config, Config::isView
+    /* Self = */ function<Size, Align, Config, Signature>, Config, Config::isView
   > {
     EMBED_DETAIL_ALL_DEFAULT(member_variable_impl)
 
@@ -2512,9 +2527,9 @@ namespace crtp_mixins {
     constexpr member_variable_impl(std::nullptr_t) noexcept
     : m_erasure(erasure_t{}), m_command(command_t{}) {}
 
-    using erasure_t = erasure_type::Erasure<Config::isView, BufferSize>;
+    using erasure_t = erasure_type::Erasure<Config::isView, Size, Align>;
     using command_t = command::CommandTable<
-      Config::isView, BufferSize, Config, Signature,
+      Config::isView, Size, Align, Config, Signature,
       typename unwrap_signature<Signature>::args>;
 
   protected:
@@ -2557,13 +2572,13 @@ namespace crtp_mixins {
   };
 
   /// @brief Implement core components for function wrapper.
-  template <bool IsView, std::size_t BufferSize, typename Config, typename Signature, typename Self>
+  template <bool IsView, typename Config, typename Signature, typename Self>
   struct core_components_impl; // undefined
 
   // Implement the Ctor, assignment operator, swap(), is_empty()
   // operator bool, etc for normal function wrapper.
-  template <std::size_t BufferSize, typename Config, typename Signature, typename Self>
-  struct core_components_impl</*IsView=*/ false, BufferSize, Config, Signature, Self> {
+  template <typename Config, typename Signature, typename Self>
+  struct core_components_impl</*IsView=*/ false, Config, Signature, Self> {
     EMBED_DETAIL_ALL_DEFAULT(core_components_impl)
 
     // Construct an empty wrapper.
@@ -2633,8 +2648,8 @@ namespace crtp_mixins {
 
   // Implement the Ctor, assignment operator, swap(), is_empty()
   // operator bool, etc for function reference (function view).
-  template <std::size_t BufferSize, typename Config, typename Signature, typename Self>
-  struct core_components_impl</*IsView=*/ true, BufferSize, Config, Signature, Self> {
+  template <typename Config, typename Signature, typename Self>
+  struct core_components_impl</*IsView=*/ true, Config, Signature, Self> {
     EMBED_DETAIL_ALL_DEFAULT(core_components_impl)
 
     // Empty state of function view is removed.
@@ -2663,35 +2678,36 @@ namespace crtp_mixins {
 
   /// @brief A lightweight and heap-free wrapper for callable objects.
   /// @tparam BufferSize - Specifies the size reserved to store the object.
+  /// @tparam Alignment - Specifies the alignment of buffer to store the object.
   /// @tparam Config - Specifies the configuration attributes of the wrapper.
   ///           See @def config_package for details.
   /// @tparam Signature - The signature of the wrapper, e.g., @e `Ret(Args...)`.
-  template <std::size_t BufferSize, typename Config, typename Signature>
+  template <std::size_t BufferSize, std::size_t Alignment, typename Config, typename Signature>
   class EMBED_DETAIL_FORCE_EBO function final
     : protected crtp_mixins::member_variable_impl<
-        /* Buf = */ BufferSize, /* Cfg = */ Config, /* Sig = */ Signature
+        /* Buf = */ BufferSize, /* Align = */ Alignment, /* Cfg = */ Config, /* Sig = */ Signature
       >,
       public crtp_mixins::operator_call_impl<
         /* IsView = */ Config::isView, /* Signature = */ Signature,
-        /* Self = */ function<BufferSize, Config, Signature>
+        /* Self = */ function<BufferSize, Alignment, Config, Signature>
       >,
       public crtp_mixins::operator_dereference_impl<
-        Signature, /* Self = */ function<BufferSize, Config, Signature>,
+        Signature, /* Self = */ function<BufferSize, Alignment, Config, Signature>,
         /* IsView = */ Config::isView
       >,
       public crtp_mixins::lifetime_operations_impl<
         /* IsView = */ Config::isView, /* IsCopyable = */ Config::isCopyable,
-        Config, /* Self = */ function<BufferSize, Config, Signature>
+        Config, /* Self = */ function<BufferSize, Alignment, Config, Signature>
       >,
       public crtp_mixins::core_components_impl<
-        /* IsView = */ Config::isView, /* BufferSize = */ BufferSize,
+        /* IsView = */ Config::isView,
         /* Config = */ Config, /* Signature = */ Signature,
-        /* Self = */ function<BufferSize, Config, Signature>
+        /* Self = */ function<BufferSize, Alignment, Config, Signature>
       >
   {
   private:
 
-    template<std::size_t, typename, typename>
+    template<std::size_t, std::size_t, typename, typename>
     friend class function;
 
     template <bool, typename, typename>
@@ -2709,13 +2725,14 @@ namespace crtp_mixins {
     template <typename, typename, bool, typename>
     friend struct crtp_mixins::operator_dereference_impl;
 
-    template <bool, std::size_t, typename, typename, typename>
+    template <bool, typename, typename, typename>
     friend struct crtp_mixins::core_components_impl;
 
-    using Base_MemberVariable = crtp_mixins::member_variable_impl<BufferSize, Config, Signature>;
+    using Base_MemberVariable =
+      crtp_mixins::member_variable_impl<BufferSize, Alignment, Config, Signature>;
 
     using Base_CoreComponents =
-      crtp_mixins::core_components_impl<Config::isView, BufferSize, Config, Signature, function>;
+      crtp_mixins::core_components_impl<Config::isView, Config, Signature, function>;
 
     using erasure_t = typename Base_MemberVariable::erasure_t;
 
@@ -2749,6 +2766,10 @@ namespace crtp_mixins {
     /// @brief Get the buffer size.
     EMBED_NODISCARD EMBED_INLINE static constexpr std::size_t
     get_buffer_size() noexcept { return BufferSize; }
+
+    /// @brief Get the alignment.
+    EMBED_NODISCARD EMBED_INLINE static constexpr std::size_t
+    get_alignment() noexcept { return Alignment; }
 
     /// @brief Return `true` if the function is copyable.
     EMBED_NODISCARD EMBED_INLINE static constexpr bool
@@ -2784,11 +2805,12 @@ namespace crtp_mixins {
     // From `function<Buffer_small, ...>` to `function<Buffer_big, ...>`.
     // Used in both OWNING mode and NON-OWNING mode.
     EMBED_DETAIL_TEMPLATE_BEGIN(
-      std::size_t OtherSize, typename OtherCfg, typename OtherSig)
+      std::size_t OtherSize, std::size_t OtherAlign, typename OtherCfg, typename OtherSig)
     EMBED_DETAIL_REQUIRES_END(
-      function<OtherSize, OtherCfg, OtherSig>::internal_is_copyable
-      && is_convertible_from_specialization<function, function<OtherSize, OtherCfg, OtherSig>>::value
-    ) function(const function<OtherSize, OtherCfg, OtherSig>& other)
+      function<OtherSize, OtherAlign, OtherCfg, OtherSig>::internal_is_copyable
+      && is_convertible_from_specialization<function,
+        function<OtherSize, OtherAlign, OtherCfg, OtherSig>>::value
+    ) function(const function<OtherSize, OtherAlign, OtherCfg, OtherSig>& other)
     noexcept(is_cfg_noexcept<Config>::value && is_cfg_noexcept<OtherCfg>::value) {
       // Suppress GCC warning: "-Wmaybe-uninitialized".
       std::memset(&m_erasure, 0, sizeof(void*));
@@ -2800,11 +2822,12 @@ namespace crtp_mixins {
     // Use `placement new` to create new functor during construction. (Move)
     // From `function<Buffer_small, ...>` to `function<Buffer_big, ...>`.
     EMBED_DETAIL_TEMPLATE_BEGIN(
-      std::size_t OtherSize, typename OtherCfg, typename OtherSig)
+      std::size_t OtherSize, std::size_t OtherAlign, typename OtherCfg, typename OtherSig)
     EMBED_DETAIL_REQUIRES_END(
       (!Config::isView)
-      && is_convertible_from_specialization<function, function<OtherSize, OtherCfg, OtherSig>>::value
-    ) function(function<OtherSize, OtherCfg, OtherSig>&& other)
+      && is_convertible_from_specialization<function,
+        function<OtherSize, OtherAlign, OtherCfg, OtherSig>>::value
+    ) function(function<OtherSize, OtherAlign, OtherCfg, OtherSig>&& other)
     noexcept(is_cfg_noexcept<Config>::value && is_cfg_noexcept<OtherCfg>::value) {
       // Suppress GCC warning: "-Wmaybe-uninitialized".
       std::memset(&m_erasure, 0, sizeof(void*));
@@ -2982,40 +3005,40 @@ namespace crtp_mixins {
   };
 
   // `true` if the wrapper has no target, `false` otherwise. (noexcept)
-  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, std::size_t Align, typename Cfg, typename Sig)
     EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
   EMBED_NODISCARD constexpr bool
-  operator==(const function<Buf, Cfg, Sig>& fn, std::nullptr_t) noexcept {
+  operator==(const function<Buf, Align, Cfg, Sig>& fn, std::nullptr_t) noexcept {
     return fn.is_empty();
   }
 
   // `true` if the wrapper has no target, `false` otherwise. (noexcept)
-  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, std::size_t Align, typename Cfg, typename Sig)
     EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
   EMBED_NODISCARD constexpr bool
-  operator==(std::nullptr_t, const function<Buf, Cfg, Sig>& fn) noexcept {
+  operator==(std::nullptr_t, const function<Buf, Align, Cfg, Sig>& fn) noexcept {
     return fn.is_empty();
   }
 
   // `true` if the wrapper does have target, `false` otherwise. (noexcept)
-  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, std::size_t Align, typename Cfg, typename Sig)
     EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
   EMBED_NODISCARD constexpr bool
-  operator!=(const function<Buf, Cfg, Sig>& fn, std::nullptr_t) noexcept {
+  operator!=(const function<Buf, Align, Cfg, Sig>& fn, std::nullptr_t) noexcept {
     return !fn.is_empty();
   }
 
   // `true` if the wrapper does have target, `false` otherwise. (noexcept)
-  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, typename Cfg, typename Sig)
+  EMBED_DETAIL_TEMPLATE_BEGIN(std::size_t Buf, std::size_t Align, typename Cfg, typename Sig)
     EMBED_DETAIL_REQUIRES_END((!Cfg::isView)) // no empty state in view mode
   EMBED_NODISCARD constexpr bool
-  operator!=(std::nullptr_t, const function<Buf, Cfg, Sig>& fn) noexcept {
+  operator!=(std::nullptr_t, const function<Buf, Align, Cfg, Sig>& fn) noexcept {
     return !fn.is_empty();
   }
 
   // Exchange the function wrapper `a` with the wrapper `b`.
-  template <std::size_t Buf, typename Cfg, typename Sig>
-  void swap(function<Buf, Cfg, Sig>& a, function<Buf, Cfg, Sig>& b)
+  template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+  void swap(function<Buf, Align, Cfg, Sig>& a, function<Buf, Align, Cfg, Sig>& b)
     noexcept(noexcept(a.swap(b)))
   { a.swap(b); }
 
@@ -3044,7 +3067,9 @@ namespace crtp_mixins {
  *                                `int(int, float) const`, `void() &&`, etc.
  *
  * @tparam BufferSize             Size of the internal storage (in bytes).
- *                                The value will NOT be automatically aligned.
+ *                                The value will be automatically aligned.
+ * 
+ * @tparam Alignment              Alignment of the internal storage (in bytes).
  *
  * @tparam IsCopyable             If `true`, the stored callable object must be
  *                                copy‑constructible; otherwise, move‑only is
@@ -3086,13 +3111,15 @@ namespace crtp_mixins {
 template <
   typename Signature,
   std::size_t BufferSize,
+  std::size_t Alignment,
   bool IsCopyable,
   bool IsView,
   bool IsThrowing,
   bool AssertObjectNoThrow
 >
 using basic_fn = detail::function<
-  /* BufferSize = */  BufferSize,
+  /* BufferSize = */  detail::get_aligned_size<Alignment>(BufferSize),
+  /* Alignment = */   Alignment,
   /* Config = */      detail::config_package<
     /* IsCopyable = */          IsCopyable,
     /* IsView = */              IsView,
@@ -3105,11 +3132,17 @@ using basic_fn = detail::function<
 /// @note Invoking the wrapper in an empty state calls `std::terminate`.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
-/// And the buffer size will be aligned automatically.
-template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+///         And the buffer size will be aligned automatically.
+/// @tparam Alignment - Alignment size. Used for storing the callable object.
+template <
+  typename Signature,
+  std::size_t BufferSize = detail::default_values::owning::buffer_size,
+  std::size_t Alignment = detail::default_values::owning::alignment
+>
 using fn = basic_fn<
   /* Signature = */           Signature,
-  /* BufferSize = */          detail::get_aligned_size(BufferSize),
+  /* BufferSize = */          BufferSize,
+  /* Alignment = */           Alignment,
   /* IsCopyable = */          true,
   /* IsView = */              false,
   /* IsThrowing = */          false,
@@ -3120,11 +3153,17 @@ using fn = basic_fn<
 /// @note Invoking the wrapper in an empty state calls `std::terminate`.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
-/// And the buffer size will be aligned automatically.
-template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+///         And the buffer size will be aligned automatically.
+/// @tparam Alignment - Alignment size. Used for storing the callable object.
+template <
+  typename Signature,
+  std::size_t BufferSize = detail::default_values::owning::buffer_size,
+  std::size_t Alignment = detail::default_values::owning::alignment
+>
 using unique_fn = basic_fn<
   /* Signature = */           Signature,
-  /* BufferSize = */          detail::get_aligned_size(BufferSize),
+  /* BufferSize = */          BufferSize,
+  /* Alignment = */           Alignment,
   /* IsCopyable = */          false,
   /* IsView = */              false,
   /* IsThrowing = */          false,
@@ -3135,11 +3174,17 @@ using unique_fn = basic_fn<
 /// @throws `std::bad_function_call` if invoked in an empty state.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
 /// @tparam BufferSize - Buffer size. Used for storing the callable object.
-/// And the buffer size will be aligned automatically.
-template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+///         And the buffer size will be aligned automatically.
+/// @tparam Alignment - Alignment size. Used for storing the callable object.
+template <
+  typename Signature,
+  std::size_t BufferSize = detail::default_values::owning::buffer_size,
+  std::size_t Alignment = detail::default_values::owning::alignment
+>
 using classic_fn = basic_fn<
   /* Signature = */           Signature,
-  /* BufferSize = */          detail::get_aligned_size(BufferSize),
+  /* BufferSize = */          BufferSize,
+  /* Alignment = */           Alignment,
   /* IsCopyable = */          true,
   /* IsView = */              false,
   /* IsThrowing = */          true,
@@ -3149,11 +3194,11 @@ using classic_fn = basic_fn<
 /// @brief Non-owning polymorphic function wrapper.
 /// @note Empty state of this wrapper has been removed.
 /// @tparam Signature - Function signature. Seems like `Ret(Args...)`.
-/// @tparam Unused - Unused.
-template <typename Signature, std::size_t Unused = 0 /* Unused */>
+template <typename Signature, std::size_t /*Unused*/ = 0, std::size_t /*Unused*/ = 0>
 using fn_ref = basic_fn<
   /* Signature = */           Signature,
-  /* BufferSize = */          detail::default_buffer_size::ref_buf,
+  /* BufferSize = */          detail::default_values::non_owning::buffer_size,
+  /* Alignment = */           detail::default_values::non_owning::alignment,
   /* IsCopyable = */          true,
   /* IsView = */              true,
   /* IsThrowing = */          false,
@@ -3165,19 +3210,19 @@ template <typename Signature, std::size_t Unused = 0 /* Unused */>
 using fn_view EMBED_DEPRECATED("Use fn_ref instead") = fn_ref<Signature>;
 
 /// @deprecated Use `fn` instead.
-template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
+template <typename Signature, std::size_t BufferSize = detail::default_values::owning::buffer_size>
 using safe_fn EMBED_DEPRECATED("Use fn instead") = basic_fn<
-  Signature, detail::get_aligned_size(BufferSize), true, false, false, true>;
-
+  Signature, BufferSize, detail::default_values::owning::alignment, true, false, false, true>;
 
 /// @brief make_fn[0]: Make function with specified signature for copyable functor.
-/// @return `fn<Signature, sizeof(Functor)>`
+/// @return `fn<Signature, sizeof(Functor), Alignment>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Signature, // [User specify] function signature.
   typename Functor,   // [Auto] Functor type.
   typename Class = detail::remove_cvref_t<Functor>,
   // [Auto] Get the nothrow guarantee in construction of functor.
-  bool NoThrow = detail::is_nothrow_construct_from_functor<Functor&&>::value
+  bool NoThrow = detail::is_nothrow_construct_from_functor<Functor&&>::value,
+  std::size_t Alignment = detail::enough_alignment<alignof(Class)>::value
 )
 EMBED_DETAIL_REQUIRES_END(
   // [Require] Functor cannot be the function pointer or pointer to member function.
@@ -3187,20 +3232,21 @@ EMBED_DETAIL_REQUIRES_END(
   // [Require] First template argument must be signature.
   && detail::unwrap_signature<Signature>::isSignature
 )
-EMBED_NODISCARD inline fn<Signature, sizeof(Class)>
+EMBED_NODISCARD inline fn<Signature, sizeof(Class), Alignment>
 make_fn(Functor&& functor) noexcept(NoThrow) {
   return detail::make_function_impl<
-    fn<Signature, sizeof(Class)>, /* NoThrow = */ NoThrow
+    fn<Signature, sizeof(Class), Alignment>, /* NoThrow = */ NoThrow
   >(std::forward<Functor>(functor));
 }
 
 /// @brief make_fn[1]: Make function with specified signature for move-only functor.
-/// @return `unique_fn<Signature, sizeof(Functor)>`
+/// @return `unique_fn<Signature, sizeof(Functor), Alignment>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Signature, // [User specify] function signature.
   typename Functor,   // [Auto] Functor type.
   // [Auto] Get the nothrow guarantee of functor.
-  bool NoThrow = std::is_nothrow_move_constructible<Functor>::value
+  bool NoThrow = std::is_nothrow_move_constructible<Functor>::value,
+  std::size_t Alignment = detail::enough_alignment<alignof(Functor)>::value
 )
 EMBED_DETAIL_REQUIRES_END(
   // [Require] Functor must be movable.
@@ -3210,10 +3256,10 @@ EMBED_DETAIL_REQUIRES_END(
   // [Require] First template argument must be signature.
   && detail::unwrap_signature<Signature>::isSignature
 )
-EMBED_NODISCARD inline unique_fn<Signature, sizeof(Functor)>
+EMBED_NODISCARD inline unique_fn<Signature, sizeof(Functor), Alignment>
 make_fn(Functor&& functor) noexcept(NoThrow) {
   return detail::make_function_impl<
-    unique_fn<Signature, sizeof(Functor)>, NoThrow
+    unique_fn<Signature, sizeof(Functor), Alignment>, NoThrow
   >(std::forward<Functor>(functor));
 }
 
@@ -3221,16 +3267,17 @@ make_fn(Functor&& functor) noexcept(NoThrow) {
 /// @return `fn<Signature, BufferSize>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Signature, // [User specify] function signature.
-  std::size_t BufferSize = detail::default_buffer_size::value
+  std::size_t BufferSize = detail::default_values::owning::buffer_size,
+  std::size_t Alignment = detail::default_values::owning::alignment
 )
 EMBED_DETAIL_REQUIRES_END(
   // [Require] First template argument must be signature.
   detail::unwrap_signature<Signature>::isSignature
 )
-EMBED_NODISCARD inline fn<Signature, BufferSize>
+EMBED_NODISCARD inline fn<Signature, BufferSize, Alignment>
 make_fn(std::nullptr_t = nullptr) noexcept {
   return detail::make_function_impl<
-    fn<Signature, BufferSize>, /* NoThrow = */ true
+    fn<Signature, BufferSize, Alignment>, /* NoThrow = */ true
   >(nullptr);
 }
 
@@ -3282,28 +3329,27 @@ make_fn(FunctionPtr func_ptr) noexcept {
 }
 
 /// @brief make_fn[5]: Create a function from another function. (Copy)
-/// @return `detail::function<Buf, Cfg, Sig>`
-template <std::size_t Buf, typename Cfg, typename Sig>
-EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
-make_fn(const detail::function<Buf, Cfg, Sig>& fn)
+/// @return `detail::function<Buf, Align, Cfg, Sig>`
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+EMBED_NODISCARD inline detail::function<Buf, Align, Cfg, Sig>
+make_fn(const detail::function<Buf, Align, Cfg, Sig>& fn)
 noexcept(Cfg::isView || Cfg::assertNoThrow) {
   return detail::make_function_impl<
-    detail::function<Buf, Cfg, Sig>,
+    detail::function<Buf, Align, Cfg, Sig>,
     /* NoThrow = */ Cfg::isView || Cfg::assertNoThrow
   >(fn);
 }
 
 /// @brief make_fn[6]: Create a function from another function. (Move)
-/// @return `detail::function<Buf, Cfg, Sig>`
-template <std::size_t Buf, typename Cfg, typename Sig>
-EMBED_NODISCARD inline detail::function<Buf, Cfg, Sig>
-make_fn(detail::function<Buf, Cfg, Sig>&& fn)
+/// @return `detail::function<Buf, Align, Cfg, Sig>`
+template <std::size_t Buf, std::size_t Align, typename Cfg, typename Sig>
+EMBED_NODISCARD inline detail::function<Buf, Align, Cfg, Sig>
+make_fn(detail::function<Buf, Align, Cfg, Sig>&& fn)
 noexcept(Cfg::isView || Cfg::assertNoThrow) {
-  using Fn = detail::function<Buf, Cfg, Sig>;
   return detail::make_function_impl<
-    detail::function<Buf, Cfg, Sig>,
+    detail::function<Buf, Align, Cfg, Sig>,
     /* NoThrow = */ Cfg::isView || Cfg::assertNoThrow
-  >(std::forward<Fn>(fn));
+  >(std::move(fn));
 }
 
 /// @brief make_fn[7]: Make a function from lambda or unique-operator() functor.
@@ -3315,12 +3361,14 @@ EMBED_DETAIL_TEMPLATE_BEGIN(
   typename Class = detail::remove_cvref_t<Lambda>,
   // [Auto] The buffer size of functor.
   std::size_t BufferSize = sizeof(Class),
+  // [Auto] The alignment size of functor.
+  std::size_t Alignment = detail::enough_alignment<alignof(Class)>::value,
   // [Auto] The signature of functor.
   typename Signature = detail::get_unique_signature_t<Class>,
   // [Auto] The function type. (fn or unique_fn)
   typename Fn = detail::conditional_t<
     std::is_copy_constructible<Class>::value,
-    fn<Signature, BufferSize>, unique_fn<Signature, BufferSize>
+    fn<Signature, BufferSize, Alignment>, unique_fn<Signature, BufferSize, Alignment>
   >,
   // [Auto] Get the nothrow guarantee in construction of functor.
   bool NoThrow = detail::is_nothrow_construct_from_functor<Lambda&&>::value
@@ -3407,12 +3455,15 @@ EMBED_NODISCARD inline auto make_fn(T Class::* ptr_memobj) noexcept
 template <typename Functor, typename... CArgs>
 EMBED_NODISCARD inline auto make_fn(std::in_place_type_t<Functor>, CArgs&&... args)
 noexcept(std::is_nothrow_constructible<Functor, CArgs...>::value) {
-  using signature = typename detail::is_ebd_fn<
-    decltype(make_fn(std::declval<Functor>()))>::signature;
+  using deduction_wrapper = decltype(make_fn(std::declval<Functor>()));
+  using signature = typename detail::is_ebd_fn<deduction_wrapper>::signature;
+  static constexpr std::size_t buffer_size = sizeof(Functor);
+  static constexpr std::size_t alignment = detail::enough_alignment<alignof(Functor)>::value;
 
   using Fn = detail::conditional_t<
     std::is_copy_constructible<Functor>::value,
-    ebd::fn<signature, sizeof(Functor)>, ebd::unique_fn<signature, sizeof(Functor)>>;
+    ebd::fn<signature, buffer_size, alignment>,
+    ebd::unique_fn<signature, buffer_size, alignment>>;
 
   return detail::make_function_impl<
     Fn, std::is_nothrow_constructible<Functor, CArgs...>::value
@@ -3425,12 +3476,15 @@ template <typename Functor, typename U, typename... CArgs>
 EMBED_NODISCARD inline auto
 make_fn(std::in_place_type_t<Functor>, std::initializer_list<U> il, CArgs&&... args)
 noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs...>::value) {
-  using signature = typename detail::is_ebd_fn<
-    decltype(make_fn(std::declval<Functor>()))>::signature;
+  using deduction_wrapper = decltype(make_fn(std::declval<Functor>()));
+  using signature = typename detail::is_ebd_fn<deduction_wrapper>::signature;
+  static constexpr std::size_t buffer_size = sizeof(Functor);
+  static constexpr std::size_t alignment = detail::enough_alignment<alignof(Functor)>::value;
 
   using Fn = detail::conditional_t<
     std::is_copy_constructible<Functor>::value,
-    ebd::fn<signature, sizeof(Functor)>, ebd::unique_fn<signature, sizeof(Functor)>>;
+    ebd::fn<signature, buffer_size, alignment>,
+    ebd::unique_fn<signature, buffer_size, alignment>>;
 
   return detail::make_function_impl<
     Fn, std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs...>::value
@@ -3470,9 +3524,9 @@ EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>, Tp&& obj) 
 
 /// @brief make_fn[14]: Make function with specified wrapper.
 /// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`.
-/// @return `Fn<Signature, sizeof(functor)>`
+/// @return `Fn<Signature, BufferSize, Alignment>`
 EMBED_DETAIL_TEMPLATE_BEGIN(
-  template <class, std::size_t> class Fn,
+  template <class, std::size_t, std::size_t> class Fn,
   typename SpecifiedSig = void,
   typename... Args,
   typename Deduction = decltype(make_fn(std::declval<Args>()...)),
@@ -3481,8 +3535,10 @@ EMBED_DETAIL_TEMPLATE_BEGIN(
                            /* Auto deduce */ detail::get_correct_signature_t<Fn, RawSig>,
           /* Use user specified signature */ SpecifiedSig>,
   std::size_t BufferSize =
-    detail::get_correct_buffer_size<Fn<int(), 0>, Deduction::get_buffer_size(), Args...>::value,
-  typename FnWrapper = Fn<Signature, BufferSize>,
+    detail::get_correct_buffer_size<Fn<int(), 0, alignof(int*)>, Deduction::get_buffer_size(), Args...>::value,
+  std::size_t Alignment = detail::is_ebd_fn<Fn<int(), 0, alignof(int*)>>::config::isView ?
+    detail::default_values::non_owning::alignment : Deduction::get_alignment(),
+  typename FnWrapper = Fn<Signature, BufferSize, Alignment>,
   bool NoThrow = noexcept(FnWrapper(std::declval<Args>()...))
 )
 EMBED_DETAIL_REQUIRES_END(
@@ -3499,11 +3555,14 @@ FnWrapper make_fn(Args&&... args) noexcept(NoThrow) {
 // When all other make_fn() fail to match the input parameters,
 // this function will be called as the fall back to avoid the
 // awful template error flood.
+#if !defined(_MSC_VER) || defined(__clang__)
+// MSVC has a bug where passing over-aligned arguments to make_fn triggers error C2718.
 template <typename Unused = void,
   EMBED_DETAIL_REQUIRES(!detail::unwrap_signature<Unused>::isSignature)>
 constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused>()) { return 0; }
-template <template <class, std::size_t> class Unused>
-constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0>>()) { return 0; }
+template <template <class, std::size_t, std::size_t> class Unused>
+constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0, 8>>()) { return 0; }
+#endif // !defined(_MSC_VER) || defined(__clang__)
 
 } // end namespace ebd
 

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3107,8 +3107,8 @@ namespace crtp_mixins {
  *
  * @example                       A move-only, non‑throwing wrapper:
  * ```cpp
- * template <typename Signature, std::size_t BufferSize>
- * using unique_safe_fn = ebd::basic_fn<Signature, BufferSize,
+ * template <typename Signature, std::size_t BufferSize, std::size_t Alignment>
+ * using unique_safe_fn = ebd::basic_fn<Signature, BufferSize, Alignment,
  *                                      false, // IsCopyable
  *                                      false, // IsView
  *                                      false, // IsThrowing

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1,9 +1,9 @@
 /**
  * @file        embed_function.hpp
  *
- * @date        2026-8-6
+ * @date        2026-8-22
  *
- * @version     2.2.2
+ * @version     2.3.0
  *
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.
@@ -3557,6 +3557,7 @@ FnWrapper make_fn(Args&&... args) noexcept(NoThrow) {
 // awful template error flood.
 #if !defined(_MSC_VER) || defined(__clang__)
 // MSVC has a bug where passing over-aligned arguments to make_fn triggers error C2718.
+// See <https://developercommunity.visualstudio.com/t/MSVC-emits-C2718-for-over-aligned-argume/11141150>.
 template <typename Unused = void,
   EMBED_DETAIL_REQUIRES(!detail::unwrap_signature<Unused>::isSignature)>
 constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused>()) { return 0; }

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1649,27 +1649,17 @@ inline namespace fn_traits {
 
   // Log error for make_fn.
   template <typename Unused>
-  constexpr bool make_fn_log_error() noexcept {
+  constexpr void make_fn_log_error() noexcept {
     static_assert(always_false<Unused>::value,
       "`make_fn()` CANNOT infer the template arguments of `ebd::basic_fn` from the given "
       "arguments.\nYou can specify the signature and try again:\n\n"
-      "        auto f = ebd::make_fn<Signature[, BufferSize]>();\n"
+      "        auto f = ebd::make_fn<Signature[, BufferSize[, Alignment]]>();\n"
       "                              ^^^^^^^^^\n"
-      "        auto f = ebd::make_fn<Signature[, BufferSize]>(nullptr);\n"
+      "        auto f = ebd::make_fn<Signature[, BufferSize[, Alignment]]>(nullptr);\n"
       "                              ^^^^^^^^^\n"
-      "        auto f = ebd::make_fn<Signature>(CallableObject);\n"
-      "                              ^^^^^^^^^\n"
-      "        auto f = ebd::make_fn<FnWrapper, Signature>(CallableObject);\n"
-      "                                         ^^^^^^^^^\n\n"
-      "The `Signature` is like `void()`, `float(int,int) const`;\n"
-      "The `BufferSize` is the size (in bytes) of the internal storage;\n"
-      "The `FnWrapper` is an alias of `ebd::basic_fn` and has "
-      "`template <class, std::size_t, std::size_t>` as a template argument "
-      "list, such as `ebd::fn_ref`, `ebd::classic_fn`, etc. If omitted, the "
-      "`FnWrapper` will be inferred to be `ebd::fn` if the `CallableObject` "
-      "is copyable, and `ebd::unique_fn` otherwise."
+      "        auto f = ebd::make_fn<[FnWrapper, ]Signature>(CallableObject);\n"
+      "                                           ^^^^^^^^^\n\n"
     );
-    return true;
   }
 
   // The trait is expression-equivalent to `Cfg::assertNoThrow || Cfg::isView`.
@@ -3567,9 +3557,9 @@ FnWrapper make_fn(Args&&... args) noexcept(NoThrow) {
 // See <https://developercommunity.visualstudio.com/t/MSVC-emits-C2718-for-over-aligned-argume/11141150>.
 template <typename Unused = void,
   EMBED_DETAIL_REQUIRES(!detail::unwrap_signature<Unused>::isSignature)>
-constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused>()) { return 0; }
+EMBED_CXX14_CONSTEXPR void make_fn(...) { detail::make_fn_log_error<Unused>(); }
 template <template <class, std::size_t, std::size_t> class Unused>
-constexpr int make_fn(...) noexcept(detail::make_fn_log_error<Unused<void(), 0, 8>>()) { return 0; }
+EMBED_CXX14_CONSTEXPR void make_fn(...) { detail::make_fn_log_error<Unused<void(), 0, 8>>(); }
 #endif // !defined(_MSC_VER) || defined(__clang__)
 
 } // end namespace ebd

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1851,6 +1851,7 @@ namespace invocation {
       }                                                                               \
     }                                                                                 \
   }; /* end view_cw */
+  /// TODO: explore `inplace_cw` according to <https://wg21.link/P2511>.
 #else
 # define EMBED_DETAIL_CW_INVOKER_IMPL(C, V, REF, NOEXCEPT)
 #endif
@@ -2950,6 +2951,8 @@ namespace crtp_mixins {
       using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw>();
 
+      /// TODO: explore to use `std::cw` in owning mode according to P2511.
+
       // Mandates are as follows.
       if constexpr (std::is_pointer_v<Fn> || std::is_member_pointer_v<Fn>) {
         /// @bug GCC bug 100313: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100313>.
@@ -2969,6 +2972,8 @@ namespace crtp_mixins {
       using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw, /*CallPointer*/false>(&m_erasure, std::addressof(obj));
 
+      /// TODO: explore to use `std::cw` in owning mode according to P2511.
+
       // Mandates are as follows.
       if constexpr (std::is_pointer_v<Fn> || std::is_member_pointer_v<Fn>) {
         /// @bug GCC bug 100313: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100313>.
@@ -2987,6 +2992,8 @@ namespace crtp_mixins {
     : Base_MemberVariable(nullptr) {
       using Cw = std::constant_wrapper<Val, Fn>;
       m_command.template cw_init<Cw, /*CallPointer*/true>(&m_erasure, obj);
+
+      /// TODO: explore to use `std::cw` in owning mode according to P2511.
 
       // Mandates are as follows.
       if constexpr (std::is_pointer_v<Fn> || std::is_member_pointer_v<Fn>) {

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -1649,7 +1649,7 @@ inline namespace fn_traits {
 
   // Log error for make_fn.
   template <typename Unused>
-  constexpr void make_fn_log_error() noexcept {
+  EMBED_CXX14_CONSTEXPR void make_fn_log_error() noexcept {
     static_assert(always_false<Unused>::value,
       "`make_fn()` CANNOT infer the template arguments of `ebd::basic_fn` from the given "
       "arguments.\nYou can specify the signature and try again:\n\n"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 # Project name.
 project(
-    "embed_function_2.2.x-GoogleTest"
+    "embed_function_2.x-GoogleTest"
     LANGUAGES CXX
 )
 

--- a/test/conformance/fn_ref/conformance.addition.pass.cpp
+++ b/test/conformance/fn_ref/conformance.addition.pass.cpp
@@ -13,8 +13,8 @@
 
 #include "test_function.hpp"
 
-template <class Sig, std::size_t Buf>
-using nothrow_fn = ebd::basic_fn<Sig, ebd::detail::get_aligned_size(Buf), true, false, false, false>;
+template <class Sig, std::size_t Buf, std::size_t Align = ebd::detail::default_values::owning::alignment>
+using nothrow_fn = ebd::basic_fn<Sig, Buf, Align, true, false, false, false>;
 
 struct empty_trivial_but_state {
   std::uintptr_t operator()() const { return reinterpret_cast<std::uintptr_t>(this); }

--- a/test/test_BasicAttributes.cpp
+++ b/test/test_BasicAttributes.cpp
@@ -14,16 +14,16 @@ TEST(BasicAttributes, SizeAndAlign) {
     using sf_t = ebd::__safe_fn<void()>;
     using fr_t = ebd::fn_ref<void()>;
 
-    ASSERT_EQ(f_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
-    ASSERT_EQ(uf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
-    ASSERT_EQ(cf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
-    ASSERT_EQ(sf_t::get_buffer_size() == ebd::detail::default_buffer_size::value, true);
-    ASSERT_EQ(fr_t::get_buffer_size() == ebd::detail::default_buffer_size::ref_buf, true);
+    ASSERT_EQ(f_t::get_buffer_size() == ebd::detail::default_values::owning::buffer_size, true);
+    ASSERT_EQ(uf_t::get_buffer_size() == ebd::detail::default_values::owning::buffer_size, true);
+    ASSERT_EQ(cf_t::get_buffer_size() == ebd::detail::default_values::owning::buffer_size, true);
+    ASSERT_EQ(sf_t::get_buffer_size() == ebd::detail::default_values::owning::buffer_size, true);
+    ASSERT_EQ(fr_t::get_buffer_size() == ebd::detail::default_values::non_owning::buffer_size, true);
 
-    ASSERT_EQ(alignof(f_t) == ebd::detail::default_buffer_size::align_value, true);
-    ASSERT_EQ(alignof(uf_t) == ebd::detail::default_buffer_size::align_value, true);
-    ASSERT_EQ(alignof(cf_t) == ebd::detail::default_buffer_size::align_value, true);
-    ASSERT_EQ(alignof(sf_t) == ebd::detail::default_buffer_size::align_value, true);
+    ASSERT_EQ(alignof(f_t) == ebd::detail::default_values::owning::alignment, true);
+    ASSERT_EQ(alignof(uf_t) == ebd::detail::default_values::owning::alignment, true);
+    ASSERT_EQ(alignof(cf_t) == ebd::detail::default_values::owning::alignment, true);
+    ASSERT_EQ(alignof(sf_t) == ebd::detail::default_values::owning::alignment, true);
     ASSERT_EQ(alignof(fr_t) == alignof(void(*)()), true);
 
     ASSERT_EQ(sizeof(f_t) - f_t::get_buffer_size(), 2 * sizeof(void*));
@@ -111,28 +111,30 @@ TEST(BasicAttributes, AlwaysConstFnView) {
 
 // BasicAttributes[4]
 TEST(BasicAttributes, DefaultConfig) {
+    static constexpr auto obuf_align = ebd::detail::default_values::owning::alignment;
+    static constexpr auto n_obuf_align = ebd::detail::default_values::non_owning::alignment;
     static_assert(
         std::is_same<
             ebd::fn<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, false, false>
+            ebd::basic_fn<void(), 0, obuf_align, true, false, false, false>
         >::value, 
         "The default config of ebd::fn has been changed!");
     static_assert(
         std::is_same<
             ebd::unique_fn<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), false, false, false, false>
+            ebd::basic_fn<void(), 0, obuf_align, false, false, false, false>
         >::value, 
         "The default config of ebd::unique_fn has been changed!");
     static_assert(
         std::is_same<
             ebd::classic_fn<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::get_aligned_size(0), true, false, true, false>
+            ebd::basic_fn<void(), 0, obuf_align, true, false, true, false>
         >::value, 
         "The default config of ebd::classic_fn has been changed!");
     static_assert(
         std::is_same<
             ebd::fn_ref<void(), 0>, 
-            ebd::basic_fn<void(), ebd::detail::default_buffer_size::ref_buf, true, true, false, false>
+            ebd::basic_fn<void(), 0, n_obuf_align, true, true, false, false>
         >::value, 
         "The default config of ebd::fn_ref has been changed!");
 }

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -12,7 +12,7 @@
 TEST(InitFunction, fn_freeFunction_v) {
     ebd::fn<void(int, int)> f = ebd_test_free_func_vii;
     const std::size_t buf_size = f.get_buffer_size();
-    const std::size_t buf_expect = ebd::detail::default_buffer_size::value;
+    const std::size_t buf_expect = ebd::detail::default_values::owning::buffer_size;
     ASSERT_EQ(buf_size, buf_expect);
     ASSERT_EQ(f != nullptr, true);
     ASSERT_EQ(f == nullptr, false);
@@ -870,4 +870,66 @@ struct ebd_test_InitFunction_Wuninitialized {
 TEST(InitFunction, Wuninitialized) {
     ebd_test_InitFunction_Wuninitialized f;
     f.set([]{});
+}
+
+// InitFunction[43]
+TEST(InitFunction, GreatAlignment) {
+    using Obj_t = ebd_test_great_alignment;
+    Obj_t obj{0};
+    {
+        ebd::fn<int(), sizeof(Obj_t), alignof(Obj_t)> f = obj;
+        ASSERT_EQ(f(), 42);
+
+        auto f_deduce = ebd::make_fn<ebd::fn>(obj);
+        ASSERT_EQ(f_deduce(), 42);
+
+        static_assert(std::is_same<decltype(f), decltype(f_deduce)>::value, "BUG");
+    }
+    {
+        ebd::unique_fn<int(), sizeof(Obj_t), alignof(Obj_t)> f = obj;
+        ASSERT_EQ(f(), 42);
+
+        auto f_deduce = ebd::make_fn<ebd::unique_fn>(obj);
+        ASSERT_EQ(f_deduce(), 42);
+
+        static_assert(std::is_same<decltype(f), decltype(f_deduce)>::value, "BUG");
+    }
+    {
+        ebd::__safe_fn<int(), sizeof(Obj_t), alignof(Obj_t)> f = obj;
+        ASSERT_EQ(f(), 42);
+
+        auto f_deduce = ebd::make_fn<ebd::__safe_fn>(obj);
+        ASSERT_EQ(f_deduce(), 42);
+
+        static_assert(std::is_same<decltype(f), decltype(f_deduce)>::value, "BUG");
+    }
+    {
+        ebd::classic_fn<int(), sizeof(Obj_t), alignof(Obj_t)> f = obj;
+        ASSERT_EQ(f(), 42);
+
+        auto f_deduce = ebd::make_fn<ebd::classic_fn>(obj);
+        ASSERT_EQ(f_deduce(), 42);
+
+        static_assert(std::is_same<decltype(f), decltype(f_deduce)>::value, "BUG");
+    }
+    {
+        ebd::fn_ref<int(), sizeof(Obj_t), alignof(Obj_t)> f = obj;
+        ASSERT_EQ(f(), 42);
+
+        auto f_deduce = ebd::make_fn<ebd::fn_ref>(obj);
+        ASSERT_EQ(f_deduce(), 42);
+
+        static_assert(std::is_same<decltype(f), decltype(f_deduce)>::value, "BUG");
+    }
+
+    // Deduction
+    {
+        ebd::fn<int(), sizeof(Obj_t), alignof(Obj_t)> f = obj;
+        ASSERT_EQ(f(), 42);
+
+        auto f_deduce = ebd::make_fn(obj);
+        ASSERT_EQ(f_deduce(), 42);
+
+        static_assert(std::is_same<decltype(f), decltype(f_deduce)>::value, "BUG");
+    }
 }

--- a/test/test_function.hpp
+++ b/test/test_function.hpp
@@ -7,8 +7,13 @@
 namespace ebd {
 
 /// @attention TEST USE ONLY!
-template <typename Signature, std::size_t BufferSize = detail::default_buffer_size::value>
-using __safe_fn = basic_fn<Signature, detail::get_aligned_size(BufferSize),
+template <
+    typename Signature,
+    std::size_t BufferSize = detail::default_values::owning::buffer_size,
+    std::size_t Alignment = detail::default_values::owning::alignment
+>
+using __safe_fn = basic_fn<Signature, BufferSize,
+                           Alignment,
                            true,    // Is Copyable
                            false,   // Not View
                            false,   // Not Throwing on empty calls
@@ -273,4 +278,9 @@ struct ebd_test_implicit_func_ptr {
     operator func_ptr() const {
         return [](int n) { return n + 42; };
     }
+};
+
+struct ebd_test_great_alignment {
+    alignas(128) int a;
+    int operator()() { return a + 42; }
 };


### PR DESCRIPTION
**🔧 Fixed Bugs**
- None.

**⚠️ Breaking Changes**
- Added an `Alignment` template parameter to polymorphic function wrappers, which changes its template argument list. Existing code that directly instantiates `basic_fn` is affected; other wrappers (`ebd::fn`, `ebd::unique_fn`, etc.) are unaffected as the new parameter has a default value. (#147)

**✨ New Features**
- Added the `Alignment` template parameter to specify the alignment of the internal storage. (#147)
- `make_fn` now automatically deduces the alignment from the callable object. (#147)

**🛠️ Optimizations and Improvements**
- None.

**📌 Notes**
- None.
