### PR TITLE
perf: do not initialize `m_erasure` in a constructor.

### DIFF
--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2539,6 +2539,9 @@ namespace crtp_mixins {
 #if defined(__GNUC__) || defined(__clang__)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wuninitialized"
+# ifndef __clang__
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+# endif // ^^^ GCC only
 #endif
 
     // The `m_erasure` is sometimes uninitialized.

--- a/include/embed/embed_function.hpp
+++ b/include/embed/embed_function.hpp
@@ -2536,7 +2536,17 @@ namespace crtp_mixins {
   struct EMBED_DETAIL_FORCE_EBO member_variable_impl : public assignment_self_clear<
     /* Self = */ function<Size, Align, Config, Signature>, Config, Config::isView
   > {
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
+
+    // The `m_erasure` is sometimes uninitialized.
     EMBED_DETAIL_ALL_DEFAULT(member_variable_impl)
+
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
 
     // Zero initialize the `m_erasure` and `m_command`.
     constexpr member_variable_impl(std::nullptr_t) noexcept
@@ -2864,8 +2874,7 @@ namespace crtp_mixins {
       && (!is_self<Functor, function>::value)
       && (!is_in_place_type<decay_t<Functor>>::value)
       && is_callable_from<Functor>::value
-    ) function(Functor&& functor) noexcept(is_nothrow_construct_from_functor<Functor&&>::value)
-    : Base_MemberVariable(nullptr) {
+    ) function(Functor&& functor) noexcept(is_nothrow_construct_from_functor<Functor&&>::value) {
 
       (void)assertions_for_functor<BufferSize, Config, Signature, Functor, Functor&&, erasure_t>{};
 

--- a/test/test_InitFunction.cpp
+++ b/test/test_InitFunction.cpp
@@ -864,8 +864,25 @@ struct ebd_test_InitFunction_Wuninitialized {
 
 // InitFunction[42]
 TEST(InitFunction, Wuninitialized) {
-    ebd_test_InitFunction_Wuninitialized f;
-    f.set([]{});
+    {
+        ebd_test_InitFunction_Wuninitialized f;
+        f.set([]{});
+    }
+    {
+        ebd::fn<bool(int, int)> f = std::less<int>{};
+        auto g = std::move(f);
+        ASSERT_TRUE(!g.is_empty());
+    }
+    {
+        ebd::fn<void()> f = static_cast<void(*)()>(nullptr);
+        auto g = std::move(f);
+        ASSERT_TRUE(g.is_empty());
+    }
+    {
+        ebd::fn<void()> f = static_cast<void(*)()>(nullptr);
+        ebd::fn<void()> g;
+        std::swap(g, f);
+    }
 }
 
 // InitFunction[43]


### PR DESCRIPTION
Reduce 8 bytes ROM usage in RV32 for each owning wrapper.