### PR TITLE
Version 2.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(embedded_function VERSION 2.3.1 LANGUAGES CXX)
+project(embedded_function VERSION 2.3.2 LANGUAGES CXX)
 add_library(embedded_function INTERFACE)
 add_library(embedded_function::functions ALIAS embedded_function)
 set_target_properties(embedded_function PROPERTIES EXPORT_NAME functions)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Embedded Function
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-2.3.1-yellow?style=for-the-badge&logo=github" alt="Version - 2.3.1">
+  <img src="https://img.shields.io/badge/Version-2.3.2-yellow?style=for-the-badge&logo=github" alt="Version - 2.3.2">
   <img src="https://img.shields.io/badge/License-MIT-orange?style=for-the-badge" alt="License - MIT">
   <img src="https://img.shields.io/badge/C++-11/14/17/20/23/26-blue?style=for-the-badge&logo=c%2B%2B" alt="C++ - 11/14/17/20/23/26">
 </p>

--- a/docs/api/make_fn.md
+++ b/docs/api/make_fn.md
@@ -184,6 +184,9 @@ EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>) noexcept;
 
 Creates an `ebd::fn_ref` from a `std::constant_wrapper` (P3948) of a free function or other callable. The signature is deduced automatically. Only available when `__cpp_lib_constant_wrapper >= 202603L`.
 
+> [!WARNING]
+> This overload is **deprecated**: its API will be changed in v2.4.0. Use `make_fn<ebd::fn_ref>(std::cw<...>)` instead.
+
 ### 14. From `std::constant_wrapper` of a member pointer and an object (C++26+)
 
 ```cpp
@@ -192,6 +195,9 @@ EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>, Tp&& obj) 
 ```
 
 Creates an `ebd::fn_ref` from a `std::constant_wrapper` together with an object (`obj` or `&obj`). The object binds to the **first parameter** of the wrapped callable (the *instance* for a member function or member object pointer, or the *first argument* of a free function), and that parameter is removed from the deduced signature.
+
+> [!WARNING]
+> This overload is **deprecated**: its API will be changed in v2.4.0. Use `make_fn<ebd::fn_ref>(std::cw<...>, obj)` instead.
 
 ### 15. Explicit wrapper type
 
@@ -300,14 +306,14 @@ struct MyClass {
 };
 
 // From a constant_wrapper of a free function.
-auto cw_fn = ebd::make_fn(std::cw<&free_func>);
+auto cw_fn = ebd::make_fn<ebd::fn_ref>(std::cw<&free_func>);
 
 // From a constant_wrapper of a member function + instance.
 MyClass obj;
-auto cw_mem = ebd::make_fn(std::cw<&MyClass::method>, obj);
+auto cw_mem = ebd::make_fn<ebd::fn_ref>(std::cw<&MyClass::method>, obj);
 
 // From a constant_wrapper of a member object + instance.
-auto cw_mem_obj = ebd::make_fn(std::cw<&MyClass::value>, &obj);
+auto cw_mem_obj = ebd::make_fn<ebd::fn_ref>(std::cw<&MyClass::value>, &obj);
 ```
 
 ## Notes

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -5,10 +5,10 @@
 - None.
 
 **✨ New Features**
-- Added the `EMBED_FN_CONFIG_EMPTY_TRIVIAL_STATEFUL` macro. When defined, empty trivial functors are no longer treated as stateless (except standard operator wrappers). (#156)
+- None.
 
 **🛠️ Optimizations and Improvements**
-- Achieved full (100%) line coverage of the library's measurable runtime code (gcov); the only lines gcov reports as unexecuted are the empty-call terminate paths executed inside death-test subprocesses, which are not measurable because the child process aborts before flushing profile data. Removed unused header includes from tests. (#153)
+- None.
 
 **📌 Notes**
 - `operator bool` still works but may warn. It will be removed in a future release.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -8,7 +8,7 @@
 - None.
 
 **🛠️ Optimizations and Improvements**
-- None.
+- Removed unused and unnecessary macros in `embed/embed_function.hpp`.
 
 **📌 Notes**
 - `operator bool` still works but may warn. It will be removed in a future release.

--- a/docs/release/release_notes.md
+++ b/docs/release/release_notes.md
@@ -12,3 +12,4 @@
 
 **📌 Notes**
 - `operator bool` still works but may warn. It will be removed in a future release.
+- `make_fn(std::cw<...>)` and `make_fn(std::cw<...>, obj)` are deprecated. Their API will be changed in v2.4.0; use `make_fn<ebd::fn_ref>(std::cw<...>)` / `make_fn<ebd::fn_ref>(std::cw<...>, obj)` instead.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -241,26 +241,14 @@
 # define EMBED_DETAIL_VIRTUAL_INHERITANCE
 #endif
 
-// Generate the default/delete move constructors and move assignment for specified class.
-#define EMBED_DETAIL_MOVE_FUNCTION(class_name, default_or_delete) \
-  class_name(class_name&&)            = default_or_delete;\
-  class_name& operator=(class_name&&) = default_or_delete;
-
-// Generate the default/delete copy constructors and copy assignment for specified class.
-#define EMBED_DETAIL_COPY_FUNCTION(class_name, default_or_delete) \
-  class_name(const class_name&)             = default_or_delete;\
-  class_name& operator=(const class_name&)  = default_or_delete;
-
-// Generate default destructor and empty default constructor.
-#define EMBED_DETAIL_DTOR_ECTOR_DEFAULT(class_name) \
-  ~class_name() = default; \
-  class_name()  = default;
-
 // Generate all default functions (Ctor, Dtor, and assignment) for specified class.
-#define EMBED_DETAIL_ALL_DEFAULT(class_name)      \
-  EMBED_DETAIL_DTOR_ECTOR_DEFAULT(class_name)     \
-  EMBED_DETAIL_COPY_FUNCTION(class_name, default) \
-  EMBED_DETAIL_MOVE_FUNCTION(class_name, default)
+#define EMBED_DETAIL_ALL_DEFAULT(class_name) \
+    class_name()                              = default;\
+    ~class_name()                             = default;\
+    class_name(class_name&&)                  = default;\
+    class_name(const class_name&)             = default;\
+    class_name& operator=(class_name&&)       = default;\
+    class_name& operator=(const class_name&)  = default;
 
 /// @brief Unify the two SFINAE writing methods of "enable_if" and "requires",
 /// eliminating the need to maintain two sets of code.
@@ -303,18 +291,6 @@
 #else
 # define EMBED_DETAIL_FAIL_MESSAGE(message)
 # define EMBED_DETAIL_ASSERT_MESSAGE(expression, message)
-#endif
-
-#if __cpp_lib_unreachable >= 202202L
-# define EMBED_DETAIL_UNREACHABLE() std::unreachable()
-#elif EMBED_HAS_BUILTIN(__builtin_unreachable)
-# define EMBED_DETAIL_UNREACHABLE() __builtin_unreachable()
-#elif defined(__GNUC__) && (__GNUC__ >= 5)
-# define EMBED_DETAIL_UNREACHABLE() __builtin_unreachable()
-#elif defined(_MSC_VER) && !defined(__clang__)
-# define EMBED_DETAIL_UNREACHABLE() __assume(false)
-#else
-# define EMBED_DETAIL_UNREACHABLE()
 #endif
 
 // Guidelines for reporting internal errors.
@@ -828,7 +804,7 @@ inline namespace cxx_traits {
     // `__builtin_launder` in MSVC is only accessible since C++17.
     return __builtin_launder(ptr);
 #elif defined(__GNUC__) || defined(__clang__)
-    __asm__("": "+r"(ptr)); // Cannot use `__asm__` in `noexcept` function.
+    __asm__("": "+r"(ptr)); // Cannot use `__asm__` in `constexpr` function.
     return ptr;
 #else
 # if defined(_MSC_VER) && !defined(__clang__)
@@ -2334,9 +2310,11 @@ namespace crtp_mixins {
   // Implement the destructor.
   template <typename Config, typename Self>
   struct destructor_impl {
-    EMBED_DETAIL_COPY_FUNCTION(destructor_impl, default)
-    EMBED_DETAIL_MOVE_FUNCTION(destructor_impl, default)
-    destructor_impl() = default;
+    destructor_impl()                                   = default;
+    destructor_impl(destructor_impl&&)                  = default;
+    destructor_impl(const destructor_impl&)             = default;
+    destructor_impl& operator=(destructor_impl&&)       = default;
+    destructor_impl& operator=(const destructor_impl&)  = default;
 
     ~destructor_impl() noexcept(Config::assertNoThrow) {
       using erasure_t = typename Self::erasure_t;
@@ -2348,8 +2326,10 @@ namespace crtp_mixins {
   // Implement the move constructor and move assignment.
   template <typename Config, typename Self>
   struct move_impl {
-    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(move_impl)
-    EMBED_DETAIL_COPY_FUNCTION(move_impl, default)
+    move_impl()                             = default;
+    ~move_impl()                            = default;
+    move_impl(const move_impl&)             = default;
+    move_impl& operator=(const move_impl&)  = default;
 
     move_impl(move_impl&& other_raw) noexcept(Config::assertNoThrow) {
       // Get the real `self` and `other`.
@@ -2386,8 +2366,10 @@ namespace crtp_mixins {
   // Implement the copy constructor and copy assignment.
   template <typename Config, typename Self>
   struct copy_impl {
-    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(copy_impl)
-    EMBED_DETAIL_MOVE_FUNCTION(copy_impl, default)
+    copy_impl()                       = default;
+    ~copy_impl()                      = default;
+    copy_impl(copy_impl&&)            = default;
+    copy_impl& operator=(copy_impl&&) = default;
 
     copy_impl(const copy_impl& other_raw) noexcept(Config::assertNoThrow) {
       // Get the real `self` and `other`.
@@ -2433,9 +2415,12 @@ namespace crtp_mixins {
     : public destructor_impl<Config, Self>,
       public move_impl<Config, Self>
   {
-    EMBED_DETAIL_DTOR_ECTOR_DEFAULT(lifetime_operations_impl)
-    EMBED_DETAIL_MOVE_FUNCTION(lifetime_operations_impl, default)
-    EMBED_DETAIL_COPY_FUNCTION(lifetime_operations_impl, delete)
+    lifetime_operations_impl()                                      = default;
+    ~lifetime_operations_impl()                                     = default;
+    lifetime_operations_impl(lifetime_operations_impl&&)            = default;
+    lifetime_operations_impl& operator=(lifetime_operations_impl&&) = default;
+    lifetime_operations_impl(const lifetime_operations_impl&)             = delete;
+    lifetime_operations_impl& operator=(const lifetime_operations_impl&)  = delete;
   };
 
   // Implement clone constructor, move constructor, destructor, clone assignment,
@@ -3593,9 +3578,6 @@ EMBED_CXX14_CONSTEXPR void make_fn(...) { detail::make_fn_log_error<Unused<void(
 #undef EMBED_DETAIL_REQUIRES
 #undef EMBED_DETAIL_FORCE_EBO
 #undef EMBED_DETAIL_VIRTUAL_INHERITANCE
-#undef EMBED_DETAIL_MOVE_FUNCTION
-#undef EMBED_DETAIL_COPY_FUNCTION
-#undef EMBED_DETAIL_DTOR_ECTOR_DEFAULT
 #undef EMBED_DETAIL_ALL_DEFAULT
 #undef EMBED_DETAIL_TEMPLATE_BEGIN
 #undef EMBED_DETAIL_REQUIRES_END
@@ -3603,7 +3585,6 @@ EMBED_CXX14_CONSTEXPR void make_fn(...) { detail::make_fn_log_error<Unused<void(
 #undef EMBED_DETAIL_TEXT_IMPL
 #undef EMBED_DETAIL_ALIAS
 #undef EMBED_DETAIL_FAIL_MESSAGE
-#undef EMBED_DETAIL_UNREACHABLE
 #undef EMBED_DETAIL_ASSERT_MESSAGE
 #undef EMBED_DETAIL_REPORT_IE
 #if EMBED_HAS_FEATURE(nullability) && defined(__clang__)

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3,7 +3,7 @@
  *
  * @date        2026-8-22
  *
- * @version     2.3.1
+ * @version     2.3.2
  *
  * @copyright   Copyright (c) 2026 Kim-J-Smith
  *              All rights reserved.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -3506,6 +3506,9 @@ noexcept(std::is_nothrow_constructible<Functor, std::initializer_list<U>&, CArgs
 /// @brief make_fn[12]: Make function from `std::cw<fn>`.
 /// @return `fn_ref<Auto-Deduction>`
 template <auto Cw, typename Fn>
+EMBED_DEPRECATED(
+  "The API of `make_fn(std::cw<...>)` will be changed in v2.4.0. "
+  "Use `make_fn<ebd::fn_ref>(std::cw<...>)` instead.")
 EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>) noexcept {
   using sig_raw = typename detail::is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature;
   using sig_correct = detail::get_correct_signature_t<fn_ref, sig_raw>;
@@ -3518,6 +3521,9 @@ EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>) noexcept {
 /// @brief make_fn[13]: Make function from `std::cw<callable>` and `obj`/`&obj`, binding the first parameter.
 /// @return `fn_ref<Auto-Deduction>`
 template <auto Cw, typename Fn, typename Tp>
+EMBED_DEPRECATED(
+  "The API of `make_fn(std::cw<...>, obj)` will be changed in v2.4.0. "
+  "Use `make_fn<ebd::fn_ref>(std::cw<...>, obj)` instead.")
 EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>, Tp&& obj) noexcept {
   using sig_raw = typename detail::is_ebd_fn<decltype(make_fn(std::declval<Fn>()))>::signature;
   using sig_wip = detail::get_correct_signature_t<fn_ref, sig_raw>;
@@ -3533,6 +3539,10 @@ EMBED_NODISCARD constexpr auto make_fn(std::constant_wrapper<Cw, Fn>, Tp&& obj) 
 /// @brief make_fn[14]: Make function with specified wrapper.
 /// @tparam Fn - Can be `ebd::fn`, `ebd::unique_fn`, `ebd::classic_fn`, or `ebd::fn_ref`.
 /// @return `Fn<Signature, BufferSize, Alignment>`
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 EMBED_DETAIL_TEMPLATE_BEGIN(
   template <class, std::size_t, std::size_t> class Fn,
   typename SpecifiedSig = void,
@@ -3559,6 +3569,9 @@ FnWrapper make_fn(Args&&... args) noexcept(NoThrow) {
     /* Fn = */ FnWrapper, /* NoThrow = */ NoThrow
   >(std::forward<Args>(args)...);
 }
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
 
 // When all other make_fn() fail to match the input parameters,
 // this function will be called as the fall back to avoid the

--- a/test/conformance/fn_ref/constant_wrapper.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper.pass.cpp
@@ -179,7 +179,7 @@ TEST(Conformance_fn_ref, constant_wrapper_pass) {
 
   {
     // constexpr and make_fn
-    constexpr auto f = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add>);
+    constexpr auto f = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_free_func_iii_add>);
     static_assert(std::is_same_v<decltype(f), const ebd::fn_ref<int(int, int) const>>);
     ASSERT_EQ(f(42, 42), 42 + 42);
   }

--- a/test/conformance/fn_ref/constant_wrapper_ptr.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper_ptr.pass.cpp
@@ -364,7 +364,7 @@ TEST(Conformance_fn_ref, constant_wrapper_ptr_pass) {
   {
     // constexpr and make_fn
     static ebd_test_member_fn obj;
-    constexpr auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, &obj);
+    constexpr auto f = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, &obj);
     static_assert(std::is_same_v<decltype(f), const ebd::fn_ref<int(int, int)>>);
     ASSERT_EQ(f(42, 42), 42 + 42);
   }
@@ -372,7 +372,7 @@ TEST(Conformance_fn_ref, constant_wrapper_ptr_pass) {
   {
     // make_fn
     static ebd_test_member_fn obj;
-    auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::member_var>, &obj);
+    auto f = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_member_fn::member_var>, &obj);
     static_assert(std::is_same_v<decltype(f), ebd::fn_ref<int&() noexcept>>);
     ASSERT_EQ(f(), 0);
   }

--- a/test/conformance/fn_ref/constant_wrapper_ref.pass.cpp
+++ b/test/conformance/fn_ref/constant_wrapper_ref.pass.cpp
@@ -386,7 +386,7 @@ TEST(Conformance_fn_ref, constant_wrapper_ref_pass) {
   {
     // constexpr and make_fn
     static ebd_test_member_fn obj;
-    constexpr auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, obj);
+    constexpr auto f = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_member_fn::mem_fn_ii_add>, obj);
     static_assert(std::is_same_v<decltype(f), const ebd::fn_ref<int(int, int)>>);
     ASSERT_EQ(f(42, 42), 42 + 42);
   }
@@ -394,20 +394,20 @@ TEST(Conformance_fn_ref, constant_wrapper_ref_pass) {
   {
     // make_fn
     static ebd_test_member_fn obj;
-    auto f = ebd::make_fn(std::cw<&ebd_test_member_fn::member_var>, obj);
+    auto f = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_member_fn::member_var>, obj);
     static_assert(std::is_same_v<decltype(f), ebd::fn_ref<int&() noexcept>>);
     ASSERT_EQ(f(), 0);
 
     int a = 0;
-    auto f2 = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add>, a);
+    auto f2 = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_free_func_iii_add>, a);
     static_assert(std::is_same_v<decltype(f2), ebd::fn_ref<int(int)>>);
     ASSERT_EQ(f2(42), 42);
 
-    auto f3 = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add_noexcept>, a);
+    auto f3 = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_free_func_iii_add_noexcept>, a);
     static_assert(std::is_same_v<decltype(f3), ebd::fn_ref<int(int&) noexcept>>);
     ASSERT_EQ(f3(a), 0);
 
-    auto f4 = ebd::make_fn(std::cw<&ebd_test_free_func_iii_add_const>, a);
+    auto f4 = ebd::make_fn<ebd::fn_ref>(std::cw<&ebd_test_free_func_iii_add_const>, a);
     static_assert(std::is_same_v<decltype(f4), ebd::fn_ref<int(const int&) const>>);
     ASSERT_EQ(f4(42), 42);
   }


### PR DESCRIPTION
**🔧 Fixed Bugs**
- None.

**⚠️ Breaking Changes**
- None.

**✨ New Features**
- None.

**🛠️ Optimizations and Improvements**
- Removed unused and unnecessary macros in `embed/embed_function.hpp`.

**📌 Notes**
- `operator bool` still works but may warn. It will be removed in a future release.
- `make_fn(std::cw<...>)` and `make_fn(std::cw<...>, obj)` are deprecated. Their API will be changed in v2.4.0; use `make_fn<ebd::fn_ref>(std::cw<...>)` / `make_fn<ebd::fn_ref>(std::cw<...>, obj)` instead.
